### PR TITLE
bazel/linux/defs.bzl: Fix kernel_module bug

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -226,7 +226,9 @@ def kernel_module(*args, **kwargs):
     Args:
       srcs: list of labels, specifying the source files that constitute the kernel module.
             If not specified, kernel_module will provide a reasonable default including all
-            files that are typically part of a kernel module.
+            files that are typically part of a kernel module (i.e., the specified makefile
+            and all .c and .h files belonging to the package where the kernel_module rule
+            has been instantiated, see https://docs.bazel.build/versions/master/be/functions.html#glob).
       module: string, name of the output module. If not specified, kernel_module will assume
             the output module name will be the same as the rule name. Also, it normalizes the
             name ensuring it has a '.ko' suffix.
@@ -237,16 +239,18 @@ def kernel_module(*args, **kwargs):
       kernels: list of kernel (same as above). kernel_module will instantiate multiple
             kernel_module_rule, one per kernel, and ensure they all build in parallel.
     """
+    if "makefile" not in kwargs:
+        kwargs["makefile"] = "Makefile"
+
     if "srcs" not in kwargs:
-        kwargs["srcs"] = native.glob(include = ["**/*"], exclude = BUILD_LEFTOVERS, allow_empty = False)
+        include = ["**/*.c", "**/*.h", kwargs["makefile"]]
+        exclude = BUILD_LEFTOVERS + ["**/*.mod.c"]
+        kwargs["srcs"] = native.glob(include = include, exclude = exclude, allow_empty = False)
 
     module = kwargs.get("module", kwargs["name"])
     if not module.endswith(".ko"):
         module = module + ".ko"
     kwargs["module"] = module
-
-    if "makefile" not in kwargs:
-        kwargs["makefile"] = "Makefile"
 
     if "kernels" not in kwargs:
         kwargs["kernel"] = _normalize_kernel(kwargs["kernel"])

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -215,7 +215,7 @@ def _normalize_kernel(kernel):
 
     return kernel
 
-BUILD_LEFTOVERS = [".*.cmd", "*.a", "*.o", "*.ko", "*.order", "*.symvers", "*.mod", "*.mod.[co]"]
+BUILD_LEFTOVERS = ["**/.*.cmd", "**/*.a", "**/*.o", "**/*.ko", "**/*.order", "**/*.symvers", "**/*.mod", "**/*.mod.c", "**/*.mod.o"]
 
 def kernel_module(*args, **kwargs):
     """Convenience wrapper around kernel_module_rule, makes it easier to use.
@@ -244,8 +244,7 @@ def kernel_module(*args, **kwargs):
 
     if "srcs" not in kwargs:
         include = ["**/*.c", "**/*.h", kwargs["makefile"]]
-        exclude = BUILD_LEFTOVERS + ["**/*.mod.c"]
-        kwargs["srcs"] = native.glob(include = include, exclude = exclude, allow_empty = False)
+        kwargs["srcs"] = native.glob(include = include, exclude = BUILD_LEFTOVERS, allow_empty = False)
 
     module = kwargs.get("module", kwargs["name"])
     if not module.endswith(".ko"):


### PR DESCRIPTION
As a default "srcs" parameter, consider only the makefile parameter and
all the .c and .h files belonging to the package where the kernel_module
rule has been instatiated.

Currently, if the user doesn't specify the "srcs" parameter of the
kernel_module rule, the implementation will consider all files belonging
to the package to be the source files for that kernel module.
If for some reason, a file with the same name of one of the intermediate
build files pollutes the package, bazel will try to copy/link that over in
the build dir. This seems to cause a compilation failure since that file
could already exist there and that filesystem is read-only?

The bug can be reproduced, for example, by copying the module_name.mod.c
in the package source tree and modifying it (or the kernel module sources).
The error will look like this:

redacted: Read-only file system
make[2]: *** [redacted/Makefile.modpost:111: redacted/Module.symvers] Error 1
make[1]: *** [redacted/Makefile:1772: single_modpost] Error 2
make: *** [redacted/Makefile:185: __sub-make] Error 2