### PR TITLE
bazel/utils: Fix minor clang-format issue

### DIFF
--- a/bazel/utils/run_clang_format.template.sh
+++ b/bazel/utils/run_clang_format.template.sh
@@ -30,6 +30,7 @@ cp "${STYLE_FILE}" '.clang-format'
 # Run clang-format on all the files conforming to the specified format
 find . -type f \( -name '{pattern}' \) -exec "$CLANG_FORMAT" -style={style} -i {} \;
 
-if test -f '.clang-format'; then
+rm '.clang-format'
+if test -f "$OLD_STYLE_FILE"; then
 	cp "$OLD_STYLE_FILE" '.clang-format'
 fi


### PR DESCRIPTION
Delete the temporary .clang-format file created during the command execution.
Copy back the .clang-format.bk only if it exists.

---
This is a minor issue, it shouldn't be worthy of a new enkit release.