### PR TITLE
bazel/utils/transform: add support for "tree artifacts".

### DIFF
--- a/bazel/utils/labels.bzl
+++ b/bazel/utils/labels.bzl
@@ -23,8 +23,10 @@ def labelrelative(label, path):
       string, path relative to where all the output files for that
       label are saved by bazel.
     """
-    to_strip = "%s/%s/" % (label.package, label.name)
-    output = path
-    if output.startswith(to_strip):
-        output = output[len(to_strip):]
-    return output
+    to_strip = "%s/%s" % (label.package, label.name)
+    if path == to_strip:
+        return ""
+
+    if path.startswith(to_strip + "/"):
+        path = path[len(to_strip) + 1:]
+    return path

--- a/bazel/utils/match.bzl
+++ b/bazel/utils/match.bzl
@@ -27,6 +27,12 @@ def match(data, pattern):
         return pattern in data
     return data.startswith(divided[0]) and data.endswith(divided[1])
 
+def to_glob(pattern):
+    """Given a pattern in match format, returns a glob in shell format."""
+    if "*" in pattern:
+        return pattern
+    return "*" + pattern + "*"
+
 def matchall(data, patterns, default = True):
     """Returns True if the supplied string matches all the patterns.
 

--- a/bazel/utils/transform/BUILD.bazel
+++ b/bazel/utils/transform/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["transformer.sh"])

--- a/bazel/utils/transform/transformer.sh
+++ b/bazel/utils/transform/transformer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+test -z "{debug}" || {
+  echo "Running $0 in debug mode" 1>&2
+  set -x
+}
+
+idir="$1"
+odir="$2"
+
+test "$#" -eq "2" || {
+  echo "invalid command line: an input dir and an output dir must be provided" 1>&2
+  exit 1
+}
+
+transform() {
+  mkdir -p "$(dirname "$output")"
+  {command}
+}
+
+include() {
+  mkdir -p "$(dirname "$output")"
+  cp -f "$input" "$output"
+}
+
+find "$idir" -not -type d | {
+  while read line; do
+    input="$line"
+    output="${odir}${line#$idir/}"
+    case "$line" in
+    {patterns}
+    esac
+  done;
+}


### PR DESCRIPTION
Background:
Bazel rules can generate "file artifacts", or "tree artifacts".
A file artifact is 1 bazel object, representing a file.
A tree artifact is 1 bazel object, representing a tree of files.

Individual files in tree artifacts are invisible to the rest of
the bazel rules, as they don't have a corresponding file object.

In this change:
- modify the transform rule so that it can handle "tree artifacts",
  and transform files from tree artifacts as per "include" and
  "transform" parameters.

- add support for the "expand" attribute, so "transform" can be
  used to break a "tree artifact" into independent "file artifacts"
  or sub-"tree artifacts".

Additionally:
- Improve labels.bzl to handle paths that start fromt the root
  of the label (wrong result was returned before).
- Add an helper function in match, to turn a simplified pattern
  into a valid shell pattern.
- Add a debug parameter to transform, so one can see what the
  rule is doing exactly.

Getting this to work was a bit tricky:
- as the content of tree artifacts is inaccessible to bazel,
  the rule now generates a shell script to transform and
  include the files from tree artifacts.