### PR TITLE
kbuild/utils/generate_custom_archive.sh: Fix bug

### DIFF
--- a/kbuild/utils/generate_custom_archive.sh
+++ b/kbuild/utils/generate_custom_archive.sh
@@ -79,11 +79,13 @@ set -e
 mkdir -p "${TARGETDIR}/arch"
 mkdir -p "${TARGETDIR}/include"
 mkdir -p "${TARGETDIR}/scripts"
+mkdir -p "${TARGETDIR}/tools"
 mkdir -p "${INSTALLDIR}/lib/modules/${KERNELVERSION}/build"
 
 generate_install_script "${INSTALLDIR}/${SCRIPTNAME}"
 chmod 755 ${INSTALLDIR}/${SCRIPTNAME}
 cp -r $SRCDIR/scripts/* $TARGETDIR/scripts/
+cp -r $SRCDIR/tools/* $TARGETDIR/tools/
 cp -r $SRCDIR/arch/* $TARGETDIR/arch/
 cp -r $SRCDIR/include/* $TARGETDIR/include/
 cp -r $SRCDIR/Makefile $SRCDIR/.config $SRCDIR/Module.symvers $TARGETDIR/


### PR DESCRIPTION
Copy the tools folder as well from the custom kernel source tree.
Not doing that was causing the make rule to build .o file from .c
files not to execute. Which was causing an error message like:
make[1]: *** No rule to make target '', needed by '.  Stop.