### PR TITLE
[WIP] initial draft of adding astore deletion

### DIFF
--- a/astore/client/astore/BUILD.bazel
+++ b/astore/client/astore/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "arch.go",
         "astore.go",
+        "delete.go",
         "formatter.go",
         "note.go",
         "publish.go",

--- a/astore/client/astore/delete.go
+++ b/astore/client/astore/delete.go
@@ -1,0 +1,10 @@
+package astore
+
+import (
+	"context"
+	"github.com/enfabrica/enkit/astore/rpc/astore"
+)
+
+func (c *Client) Delete(ctx context.Context, request *astore.DeleteRequest) {
+	//TODO
+}

--- a/astore/client/commands/BUILD.bazel
+++ b/astore/client/commands/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "commands.go",
+        "delete.go",
         "formatter.go",
         "guess.go",
         "note.go",

--- a/astore/client/commands/commands.go
+++ b/astore/client/commands/commands.go
@@ -33,7 +33,6 @@ func New(base *client.BaseFlags) *Root {
 	root.AddCommand(NewTag(root).Command)
 	root.AddCommand(NewNote(root).Command)
 	root.AddCommand(NewPublic(root).Command)
-	root.AddCommand(NewDelete(root).Command)
 	return root
 }
 

--- a/astore/client/commands/commands.go
+++ b/astore/client/commands/commands.go
@@ -33,7 +33,7 @@ func New(base *client.BaseFlags) *Root {
 	root.AddCommand(NewTag(root).Command)
 	root.AddCommand(NewNote(root).Command)
 	root.AddCommand(NewPublic(root).Command)
-
+	root.AddCommand(NewDelete(root).Command)
 	return root
 }
 

--- a/astore/client/commands/delete.go
+++ b/astore/client/commands/delete.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type DeleteCommand struct {
+	*cobra.Command
+	root *Root
+
+	name string
+}
+
+func (uc *Delete) Run(cmd *cobra.Command, args []string) error {
+	//TODO
+	return nil
+}
+
+type Delete struct {
+	*cobra.Command
+	root *Root
+	isDryRun bool
+}
+
+func NewDelete(root *Root) *Delete {
+	command := &Delete{
+		Command: &cobra.Command{
+			Use:   "delete",
+			Short: "Deletes an artifact from astore",
+
+		},
+		root: root,
+	}
+	command.Flags().BoolVarP(&command.isDryRun, "dry-run", "dr",  false, "will attempt to delete the resource without doing so")
+	command.Command.RunE = command.Run
+	return command
+}
+

