### PR TITLE
fix: compute home directory correctly even in the absence of $HOME.

### DIFF
--- a/lib/config/directory/homedir_test.go
+++ b/lib/config/directory/homedir_test.go
@@ -5,8 +5,23 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestOpenHomeDir(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("HOME", "/home/test")
+	Refresh()
+	dir, err := OpenHomeDir("app", "identity")
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(dir.path, "/home/test"), "path %s", dir.path)
+	os.Unsetenv("HOME")
+	Refresh()
+	dir, err = OpenHomeDir("app", "identity")
+	assert.Nil(t, err, "%v", err)
+	assert.True(t, strings.HasPrefix(dir.path, "/home"), "path %s", dir.path)
+}
 
 func TestOpenDir(t *testing.T) {
 	dir, err := ioutil.TempDir("", "opendir")


### PR DESCRIPTION
Background:
bazel runs builds in a sandbox. astore commands need to be run in bazel.
From within the sandbox, there is no HOME env variable.

Problem:
before this change, the code relied solely on the HOME environment
variable to find user configurations.

After this change:
if an absolute home directory cannot be found through configdir, the
library that uses the HOME var, fall back to looking up the home directory
in nis by using the correct system call, via os/user.

Additionally:
- added a small test that verify the correct behavior.
- introduced a Refresh function to allow the test to be written.