### PR TITLE
lib/goroutine, lib/multierror: minor API improvements.

### DIFF
--- a/lib/goroutine/BUILD.bazel
+++ b/lib/goroutine/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["gochan.go"],
     importpath = "github.com/enfabrica/enkit/lib/goroutine",
     visibility = ["//visibility:public"],
+    deps = ["//lib/multierror:go_default_library"],
 )

--- a/lib/goroutine/gochan.go
+++ b/lib/goroutine/gochan.go
@@ -1,5 +1,9 @@
 package goroutine
 
+import (
+	"github.com/enfabrica/enkit/lib/multierror"
+)
+
 // ErrorChannel is a simple "chan error" with a couple convenience methods,
 // and strong typing to help the compiler.
 type ErrorChannel chan error
@@ -23,7 +27,7 @@ func Run(goroutine func() error) ErrorChannel {
 }
 
 // WaitAll runs a goroutine for each function, waits for each to complete, and returns all errors.
-func WaitAll(goroutine ...func() error) []error {
+func WaitAll(goroutine ...func() error) error {
 	type eix struct {
 		err error
 		ix  int
@@ -51,7 +55,7 @@ func WaitAll(goroutine ...func() error) []error {
 			errs[result.ix] = result.err
 		}
 	}
-	return errs
+	return multierror.New(errs)
 }
 
 // WaitFirst runs a goroutine for each function, returns as soon as all have completed, or one errors out.


### PR DESCRIPTION
Specifically:
WaitAll() now returns a multierror rather than a plain array
of errors, only if an error was actually received.

multierror is expanded to have support for sparse arrays of errors,
eg, an array with some entries being nil (all good) and some entries
being actual errors.

Why?
1 - This allows WaitAll() to be used just like any other function,
    it just returns an error, or nil if there are no errors.
    Before, it always returned an array.

2 - This allows to chain WaitFirstError() and WaitAll() arbitrarily
    Like: WaitAll(WaitFirstError(func1, WaitAll(func5, func6)), WaitAll(func3, func4))
    and still have error propagation work correctly.

The cost on multierror should be negligible: people that were using
a contiguous array should have no additional cost. Sparse arrays are
slightly more costly as they need to be scanned to determine if they
contain an error or not.