--- a/astore/client/commands/delete.go
+++ b/astore/client/commands/delete.go
@@ -18,8 +18,9 @@ func (uc *Delete) Run(cmd *cobra.Command, args []string) error {
 
 type Delete struct {
 	*cobra.Command
-	root *Root
-	isDryRun bool
+	root        *Root
+	isDryRun    bool
+	skipConfirm bool
 }
 
 func NewDelete(root *Root) *Delete {
@@ -27,12 +28,11 @@ func NewDelete(root *Root) *Delete {
 		Command: &cobra.Command{
 			Use:   "delete",
 			Short: "Deletes an artifact from astore",
-
 		},
 		root: root,
 	}
-	command.Flags().BoolVarP(&command.isDryRun, "dry-run", "dr",  false, "will attempt to delete the resource without doing so")
+	command.Flags().BoolVarP(&command.isDryRun, "dry-run", "dr", false, "will attempt to delete the resource without doing so")
+	command.Flags().BoolVarP(&command.skipConfirm, "skip-confirm", "sc", false, "will not promp the terminal upon deletion of an sid")
 	command.Command.RunE = command.Run
 	return command
 }
-

--- a/astore/rpc/astore.proto
+++ b/astore/rpc/astore.proto
@@ -133,6 +133,15 @@ message NoteResponse {
   repeated Artifact artifact = 1;
 }
 
+message DeleteRequest {
+  string id = 1; //SID or UID (will be interpreted to which based on length)
+}
+
+message DeleteResponse {
+  int32 code = 1; //Valid values are like fs errors, either 0 1 or 2;
+  string message = 2; //Raw error or success message
+}
+
 service Astore {
   rpc Store(StoreRequest) returns (StoreResponse) {}
   rpc Commit(CommitRequest) returns (CommitResponse) {}
@@ -140,6 +149,7 @@ service Astore {
   rpc List(ListRequest) returns (ListResponse) {}
   rpc Tag(TagRequest) returns (TagResponse) {}
   rpc Note(NoteRequest) returns (NoteResponse) {}
+  rpc Delete(DeleteRequest) returns (DeleteResponse){}
 
   rpc Publish(PublishRequest) returns (PublishResponse) {}
   rpc Unpublish(UnpublishRequest) returns (UnpublishResponse) {}

--- a/astore/rpc/astore.proto
+++ b/astore/rpc/astore.proto
@@ -138,8 +138,7 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-  int32 code = 1; //Valid values are like fs errors, either 0 1 or 2;
-  string message = 2; //Raw error or success message
+  repeated string ids = 1; //list of deleted sid's and deleted uids
 }
 
 service Astore {

--- a/astore/server/astore/BUILD.bazel
+++ b/astore/server/astore/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "astore.go",
+        "delete.go",
         "factory.go",
         "interface.go",
         "note.go",

--- a/astore/server/astore/delete.go
+++ b/astore/server/astore/delete.go
@@ -1,0 +1,10 @@
+package astore
+
+import (
+	"context"
+	"github.com/enfabrica/enkit/astore/rpc/astore"
+)
+
+func (s *Server) Delete(ctx context.Context, request *astore.DeleteRequest) (*astore.DeleteResponse, error) {
+	panic("implement me")
+}

--- a/kbuild/kapt/controlurl.go
+++ b/kbuild/kapt/controlurl.go
@@ -2,8 +2,8 @@ package kapt
 
 import (
 	"github.com/cybozu-go/aptutil/apt"
-	"github.com/enfabrica/enkit/lib/khttp/protocol"
 	"github.com/enfabrica/enkit/lib/karchive"
+	"github.com/enfabrica/enkit/lib/khttp/protocol"
 
 	"fmt"
 	"io"

--- a/kbuild/main.go
+++ b/kbuild/main.go
@@ -9,10 +9,10 @@ import (
 	"github.com/enfabrica/enkit/kbuild/kapt"
 
 	"github.com/enfabrica/enkit/lib/config/marshal"
+	"github.com/enfabrica/enkit/lib/karchive"
 	"github.com/enfabrica/enkit/lib/khttp/protocol"
 	"github.com/enfabrica/enkit/lib/khttp/scheduler"
 	"github.com/enfabrica/enkit/lib/khttp/workpool"
-	"github.com/enfabrica/enkit/lib/karchive"
 	"github.com/enfabrica/enkit/lib/retry"
 	"github.com/enfabrica/kbuild/assets"
 	"github.com/xor-gate/ar"

--- a/lib/khttp/dispatch.go
+++ b/lib/khttp/dispatch.go
@@ -53,7 +53,7 @@ type HostDispatch struct {
 	// The Host string can also specify a port number for example: www.mydomain.com:1001.
 	// Port 80 or 443 are stripped by default and matched without port, as the RFC
 	// recommandation is that port 80 and 443 are to be stripped in host headers.
-	Host    string
+	Host string
 
 	// Handler is the handler to invoke for all requests matching this host.
 	Handler http.Handler

--- a/lib/khttp/downloader/downloader.go
+++ b/lib/khttp/downloader/downloader.go
@@ -143,10 +143,10 @@ func (o *roptions) Retrier() *retry.Options {
 
 func (o *roptions) ProtocolModifiers() []protocol.Modifier {
 	return append(protocol.Modifiers{
-			protocol.WithContext(o.ctx),
-			protocol.WithTimeout(o.timeout),
-			protocol.WithRequestOptions(o.request...),
-			protocol.WithClientOptions(o.client...)}, o.protocol...)
+		protocol.WithContext(o.ctx),
+		protocol.WithTimeout(o.timeout),
+		protocol.WithRequestOptions(o.request...),
+		protocol.WithClientOptions(o.client...)}, o.protocol...)
 }
 
 // Get will fetch the specified url, invoke handler to process the response, and eh to process the returned error.

--- a/lib/khttp/kcache/cache.go
+++ b/lib/khttp/kcache/cache.go
@@ -177,7 +177,7 @@ type CachedFile struct {
 	// Path is the final path of where the cached file has been stored.
 	//
 	// This includes any directory provided by the cache storage layer.
-	Path  string
+	Path string
 
 	// If false, indicates that the file was just downloaded.
 	// If true, it was either re-used from cache because nothing changed, or because

--- a/lib/oauth/ogithub/github.go
+++ b/lib/oauth/ogithub/github.go
@@ -1,20 +1,20 @@
 package ogithub
 
 import (
+	"context"
 	"fmt"
 	"log"
-	"context"
 
 	"github.com/enfabrica/enkit/lib/oauth"
 	gh "github.com/google/go-github/github"
-	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
 )
 
 func Defaults() oauth.Modifier {
 	return oauth.WithModifiers(
-		oauth.WithScopes([]string {
-				"repos",
+		oauth.WithScopes([]string{
+			"repos",
 		}),
 		oauth.WithEndpoint(github.Endpoint),
 		oauth.WithFactory(GetUserVerifier),
@@ -48,5 +48,3 @@ func GetUserVerifier(conf *oauth2.Config) (oauth.Verifier, error) {
 		}, nil
 	}, nil
 }
-
-


### PR DESCRIPTION
Currently:

- adds command with dry run flag
- adds proto stubs

Plan (detailed):

- finish client stubbing in `astore/client/astore/delete.go`
- add additional/remove flags? 
- implement guess sid or id from single string
- add raw delete functionality server side and unit test
- add delete to rpc server and implement e2e testing with client stubs

Future:

- Running garbage collection could just be a chronjobbed github action that reads the metadata from the remote and deletes as necessary. Linux runners are pretty much free.

- Altering the timestamps of files could be a good way to test this

- for e2e testing we can multistage an intermediate docker image and save code coverage across stages.
