### PR TITLE
proxy/ptunnel,nasshp: significantly improved cleanup and error handling.

### DIFF
--- a/lib/knetwork/BUILD.bazel
+++ b/lib/knetwork/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["shutdown.go"],
+    importpath = "github.com/enfabrica/enkit/lib/knetwork",
+    visibility = ["//visibility:public"],
+)

--- a/lib/knetwork/shutdown.go
+++ b/lib/knetwork/shutdown.go
@@ -1,0 +1,55 @@
+package knetwork
+
+import (
+	"io"
+)
+
+// ReadOnlyCloser is any object that is capable of closing the
+// read direction without closing the write direction.
+//
+// This is typical of eg, TCP connection where a shutdown() call
+// can close one direction but not the other.
+type ReadOnlyCloser interface {
+	io.Reader
+	CloseRead() error
+}
+
+// WriteOnlyCloser is any object that is capable of closing the
+// write direction without closing the read direction.
+//
+// This is typical of eg, TCP connection where a shutdown() call
+// can close one direction but not the other.
+type WriteOnlyCloser interface {
+	io.Writer
+	CloseWrite() error
+}
+
+type readOnlyCloseAdapter struct {
+	ReadOnlyCloser
+}
+func (roca *readOnlyCloseAdapter) Close() error {
+	return roca.CloseRead()
+}
+
+// ReadOnlyClose returns an io.ReadCloser that will only close
+// the read channel of the connection passed.
+//
+// When the object is "Close()", "ReadClose()" will be invoked instead.
+func ReadOnlyClose(woc ReadOnlyCloser) io.ReadCloser {
+	return &readOnlyCloseAdapter{woc}
+}
+
+type writeOnlyCloseAdapter struct {
+	WriteOnlyCloser
+}
+func (roca *writeOnlyCloseAdapter) Close() error {
+	return roca.CloseWrite()
+}
+
+// WriteOnlyClose returns an io.WriteCloser that will only close
+// the write channel of the connection passed.
+//
+// When the object is "Close()", "WriteClose()" will be invoked instead.
+func WriteOnlyClose(woc WriteOnlyCloser) io.WriteCloser {
+	return &writeOnlyCloseAdapter{woc}
+}

--- a/proxy/nasshp/browser.go
+++ b/proxy/nasshp/browser.go
@@ -111,6 +111,7 @@ func (gb *ReplaceableBrowser) Close(err error) {
 		gb.wc.Close()
 		gb.wc = nil
 	}
+	gb.cond.Broadcast()
 }
 
 func (gb *ReplaceableBrowser) Error(wc *websocket.Conn, err error) {

--- a/proxy/ptunnel/commands/BUILD.bazel
+++ b/proxy/ptunnel/commands/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "//lib/khttp:go_default_library",
         "//lib/khttp/krequest:go_default_library",
         "//lib/khttp/protocol:go_default_library",
+        "//lib/knetwork:go_default_library",
+        "//lib/retry:go_default_library",
         "//proxy/nasshp:go_default_library",
         "//proxy/ptunnel:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",


### PR DESCRIPTION
Background:
Before this PR, the cleanup code on tunnel close was sketchy at best,
potentially leaking goroutines, leaving connections opened, and not
really propagating close() events correctly.

In this PR:
- try to propagate close and shutdown events correctly from web sockets.
  If the web socket stops being readable, do a shutdown for write.
  If the web socket stops being writable, do a shutdown for read.
  This resulted in adding a couple utilities in knetwork/shutdown.go.

- close the client connection if the websocket dies.
  Apart from the shutdown, the new code tries to close the socket
  correctly when all is done.

- close the websocket with the server, and try to ensure the corresponding
  routines. This is very tricky to get right, as the websockets library
  used doesn't really have non-blocking or interruptible read / write
  calls. The code relies on a) injecting error, eg, ensuring that the
  next poll fails, and b) closing the web socket.

Additionally:
- make the Waiter object in blocking window much safer to close/fail.

  Specifically:
  - before this change, if Fail() was called with no reader, it would
    block forever (simple channel semantics). If multiple threads were
    waiting on the window (illegal by contract, but not enforced), only
    one would fail. If a reader raced and used the object after failing
    it, the reader would still move forward like nothing happened.

  - after this change, Fail() will mark the object as failed forever,
    without blocking. Any reader/waiter will unblock immediately (yes,
    even multiple readers) and get the error immediately. If the
    object is re-used, the reader will still get the error immediately.