### PR TITLE
proxy/ptunnel: re-load credentials at every connection attempt.

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -147,10 +147,11 @@ func (bf *BaseFlags) IdentityToken() (string, string, error) {
 
 	identity := bf.Identity()
 	username, token, err := store.Load(identity)
-	bf.Log.Infof("Using credentials of '%s' for requested '%s'", username, bf.Printable())
 	if err != nil {
+		bf.Log.Infof("Error loading credentials for '%s' - %s", bf.Printable(), err)
 		return "", "", kflags.NewIdentityError(err)
 	}
+	bf.Log.Infof("Using credentials of '%s' for requested '%s'", username, bf.Printable())
 	return username, token, nil
 }
 

--- a/proxy/ptunnel/tunnel.go
+++ b/proxy/ptunnel/tunnel.go
@@ -31,17 +31,17 @@ type Tunnel struct {
 	ReceiveWin *nasshp.BlockingReceiveWindow
 }
 
-type getOptions struct {
+type GetOptions struct {
 	getOptions     []protocol.Modifier
 	retryOptions   []retry.Modifier
 	connectOptions []ConnectModifier
 }
 
-type GetModifier func(*getOptions) error
+type GetModifier func(*GetOptions) error
 
 type GetModifiers []GetModifier
 
-func (mods GetModifiers) Apply(o *getOptions) error {
+func (mods GetModifiers) Apply(o *GetOptions) error {
 	for _, m := range mods {
 		if err := m(o); err != nil {
 			return err
@@ -51,28 +51,35 @@ func (mods GetModifiers) Apply(o *getOptions) error {
 }
 
 func WithRetryOptions(mods ...retry.Modifier) GetModifier {
-	return func(o *getOptions) error {
+	return func(o *GetOptions) error {
 		o.retryOptions = append(o.retryOptions, mods...)
 		return nil
 	}
 }
 
+// Configures options to use in the GET requests to prepare the tunnel.
+// This mostly affects the GetSID() call, invoked once per attempt to log in.
 func WithGetOptions(mods ...protocol.Modifier) GetModifier {
-	return func(o *getOptions) error {
+	return func(o *GetOptions) error {
 		o.getOptions = append(o.getOptions, mods...)
 		return nil
 	}
 }
 
+// Configures options to use to establish the websocket moving bytes around.
+//
+// This mostly affects the Connect(), ConnectSID() and ConnectURL() call,
+// invoked once per attempt to establish the websocket used as the actual
+// tunnel.
 func WithConnectOptions(mods ...ConnectModifier) GetModifier {
-	return func(o *getOptions) error {
+	return func(o *GetOptions) error {
 		o.connectOptions = append(o.connectOptions, mods...)
 		return nil
 	}
 }
 
-func WithOptions(r *getOptions) GetModifier {
-	return func(o *getOptions) error {
+func WithOptions(r *GetOptions) GetModifier {
+	return func(o *GetOptions) error {
 		*o = *r
 		return nil
 	}
@@ -87,7 +94,7 @@ func GetSID(proxy *url.URL, host string, port uint16, mods ...GetModifier) (stri
 	curl.RawQuery = params.Encode()
 	curl.Path = path.Join(curl.Path, "/proxy")
 
-	options := &getOptions{}
+	options := &GetOptions{}
 	if err := GetModifiers(mods).Apply(options); err != nil {
 		return "", err
 	}
@@ -118,7 +125,7 @@ func GetSID(proxy *url.URL, host string, port uint16, mods ...GetModifier) (stri
 }
 
 func Connect(proxy *url.URL, host string, port uint16, pos, ack uint32, mods ...GetModifier) (*websocket.Conn, error) {
-	options := &getOptions{}
+	options := &GetOptions{}
 	if err := GetModifiers(mods).Apply(options); err != nil {
 		return nil, err
 	}
@@ -376,7 +383,7 @@ func NewTunnel(pool *nasshp.BufferPool, mods ...Modifier) (*Tunnel, error) {
 }
 
 func (t *Tunnel) KeepConnected(proxy *url.URL, host string, port uint16, mods ...GetModifier) error {
-	options := &getOptions{}
+	options := &GetOptions{}
 	if err := GetModifiers(mods).Apply(options); err != nil {
 		return err
 	}


### PR DESCRIPTION
Problem:
When credentials expire, even if refreshed, "enkit tunnel" is unable
to recover the session. This is because credentials are never reloaded
from disk.

In this change:
- have commands/tunnel.go set things up so credentials are re-loaded
  every time we attempt a connection, so the latest are always used.
- ... but stick to the last known valid credentials if loading fails.

Additionally:
- clarify logging slightly, so that the problem is clear for someone
  looking at the log.