### PR TITLE
bazel/linux: add uml_dir arg to kunit test script

### DIFF
--- a/bazel/linux/run_um_kunit_tests.template
+++ b/bazel/linux/run_um_kunit_tests.template
@@ -3,6 +3,6 @@
 set -e
 
 MODULE=$(dirname $(realpath {module}))
-TMPOUTPUT=$TEST_UNDECLARED_OUTPUTS_DIR/.output
-{kernel} ubd0={rootfs} hostfs=$MODULE | tee $TMPOUTPUT
+TMPOUTPUT=$TEST_TMPDIR/.output
+{kernel} ubd0={rootfs} hostfs=$MODULE uml_dir=$TEST_TMPDIR | tee $TMPOUTPUT
 {parser} parse < $TMPOUTPUT


### PR DESCRIPTION
This should fix the cloudbuild issues. See bazel documentation related to $TEST_TMPDIR here https://docs.bazel.build/versions/master/test-encyclopedia.html#initial-conditions.