### PR TITLE
WIP: Add rule to declare and run kernel unit tests

### DIFF
--- a/bazel/linux/BUILD.bazel
+++ b/bazel/linux/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["run_um_kunit_tests.sh"])

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -312,27 +312,25 @@ Example:
     },
 )
 
-def kernel_test(name, repo_name, module, kernel_image, rootfs_image):
-    """Convenience wrapper around sh_test, makes it easier to declare and run KUnit user-mode linux tests.
+def kernel_test(name, module, kernel_image, rootfs_image, tap_parser, repo_name="@enkit"):
+    """Convenience wrapper around sh_test, useful for running kernel tests.
 
     Args:
       name: string, name for the underlying sh_test rule.
-      repo_name: label, @name used to import this external repository. Used to
-                 implicitly define the local file run_um_kunit_tests.sh as the test
-	         runner.
       module: label, KUnit kernel module containing the tests.
       kernel_image: label, executable user-mode linux image file.
       rootfs_image: label, rootfs image file to be used by the linux image.
+      tap_parser: label, script to use to parse the test TAP output.
+      repo_name: label, @name used to import this external repository. Used to
+                 implicitly define the local file run_um_kunit_tests.sh as the test
+                 runner. Default = "@enkit".
     """
     srcs = [repo_name + "//bazel/linux:run_um_kunit_tests.sh"]
     data = [
-        module,
         kernel_image,
-        rootfs_image
+        rootfs_image,
+        module,
+	tap_parser
     ]
-    args = [
-        "$(location %s)" % kernel_image,
-        "$(location %s)" % rootfs_image,
-        "$(location %s)" % module
-    ]
+    args = ["$(location %s)" % elem for elem in data]
     return native.sh_test(name=name, srcs=srcs, data=data, args=args)

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -311,3 +311,23 @@ Example:
         ),
     },
 )
+
+def kernel_unit_test(name, module, linux_image, rootfs_image):
+    """Convenience wrapper around sh_test, makes it easier to declare and run KUnit user-mode linux tests.
+
+    Args:
+      name: string, name for the underlying sh_test rule.
+      module: label, target KUnit kernel module containing the tests.
+      linux_image: label, executable user-mode linux image file.
+      rootfs_image: label, rootfs image file to be used by the linux image.
+    """
+    srcs = ["run_um_kunit_tests.sh"]
+    data = [
+        module,
+        linux_image,
+        rootfs_image]
+    args = [
+        "$(location %s)" % linux_image,
+        "$(location %s)" % rootfs_image,
+        "$(location %s)" % module]
+    return native.sh_test(name=name, srcs=srcs, data=data, args=args)

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -312,22 +312,27 @@ Example:
     },
 )
 
-def kernel_unit_test(name, module, linux_image, rootfs_image):
+def kernel_test(name, repo_name, module, kernel_image, rootfs_image):
     """Convenience wrapper around sh_test, makes it easier to declare and run KUnit user-mode linux tests.
 
     Args:
       name: string, name for the underlying sh_test rule.
-      module: label, target KUnit kernel module containing the tests.
-      linux_image: label, executable user-mode linux image file.
+      repo_name: label, @name used to import this external repository. Used to
+                 implicitly define the local file run_um_kunit_tests.sh as the test
+	         runner.
+      module: label, KUnit kernel module containing the tests.
+      kernel_image: label, executable user-mode linux image file.
       rootfs_image: label, rootfs image file to be used by the linux image.
     """
-    srcs = ["run_um_kunit_tests.sh"]
+    srcs = [repo_name + "//bazel/linux:run_um_kunit_tests.sh"]
     data = [
         module,
-        linux_image,
-        rootfs_image]
+        kernel_image,
+        rootfs_image
+    ]
     args = [
-        "$(location %s)" % linux_image,
+        "$(location %s)" % kernel_image,
         "$(location %s)" % rootfs_image,
-        "$(location %s)" % module]
+        "$(location %s)" % module
+    ]
     return native.sh_test(name=name, srcs=srcs, data=data, args=args)

--- a/bazel/linux/run_um_kunit_tests.sh
+++ b/bazel/linux/run_um_kunit_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+LINUXIMG=$1
+ROOTFS=$2
+HOSTFS=$(dirname $(realpath $3))
+
+set -e
+
+mkdir -p /tmp/uml
+USER=$(whoami)
+chown "${USER}.${USER}" /tmp/uml
+chmod 777 /tmp/uml
+export TMPDIR=/tmp/uml
+
+OUTFILE="${TMPDIR}/output"
+KUNIT_TAP_PARSER=/path/to/kunit_tap_parser
+
+"$LINUXIMG" ubd0="$ROOTFS" hostfs="$HOSTFS" | tee $OUTFILE
+KUNIT_TAP_PARSER parse < $OUTFILE

--- a/bazel/linux/run_um_kunit_tests.sh
+++ b/bazel/linux/run_um_kunit_tests.sh
@@ -5,10 +5,10 @@ set -e
 LINUXIMG=$1
 ROOTFS=$2
 HOSTFS=$(dirname $(realpath $3))
+KUNIT_TAP_PARSER=$4
 
 export TMPDIR=$(mktemp -d)
 OUTFILE="${TMPDIR}/output"
-KUNIT_TAP_PARSER=/path/to/kunit_tap_parser
 
 "$LINUXIMG" ubd0="$ROOTFS" hostfs="$HOSTFS" | tee "$OUTFILE"
 "$KUNIT_TAP_PARSER" parse < "$OUTFILE"

--- a/bazel/linux/run_um_kunit_tests.sh
+++ b/bazel/linux/run_um_kunit_tests.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 
+set -e
+
 LINUXIMG=$1
 ROOTFS=$2
 HOSTFS=$(dirname $(realpath $3))
 
-set -e
-
-mkdir -p /tmp/uml
-USER=$(whoami)
-chown "${USER}.${USER}" /tmp/uml
-chmod 777 /tmp/uml
-export TMPDIR=/tmp/uml
-
+export TMPDIR=$(mktemp -d)
 OUTFILE="${TMPDIR}/output"
 KUNIT_TAP_PARSER=/path/to/kunit_tap_parser
 
-"$LINUXIMG" ubd0="$ROOTFS" hostfs="$HOSTFS" | tee $OUTFILE
-KUNIT_TAP_PARSER parse < $OUTFILE
+"$LINUXIMG" ubd0="$ROOTFS" hostfs="$HOSTFS" | tee "$OUTFILE"
+"$KUNIT_TAP_PARSER" parse < "$OUTFILE"


### PR DESCRIPTION
Introduce a bash script to run kernel unit tests inside a user-mode linux image
generated with KUnit enabled. To do that the scripts expects three parameters:
1. Path to the user-mode linux image
2. Path to the rootfs image
3. Path to the folder to expose as hostfs to the user-mode linux proces (this
   can be used to expose test kernel modules to the running user-mode linux
   process, so that it will be able to load and run them at runtime).

The new macro rule simplifies the work required to instantiate the underlying
sh_test rule: it defines the kernel module, linux and rootfs image as required
data to run the test, then passes their runtime paths to the bash script we
just introduced.