### PR TITLE
lib/kflags, lib/client: fix initialization bug.

### DIFF
--- a/lib/kflags/flags.go
+++ b/lib/kflags/flags.go
@@ -111,5 +111,10 @@ type ErrorHandler func(err error) error
 // Printer is a function capable of printing Printf like strings.
 type Printer func(format string, v ...interface{})
 
-// Runner is a function capable of starting a program with a given set of flags.
-type Runner func(FlagSet, Printer)
+// An initialization function capable of preparing internal objects once flags have been parsed.
+type Init func() error
+
+// Runner is a function capable of parsing argv according to the supplied FlagSet,
+// log problems using the supplied Printer, initialize internal object with the
+// parsed flags by invoking Init, and finally running the program.
+type Runner func(FlagSet, Printer, Init)


### PR DESCRIPTION
Problem:
Current flag initialization logic has the default flag values
set in the .go code, (possibly) overridden by env variable,
(possibly) overridden by parameters downloaded via http/astore.
Finally, the cobra handler parses the flags, and the final
value is set.

Every time flags change values, some objects need to be
re-created. For example: if log verbosity is changed, the
logger object needs to be re-created (well, or updated).

Before this change:
- the logger object was re-created when the DEFAULTS were
  changed, but not when the final set of flags was loaded.

  Pretty much causing some flags to be ignored when passed
  from the command line (but not when defaulted from env
  or from http configurations).

After this change:
- actually plumbed the object initialization logic with
  current flag parsers.