### PR TITLE
Change Auth Flow to not send Priv Key over the wire 

### DIFF
--- a/astore/rpc/auth.proto
+++ b/astore/rpc/auth.proto
@@ -15,15 +15,15 @@ message AuthenticateResponse {
 
 message TokenRequest {
   string url = 1; // URL returned by server.
+  bytes publickey = 2; // Public key to be signed by the server. Optional.
 }
 
 message TokenResponse {
   bytes nonce = 1; // Nonce used for encryption.
   bytes token = 2; // Encrypted token. Requires the private key corresponding to the public key supplied to open.
-  bytes key = 3; // Private Key used to login
-  bytes cert = 4; // Certificate signed to be used with the Private Key
-  bytes capublickey = 5; // CA Public Key to be added to the authenticated client
-  repeated string cahosts = 6; // List of hosts the CA should be trusted for
+  bytes cert = 3; // Certificate signed to be used with the Private Key, is a signed version of the public key sent in the TokenRequest
+  bytes capublickey = 4; // CA Public Key to be added to the authenticated client
+  repeated string cahosts = 5; // List of hosts the CA should be trusted for
 }
 
 message HostCertificateRequest {

--- a/astore/rpc/auth.proto
+++ b/astore/rpc/auth.proto
@@ -21,9 +21,9 @@ message TokenRequest {
 message TokenResponse {
   bytes nonce = 1; // Nonce used for encryption.
   bytes token = 2; // Encrypted token. Requires the private key corresponding to the public key supplied to open.
-  bytes cert = 4; // Certificate signed to be used with the Private Key, is a signed version of the public key sent in the TokenRequest
-  bytes capublickey = 5; // CA Public Key to be added to the authenticated client
-  repeated string cahosts = 6; // List of hosts the CA should be trusted for
+  bytes cert = 4; // Certificate signed to be used with the Private Key, is a signed version of the public key sent in the TokenRequest.
+  bytes capublickey = 5; // CA Public Key to be added to the authenticated client.
+  repeated string cahosts = 6; // List of hosts the CA should be trusted for.
 }
 
 message HostCertificateRequest {

--- a/astore/rpc/auth.proto
+++ b/astore/rpc/auth.proto
@@ -21,9 +21,9 @@ message TokenRequest {
 message TokenResponse {
   bytes nonce = 1; // Nonce used for encryption.
   bytes token = 2; // Encrypted token. Requires the private key corresponding to the public key supplied to open.
-  bytes cert = 3; // Certificate signed to be used with the Private Key, is a signed version of the public key sent in the TokenRequest
-  bytes capublickey = 4; // CA Public Key to be added to the authenticated client
-  repeated string cahosts = 5; // List of hosts the CA should be trusted for
+  bytes cert = 4; // Certificate signed to be used with the Private Key, is a signed version of the public key sent in the TokenRequest
+  bytes capublickey = 5; // CA Public Key to be added to the authenticated client
+  repeated string cahosts = 6; // List of hosts the CA should be trusted for
 }
 
 message HostCertificateRequest {

--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -133,7 +133,7 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 				Token: box.Seal(nil, []byte(authData.Cookie), &nonce, (*[32]byte)(clientPub), (*[32]byte)(s.serverPriv)),
 			}, nil
 		}
-		// if the ca signer was present, continuing with public keys
+		// If the ca signer was present, continuing with public keys.
 		savedPubKey, err := ssh.ParsePublicKey(b.Bytes)
 		if err != nil {
 			return nil, err
@@ -148,7 +148,7 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 			Token:       box.Seal(nil, []byte(authData.Cookie), &nonce, (*[32]byte)(clientPub), (*[32]byte)(s.serverPriv)),
 			Capublickey: s.marshalledCAPublicKey,
 			// Always trust the CA for now since the DNS gets resolved behind tunnel and therefore the client doesn't know
-			// which to trust
+			// which to trust.
 			Cahosts: []string{"*"},
 			Cert:    ssh.MarshalAuthorizedKey(userCert),
 		}, nil

--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -126,7 +126,7 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 		}
 		b, _ := pem.Decode(req.Publickey)
 		// If the ca signer is nil that means the CA was never passed in flags, if the request never sent a public key
-		// then so ssh certs will be sent back
+		// then so ssh certs will be sent back.
 		if s.caSigner == nil || b == nil {
 			return &auth.TokenResponse{
 				Nonce: nonce[:],

--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -125,7 +125,7 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 			return nil, status.Errorf(codes.Internal, "could not generate nonce - %s", err)
 		}
 		b, _ := pem.Decode(req.Publickey)
-		// if the ca signer is nil that means the CA was never passed in flags, if the request never sent a public key
+		// If the ca signer is nil that means the CA was never passed in flags, if the request never sent a public key
 		// then so ssh certs will be sent back
 		if s.caSigner == nil || b == nil {
 			return &auth.TokenResponse{

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -189,7 +189,7 @@ func CreateNewSSHAgent() (*SSHAgent, error) {
 // GenerateUserSSHCert will sign and return credentials based on the CA signer and given parameters
 // to generate a user cert, certType must be 1, and host certs ust have certType 2
 func GenerateUserSSHCert(ca ssh.Signer, certType uint32, principals []string, ttl time.Duration) (*rsa.PrivateKey, *ssh.Certificate, error) {
-	priv, pub, err := makeKeys()
+	priv, pub, err := MakeKeys()
 	if err != nil {
 		return priv, nil, err
 	}
@@ -209,7 +209,7 @@ func GenerateUserSSHCert(ca ssh.Signer, certType uint32, principals []string, tt
 	return priv, cert, nil
 }
 
-func makeKeys() (*rsa.PrivateKey, ssh.PublicKey, error) {
+func MakeKeys() (*rsa.PrivateKey, ssh.PublicKey, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/lib/oauth/oauth.go
+++ b/lib/oauth/oauth.go
@@ -495,10 +495,10 @@ func (a *Authenticator) PerformLogin(w http.ResponseWriter, r *http.Request, lm 
 }
 
 type AuthData struct {
-	Creds  *CredentialsCookie
-	Cookie string
-	Target string
-	State  interface{}
+	Creds         *CredentialsCookie
+	Cookie        string
+	Target        string
+	State         interface{}
 }
 
 func (a *Authenticator) ExtractAuth(w http.ResponseWriter, r *http.Request) (AuthData, error) {


### PR DESCRIPTION
I still need to test this but the code is here to review.

Public Key is send with the token request and not with the auth request:
Reason: The way that the auth requests cookie is sent would requrie significant refactoring in main.go of astore server.
Downside:  A public key isn't tied to a per login flow.  
