### PR TITLE
bazel/linux: add missing space to make template

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -129,7 +129,7 @@ def _kernel_module(ctx):
     ctx.actions.run_shell(
         mnemonic = "KernelBuild",
         progress_message = "kernel building: compiling kernel module %s for %s" % (module, ki.package),
-        command = "make -s M=$PWD/%s -C $PWD/%s/%s%s && cp $PWD/%s/%s %s && echo ==== NO FATAL ERRORS - MODULE CREATED - bazel-bin/%s" % (
+        command = "make -s M=$PWD/%s -C $PWD/%s/%s %s && cp $PWD/%s/%s %s && echo ==== NO FATAL ERRORS - MODULE CREATED - bazel-bin/%s" % (
             srcdir,
             ki.root,
             ki.build,


### PR DESCRIPTION
Add missing space between kernel directory and extra arguments
passed to the make command used internally by kernel_module_rule.
Specifying an extra argument while instantiating the rule, would cause
the argument to become interpreted as part of the kernel path instead of
additional args.