### PR TITLE
proxy/nss: add support for certificate authentication. 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,7 +49,7 @@ yarn_install(
 
 http_archive(
     name = "gtest",
-    url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
-    strip_prefix = "googletest-release-1.10.0",
     sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
+    strip_prefix = "googletest-release-1.10.0",
+    url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,3 +46,10 @@ yarn_install(
     package_json = "//ui/ptunnel:package.json",
     yarn_lock = "//ui/ptunnel:yarn.lock",
 )
+
+http_archive(
+    name = "gtest",
+    url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
+    strip_prefix = "googletest-release-1.10.0",
+    sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
+)

--- a/proxy/nss/BUILD.bazel
+++ b/proxy/nss/BUILD.bazel
@@ -1,67 +1,67 @@
 cc_library(
-  name = "nss_autouser",
-  copts = [
-    "-D_POSIX_C_SOURCE=200809L",
-    "-pedantic",
-    "-Wall",
-    "-std=c17",
-  ],
-  hdrs = [
-      "nss-autouser.h",
-      "//proxy/nss/confparse:confparse.h",
-  ],
-  srcs = [
-      "nss-autouser.c",
-      "//proxy/nss/confparse:confparse.c",
-  ],
+    name = "nss_autouser",
+    srcs = [
+        "nss-autouser.c",
+        "//proxy/nss/confparse:confparse.c",
+    ],
+    hdrs = [
+        "nss-autouser.h",
+        "//proxy/nss/confparse:confparse.h",
+    ],
+    copts = [
+        "-D_POSIX_C_SOURCE=200809L",
+        "-pedantic",
+        "-Wall",
+        "-std=c17",
+    ],
 )
 
 genrule(
-  name = "nss_autouser-nostatic",
-  srcs = [
-      "nss-autouser.c",
-  ],
-  outs = [
-      "nss-autouser-nostatic.c",
-  ],
-  cmd = "sed -e 's@^static @@' < $< > $@",
+    name = "nss_autouser-nostatic",
+    srcs = [
+        "nss-autouser.c",
+    ],
+    outs = [
+        "nss-autouser-nostatic.c",
+    ],
+    cmd = "sed -e 's@^static @@' < $< > $@",
 )
 
 cc_library(
-  name = "nss_autouser-fortesting",
-  copts = [
-    "-DAU_CONFIG_PATH=\\\"./nss-autouser.conf\\\"",
-    "-D_POSIX_C_SOURCE=200809L",
-    "-Iproxy/nss",
-    "-pedantic",
-    "-Wall",
-    "-std=c17",
-  ],
-  hdrs = [
-      "nss-autouser.h",
-  ],
-  srcs = [
-      ":nss_autouser-nostatic",
-  ],
-  deps = [
-    "//proxy/nss/confparse:confparse",
-  ]
+    name = "nss_autouser-fortesting",
+    srcs = [
+        ":nss_autouser-nostatic",
+    ],
+    hdrs = [
+        "nss-autouser.h",
+    ],
+    copts = [
+        "-DAU_CONFIG_PATH=\\\"./nss-autouser.conf\\\"",
+        "-D_POSIX_C_SOURCE=200809L",
+        "-Iproxy/nss",
+        "-pedantic",
+        "-Wall",
+        "-std=c17",
+    ],
+    deps = [
+        "//proxy/nss/confparse",
+    ],
 )
 
 cc_test(
-  name = "nss_autouser_test",
-  copts = [
-    "-std=c++2a",
-    "-Wall",
-    "-pedantic",
-  ],
-  srcs = [
-    "nss-autouser_test.cc",
-  ],
-  deps = [
-    ":nss_autouser-fortesting",
-    "//proxy/nss/confparse:confparse",
-    "@gtest//:gtest_main",
-  ],
-  data = glob(["testdata/**"]),
+    name = "nss_autouser_test",
+    srcs = [
+        "nss-autouser_test.cc",
+    ],
+    copts = [
+        "-std=c++2a",
+        "-Wall",
+        "-pedantic",
+    ],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":nss_autouser-fortesting",
+        "//proxy/nss/confparse",
+        "@gtest//:gtest_main",
+    ],
 )

--- a/proxy/nss/BUILD.bazel
+++ b/proxy/nss/BUILD.bazel
@@ -1,0 +1,67 @@
+cc_library(
+  name = "nss_autouser",
+  copts = [
+    "-D_POSIX_C_SOURCE=200809L",
+    "-pedantic",
+    "-Wall",
+    "-std=c17",
+  ],
+  hdrs = [
+      "nss-autouser.h",
+      "//proxy/nss/confparse:confparse.h",
+  ],
+  srcs = [
+      "nss-autouser.c",
+      "//proxy/nss/confparse:confparse.c",
+  ],
+)
+
+genrule(
+  name = "nss_autouser-nostatic",
+  srcs = [
+      "nss-autouser.c",
+  ],
+  outs = [
+      "nss-autouser-nostatic.c",
+  ],
+  cmd = "sed -e 's@^static @@' < $< > $@",
+)
+
+cc_library(
+  name = "nss_autouser-fortesting",
+  copts = [
+    "-DAU_CONFIG_PATH=\\\"./nss-autouser.conf\\\"",
+    "-D_POSIX_C_SOURCE=200809L",
+    "-Iproxy/nss",
+    "-pedantic",
+    "-Wall",
+    "-std=c17",
+  ],
+  hdrs = [
+      "nss-autouser.h",
+  ],
+  srcs = [
+      ":nss_autouser-nostatic",
+  ],
+  deps = [
+    "//proxy/nss/confparse:confparse",
+  ]
+)
+
+cc_test(
+  name = "nss_autouser_test",
+  copts = [
+    "-std=c++2a",
+    "-Wall",
+    "-pedantic",
+  ],
+  srcs = [
+    "nss-autouser_test.cc",
+  ],
+  deps = [
+    ":nss_autouser-fortesting",
+    "//proxy/nss/confparse:confparse",
+    "@gtest//:gtest_main",
+  ],
+  data = glob(["testdata/**"]),
+)

--- a/proxy/nss/README.md
+++ b/proxy/nss/README.md
@@ -1,0 +1,255 @@
+# NSS Autouser
+
+This directory contains `libnss_autouser`. `libnss_autouser` can do
+two separate things:
+
+* Change user login configurations on the fly based on the user and
+  the program the user is logging in with (dynamic user configuration).
+
+  This is useful, for example, to throw users in different containers
+  at login, or access the host/hypervisor.
+
+* Help create users on the fly when password authentication is not used
+  (dynamic user creation).
+
+This module was designed to be used with `ssh` certificate based authentication
+or `oauth` or `google` based authentication without having NIS, LDAP, or other
+shared databases in the network.
+
+If you don't know about ssh certificates, [this is a good article](https://berndbausch.medium.com/ssh-certificates-a45bdcdfac39)
+to read, but please keep in mind that "ssh certificates" != "ssh keys".
+
+## The big picture
+
+When `sshd` (or `login`, or a graphic authentication program) is authenticating
+a user, typicailly:
+
+1. The daemon will look up the user, in the `passwd` database.
+
+   This ends up invoking `getpwent`, which reads `/etc/nsswitch.conf`, which
+   typically ends up reading the `/etc/passwd` file. But this can be configured
+   by adding _moudles_ in `/etc/nsswitch.conf`, to, for example, use an ldap
+   database.
+
+2. Once the user is identified as existing (there is a passwd entry),
+   by looking at this entry the daemon will know the home directory, if
+   a password is accepted, the shell, the UID and GID.
+
+3. `sshd` will use this information to check the home directory for the user
+   for configuration files like the `authorized_keys` file, or apply policies
+   defined in the `sshd_config` file, like `AllowUsers`, `DenyUsers`.
+
+4. Assuming the user is allowed to log in, at this point the daemon
+   will typically use some mechanism to authenticate the user by eg,
+   verifying the user has the correct keys or certificates, or invoke
+   the `PAM` library for authentication.
+
+   The `PAM` library is configured via files in `/etc/pam.d/`, `sshd`
+   for example, and provides a very flexible mechanism to pick and
+   configure not only authentication methods, but actions that need
+   to be performed to set up the user environment.
+
+   For example, environment variables, memory or file descriptor limits,
+   auditing tools, ...
+
+5. If the user is authenticated, `PAM` is invoked once again to
+   set up the user environment, and a `shell` is finally spawned.
+
+## Installation
+
+Regardless of the configuration, to install `libnss_autouser` you need to:
+
+1. Build `libnss_autouser`, `bazelisk build //proxy/nss:libnss_autouser`
+   in the top level directory of this repository, and look for the path
+   of the output file in the bazel output.
+
+2. Copy `libnss_autouser.so` in the correct path, generally (*important*:
+   name has to end with `.so.2` in the final path):
+
+       cp -f bazel-bin/proxy/nss/libnss_autouser.so /lib/x86_64-linux-gnu/libnss_autouser.so.2
+
+3. Edit `/etc/nsswitch.conf` to have the correct line, something like:
+
+       passwd:         files autouser systemd
+
+4. Create a `/etc/nss-autouser.conf` file, make sure it is set with `chmod 0600`.
+
+The `configs` directory contains a couple examples, but read along.
+
+
+## Dynamic User Creation
+
+Let's say you are using `ssh` certificates, and you are managing a cluster
+full of machines.
+
+When a user presents its certificates, by checking the signature on the key
+`sshd` can be certain of the identity of the user. The certificate contains
+both the authorized identities, and a signature by a trusted authority.
+
+On a typical linux setup, the user would still *be denied entry*: as the user
+does not exist in the `passwd` database, unless something like LDAP or NIS is used.
+
+`libnss_autouser` allows to:
+
+1. Assign a free UID, GID, and home on the fly based on the user name.
+   When `libnss_autouser` runs, it exports a few environment variables
+   indicating the details of the user.
+
+2. If `sshd` then authenticates the user, `libpam_script` can then be used
+   before the login completes to create the home directory, and add the
+   user to the `passwd` file.
+
+To do so, you need to:
+
+1. Install `libnss_autouser` as described above.
+
+2. Create a `/etc/nss-autouser.conf` file, make sure it is set with `chmod 0600`,
+   with something like:
+
+       Seed enfabrica-test # change the seed to a random value that you like!
+       # DebugLog /tmp/debug.log
+       
+       Match sshd:*
+         MinUid 70000
+         MaxUid 0xfffffff0
+         Shell /bin/bash
+
+3. Test that nothing has broken, `getent passwd root` or `getent passwd non-existing-user`
+   should lead the correct result (no crash, no error, ...). If you change the `Match` line
+   to have `getent`, you should see `getent passwd non-existing-user` start succeeding
+   with a phony home, uid and gid.
+
+4. Configure `libpam-script` on your system to run a script to create the user on the fly.
+   This generally requires installing `libpam-script` (`apt-get install libpam-script`) and...
+
+5. Edit the `/etc/pam.d/sshd` file to have the line:
+
+       account required  pam_script.so dir=/etc/security
+
+6. Create a script `/etc/security/pam_script_acct` (don't forget to `chmod 0755` it)
+   to create the user on the fly.
+
+And enjoy!
+
+You can see an example `pam_script_acct` and `/etc/pam.d/sshd` configuration file in
+`./configs`.
+
+If this does not work, read the [debugging](#Debugging) section.
+
+
+## Dynamic User Configuration
+
+Let's that you use docker containers (or VMs) to provide shells to your users.
+Or let's say that you have a shared home directory on NFS, that sometimes fails.
+
+With `libnss_autouser` you can configure pattern matching so for example:
+
+* When an user `alice` logs into a system as `alice-nonfs`, a different `/home`
+  directory is used.
+
+* When an user `bob` logs into a system as `alice-host`, instead of running a
+  shell that throws the user in a container, a shell that gives access to the
+  host is used.
+
+To use this:
+
+1. Build and install `libnss_autouser` as described above.
+
+2. Create a `/etc/nss-autouser.conf` file, make sure it is set with `chmod 0600`,
+   with something like:
+
+       Seed enfabrica-test # change the seed to a random value that you like!
+       # DebugLog /tmp/debug.log
+       
+       Match sshd:*
+         MinUid 70000       # Very important!!
+         MaxUid 0xfffffff0  # Very important!!
+
+         Shell /bin/run-docker
+
+         Suffix -nonfs
+           Home /usr/local/home
+
+         Suffix -host
+           Shell /bin/bash
+
+
+Make sure to specify a `MinUid` and `MaxUid` that matches the
+uids assigned to your users. If a user has an uid outside this
+range, no mangling will be performed.
+
+# Security
+
+The accounts generated on the fly by `libnss_autouser` have password
+disabled by default, which on a properly configured system means that
+the user cannot login without an alternative mechanism of authentication.
+
+PAM plays an important role: if you disable ssh authentication and pam
+authentication, the user won't even need an account to log onto the machine!
+
+By specifying the MinUid and MaxUid range, you protect system accounts.
+
+`libnss_autouser` is inherently racy: the UID and GID assigned are to all
+effects effimeral and can be assigned to other users until they are saved in
+the passwd database, until after the user successfully authenticates.
+
+If *two non-existing users* with *valid credentials* and a *name that clashes
+on the same computed hash* try to log in at the same time, they will be
+assigned the same UID and GID.
+
+However, when the `pam_script_acct` script is run, if written properly,
+one of the users will succeed whlie the other user will be kicked out.
+
+If this second user retries, he/she will be assigned a different UID/GID
+(the module is guaranteed to assign a free UID/GID).
+
+To ensure security, it is recommended to:
+
+1. Make sure that `pam_script_acct` fails (exits with non 0 status) if
+   the user already exists at time of insertion in the database. 
+
+2. Make sure that whatever tool `pam_script_acct` uses to create the
+   user does locking. Without locking, adding two users at the same
+   time can corrupt the `passwd` database.
+
+3. Make sure `pam_script.so` has the magic *required* word next to
+   it, *appears first* in the configuration file (just to be safe),
+   does not have `onerr=success`. Having a `pam_deny.so` right after
+   this line may also be a good defense.
+
+4. Configure `ssh` to `UsePAM yes` explicitly.
+
+5. Do something so that your distro updates don't mess up your
+   configuration files. A favourite of mine is to run `chattr +i`
+   on critical files.
+
+6. Make sure `/etc/nss-autouser.conf` is only writable by root,
+   and that it is enabled only for very specific processes.
+   Don't specify *MinUid* and *MaxUid* globally, but only inside
+   *Match* statements.
+
+Why not reserve UIDs immediately when `libnss_autouser` is invoked?
+
+When the library is called, the user *has not* authenticated yet.
+It would be trivial to DoS the system, or create millions of invalid users.
+
+We could implement a small pool of recently used UIDs that cannot be
+re-used to mitigate the risk, but this will still not prevent malicious
+attempts.
+
+Note that for the attack to be successful and lead to different users
+having the same UID, *both users still need to have valid credentials*,
+with the system using unsafe login scripts.
+
+
+# Debugging
+
+For debugging, here are a few suggestions:
+
+1. Change the configuration file `/etc/nss-autouser.conf` to have a `DebugLog` file.
+   Look at the content of the log file.
+
+2. Check `/var/log/syslog` or `journalctl`. `libnss_autouser` tries to log problems.
+
+3. Change `/etc/nss-autouser.conf` to `Match` on `getent`, and use `strace getent 2>&1 |less`
+   to check what is happening, search for the string `autouser`.

--- a/proxy/nss/configs/certs.conf
+++ b/proxy/nss/configs/certs.conf
@@ -1,0 +1,11 @@
+# Drop this file in /etc/ssh/sshd_config.d/ after signing
+# and creating the proper certificates to enable certificate
+# authentication, while using PAM.
+
+
+HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub
+HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
+HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub
+TrustedUserCAKeys /etc/ssh/certs/ca.pub
+# LogLevel DEBUG
+UsePam yes

--- a/proxy/nss/configs/nss-autouser.simple.conf
+++ b/proxy/nss/configs/nss-autouser.simple.conf
@@ -1,0 +1,7 @@
+Seed enfabrica-test
+
+Match sshd:*
+  MinUid 70000
+  MaxUid 0xfffffff0
+ 
+  Shell /bin/bash

--- a/proxy/nss/configs/pam_script_acct
+++ b/proxy/nss/configs/pam_script_acct
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Move this script to: /etc/security/pam_script_acct.
+#
+# If you configure PAM correctly, it will be invoked when a user session is
+# started, and will create the user on the system on the fly.
+
+function error() {
+  echo "$@" 1>&2
+  logger -p auth.warning "autouser pam - $@" &>/dev/null || true
+  exit 1
+}
+
+# Exit with failure if there's any user creation problem.
+# Failure exit will cause PAM to fail login.
+set -e
+
+test -n "$PAM_USER" -a -n "$AUTOUSER_ORIGINAL" -a -n "$AUTOUSER_AUTOGEN" || {
+  error "User creation script invoked without all the environment variables."
+}
+
+test "$PAM_USER" == "$AUTOUSER_ORIGINAL" || {
+  error "$PAM_USER and $AUTOUSER_ORIGINAL disagree - leftover? race condition?"
+}
+
+test "$PAM_SERVICE" == "sshd" || {
+  error "User creation script invoked for non-ssh login"
+}
+
+test "$AUTOUSER_AUTOGEN" == "true" || {
+  exit 0 # nothing to do.
+}
+
+# If there is a one GID per user policy, implement it.
+test "$AUTOUSER_GID" != "$AUTOUSER_UID" || {
+  logger -p auth.info "autouser pam - adding group for $AUTOUSER_NAME $AUTOUSER_GID - vars" "$(printenv|grep AUTOUSER)" &>/dev/null || true
+  groupadd --gid "$AUTOUSER_GID" "$AUTOUSER_NAME"
+  trap "delgroup --only-if-empty \"$AUTOUSER_NAME\"; logger \"autouser - group $AUTOUSER_NAME, attempted removal\"; exit 1" EXIT
+}
+logger -p auth.info "autouser pam - adding user $AUTOUSER_NAME $AUTOUSER_UID - vars" "$(printenv|grep AUTOUSER)" &>/dev/null || true
+useradd --uid "$AUTOUSER_UID" --gid "$AUTOUSER_GID" -m -s "$AUTOUSER_SHELL" "$AUTOUSER_NAME" &> /tmp/error.log
+trap - EXIT

--- a/proxy/nss/configs/sshd
+++ b/proxy/nss/configs/sshd
@@ -1,0 +1,65 @@
+# The PAM configuration file for ssh on my system. Changes distro by distro,
+# release by release, based on the packages installed.
+#
+# To use libnss_autouser, to create accounts on the file, there is a single
+# line you need to add:
+#
+#    account required 	pam_script.so dir=/etc/security
+#
+# Just adding it at the top, as the first account module, is enough.
+#
+account	   required     pam_script.so dir=/etc/security
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/proxy/nss/confparse/BUILD.bazel
+++ b/proxy/nss/confparse/BUILD.bazel
@@ -1,0 +1,36 @@
+exports_files(glob(["*.c", "*.h"]), visibility = [    "//visibility:public"])
+
+cc_library(
+  name = "confparse",
+  copts = [
+    "-D_POSIX_C_SOURCE=200809L",
+    "-pedantic",
+    "-Wall",
+    "-std=c17",
+  ],
+  hdrs = [
+      "confparse.h",
+  ],
+  srcs = [
+      "confparse.c",
+  ],
+  visibility = [
+    "//visibility:public",
+  ],
+)
+
+cc_test(
+  name = "confparse_test",
+  copts = [
+    "-std=c++2a",
+    "-Wall",
+    "-pedantic",
+  ],
+  srcs = [
+    "confparse_test.cc",
+  ],
+  deps = [
+    ":confparse",
+    "@gtest//:gtest_main",
+  ],
+)

--- a/proxy/nss/confparse/BUILD.bazel
+++ b/proxy/nss/confparse/BUILD.bazel
@@ -1,36 +1,42 @@
-exports_files(glob(["*.c", "*.h"]), visibility = [    "//visibility:public"])
+exports_files(
+    glob([
+        "*.c",
+        "*.h",
+    ]),
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
-  name = "confparse",
-  copts = [
-    "-D_POSIX_C_SOURCE=200809L",
-    "-pedantic",
-    "-Wall",
-    "-std=c17",
-  ],
-  hdrs = [
-      "confparse.h",
-  ],
-  srcs = [
-      "confparse.c",
-  ],
-  visibility = [
-    "//visibility:public",
-  ],
+    name = "confparse",
+    srcs = [
+        "confparse.c",
+    ],
+    hdrs = [
+        "confparse.h",
+    ],
+    copts = [
+        "-D_POSIX_C_SOURCE=200809L",
+        "-pedantic",
+        "-Wall",
+        "-std=c17",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
 )
 
 cc_test(
-  name = "confparse_test",
-  copts = [
-    "-std=c++2a",
-    "-Wall",
-    "-pedantic",
-  ],
-  srcs = [
-    "confparse_test.cc",
-  ],
-  deps = [
-    ":confparse",
-    "@gtest//:gtest_main",
-  ],
+    name = "confparse_test",
+    srcs = [
+        "confparse_test.cc",
+    ],
+    copts = [
+        "-std=c++2a",
+        "-Wall",
+        "-pedantic",
+    ],
+    deps = [
+        ":confparse",
+        "@gtest//:gtest_main",
+    ],
 )

--- a/proxy/nss/confparse/README.md
+++ b/proxy/nss/confparse/README.md
@@ -1,0 +1,206 @@
+# confparse
+
+`confparse` is a tiny C library to parse configuration files similar
+to `ssh_config` or `sshd_config` into C structs.
+
+Compared to other libraries:
+
+* Self contained, depends only on basic C library functions, ~20 of them.
+* < 600 lines of actual code.
+* Supports sections, and recursive parsing.
+* Defines a read-only static parsing tree at compile time, that can
+  be reused over and over for parsing.
+
+Additionally:
+* It is trivial to use.
+* Has clear error messages.
+  Provides the context of the error, line and character.
+* Is trivial to modify and trim down.
+* Comes with some good unit level testing.
+
+To use it in your own project, you can easily copy `confparse.h`
+and `confparse.c` in your tree, and build them with your favourite
+build system.
+
+The code is clean to compile with:
+
+    gcc -D_POSIX_C_SOURCE=200809L -pedantic -Wall -std=c17
+
+(yes, we favour modern versions of the language and features,
+at time of writing, c17 is at least 4 years old).
+
+# Using the library
+
+Using the library is trivial. Check the [unit test](confparse_test.c)
+for some examples.
+
+In short, something like this:
+
+    #include "confparse.h"
+
+    typedef struct {
+      char* path;
+      char* user;
+      char* host;
+
+      uint32_t port;
+    } my_config_t;
+
+    void my_function() {
+      statement_t language[] = {
+        { OPT_NONE, match_exact("Path"), expect_string(offsetof(my_config_t, path)) },
+        { OPT_NONE, match_exact("User"), expect_string(offsetof(my_config_t, user)) },
+        { OPT_NONE, match_exact("Host"), expect_string(offsetof(my_config_t, host)) },
+        { OPT_NONE, match_exact("Port"), expect_uint32(offsetof(my_config_t, port)) },
+      }
+
+      perror_t error = perror_init();
+      my_config_t config = {NULL};
+
+      int status = parse_file("/etc/module.conf", language, &config, &error);
+
+      if (status < 0) {
+        fprintf(stderr, "error parsing file: %s", error.message);
+      }
+
+      config_free(&config); // You'll have to write this one.
+      perror_free(error);   // Yes, safe to call even without errors.
+    }
+
+Will accept configuration files that look like:
+
+      # Comments are fine on a line.
+    User carlo # .. or at the end of the line.
+    Path "/home/data/My Movies" # Quoting is fine for strings, \\ escapes.
+    Host this@is-an-host
+    Port 0x10 # hex, decimal, or octal are supported.
+
+By using `OPT_` modifiers, you can tune the behavior.
+
+With the language definition above, for example, a config like this
+would also be accepted:
+
+    User carlo
+
+... or even an empty file, as no statement is marked as mandatory with
+`OPT_MUST`. While a config like this:
+
+    User carlo
+    User carlo
+
+would be rejected, as `User` is not marked with `OPT_MULTI`.
+
+Parsing a buffer is also really easy, just use:
+
+    parse_buffer(buffer, language, &config, &error);
+
+... same as above!
+
+
+# A more complex example
+
+Let's say you need to support "configuration blocks": for example,
+you have different settings for different directories, or users.
+
+You want your configuration file to look like:
+
+    Directory /home/test
+      Scan true
+      MaxFile 64000
+      Owner carlo
+
+    Directory /home/bar
+      Scan false
+      Owner mario
+
+    Default
+      Scan false
+      Owner mario
+
+Your language could look like this:
+
+    enum {
+      ENABLE_SCAN = 1,
+    };
+    typedef struct {
+      uint32_t flags;
+
+      char* directory;
+      char* owner;
+      uint32_t max;
+    } my_directory_t;
+
+    typedef struct {
+      my_directory_t defaults; /* Defaults from Default section. */
+
+      my_directory_t* dir; /* Each directory is added here. */
+      int dirn;            /* Number of directories. */
+    } my_config_t;
+
+    statement_t options[] = {
+        { OPT_NONE, match_exact("Scan"), expect_bool32(offsetof(my_config_t, flags), 0, ENABLE_SCAN) },
+        { OPT_NONE, match_exact("MaxFile"), expect_uint32(offsetof(my_config_t, max)) },
+        { OPT_NONE|OPT_MUST, match_exact("Owner"), expect_string(offsetof(my_config_t, owner)) },
+    };
+
+    statement_t directory[] = {
+        { OPT_NONE, match_exact("Directory"), expect_string(offsetof(my_config_t, directory)) },
+        { OPT_NONE|OPT_MUST, match_any(), expect_section(options, NULL) },
+    };
+
+    statement_t defaults[] = {
+        { OPT_NONE, match_exact("Default"), expect_nothing() },
+        { OPT_NONE|OPT_MUST, match_any(), expect_section(options, NULL) },
+    };
+
+    statement_t language[] = {
+        { OPT_NONE, match_exact("Default"), expect_section(directory, (adder_f)(my_config_add_default) },
+        { OPT_NONE|OPT_MULTI, match_exact("Directory"), expect_section(defaults, (adder_f)(my_config_add_dir)) },
+    };
+
+Now, you may wonder...
+
+* Why the two levels of nesting? Well, we need to tell the parsing library how to parse the `Directory` and
+  `Default` statements themselves, and that parsing is different in the two objects.
+
+  By using `OPT_START` you can even create sections implicitly, the first time a specific statement is
+  encountered.
+
+* What are `my_config_add_default` and `my_config_add_dir`? They are two simple functions that given
+  a `my_config_t` object are in charge of adding the `section` described. For example:
+
+    void* my_config_add_default(void* config) {
+      my_config_t* real = config;
+      return &real->defaults;
+    }
+
+    void* my_config_add_dir(void* config) {
+      my_config_t* real = config;
+      real->dir = realloc(real->dir, sizeof(my_directory_t) * (real->dirn + 1));
+      my_directory_t* dir = real->dir[(real->dirn)++];
+      memset(dir, 0, sizeof(*dir));
+      return dir;
+    }
+
+If you peek through the code and tests, you will see more examples like this.
+Happy hacking!
+
+# A couple remarks
+
+Adding custom types or extending the set of types supported is relatively
+easy: define a parsing and storing function, and store your callback and
+its state in a statement. Just follow the same pattern as other parser.
+
+All the necessary functions and structs are exported in the .h file for
+convenience.
+
+# Sharp edges
+
+The library assumes that it owns any value in the supplied config.
+If you mark a string as `OPT_MULTI`, newer values will overwrite old ones,
+as is typical in configuration files.
+
+To avoid memory leask, the library will of course `free()` any previous value.
+So:
+* Make sure you always initialize your config to 0.
+* Don't assign string constants as defaults. 

--- a/proxy/nss/confparse/confparse.c
+++ b/proxy/nss/confparse/confparse.c
@@ -26,231 +26,268 @@
  * free() unless an error is returned.
  *
  * Returns -1 in case of error, or the amount of bytes read. */
-static ssize_t read_file(const char* path, char** buffer) {
-  FILE* f = fopen(path, "rb");
-  if (!f) return -1;
+static ssize_t read_file(const char *path, char **buffer)
+{
+	FILE *f = fopen(path, "rb");
+	if (!f)
+		return -1;
 
-  fseek(f, 0, SEEK_END);
-  long size = ftell(f);
-  fseek (f, 0, SEEK_SET);
-  if (!buffer) {
-    fclose(f);
-    return -1;
-  }
+	fseek(f, 0, SEEK_END);
+	long size = ftell(f);
+	fseek(f, 0, SEEK_SET);
+	if (!buffer) {
+		fclose(f);
+		return -1;
+	}
 
-  *buffer = malloc(size + 1);
-  size_t got = fread(*buffer, 1, size, f);
-  fclose (f);
+	*buffer = malloc(size + 1);
+	size_t got = fread(*buffer, 1, size, f);
+	fclose(f);
 
-  if (got < size) {
-    free(*buffer);
-    *buffer = NULL;
-    return -1;
-  }
-  (*buffer)[size] = '\0';
-  return size;
+	if (got < size) {
+		free(*buffer);
+		*buffer = NULL;
+		return -1;
+	}
+	(*buffer)[size] = '\0';
+	return size;
 }
 
 /* verrorp is just like error() below, but takes a va_list and prefix. */
-error_code_e verrorp(perror_t* error, const char* prefix, const char* fmt, va_list input) {
-  if (!error) return CPE_SUCCESS;
-  perror_free(error);
+error_code_e verrorp(perror_t *error, const char *prefix, const char *fmt,
+		     va_list input)
+{
+	if (!error)
+		return CPE_SUCCESS;
+	perror_free(error);
 
-  va_list args;
-  va_copy(args, input);
-  size_t size = vsnprintf(NULL, 0, fmt, args);
-  va_end(args);
-  
-  if (size <= 0)
-    return CPE_INTERNAL;
+	va_list args;
+	va_copy(args, input);
+	size_t size = vsnprintf(NULL, 0, fmt, args);
+	va_end(args);
 
-  int plen = 0;
-  if (prefix)
-    plen = strlen(prefix);
+	if (size <= 0)
+		return CPE_INTERNAL;
 
-  error->message = malloc(plen + size + 1);
+	int plen = 0;
+	if (prefix)
+		plen = strlen(prefix);
 
-  if (prefix)
-    strcpy(error->message, prefix);
+	error->message = malloc(plen + size + 1);
 
-  va_copy(args, input);
-  size = vsnprintf(error->message + plen, size + 1, fmt, args);
-  va_end(args);
+	if (prefix)
+		strcpy(error->message, prefix);
 
-  /* In the unlikely case vsnprintf failed, we don't want to return
+	va_copy(args, input);
+	size = vsnprintf(error->message + plen, size + 1, fmt, args);
+	va_end(args);
+
+	/* In the unlikely case vsnprintf failed, we don't want to return
    * a buffer containing garbage to the user. */
-  if (size < 0) {
-    perror_free(error);
-  }
+	if (size < 0) {
+		perror_free(error);
+	}
 
-  return CPE_SUCCESS;
-}
- 
-int error(perror_t* error, error_code_e code, const char* fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  int result = verrorp(error, "", fmt, args);
-  va_end(args);
-
-  if (code < 0) return code;
-  return result;
+	return CPE_SUCCESS;
 }
 
-error_code_e adapter_string(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  char** target = (char **)((char*)(dest) + data->offset);
-  if (target && *target) { free(*target); *target = NULL; }
-  return parse_string(ctx, target);
+int error(perror_t *error, error_code_e code, const char *fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	int result = verrorp(error, "", fmt, args);
+	va_end(args);
+
+	if (code < 0)
+		return code;
+	return result;
 }
 
-parse_t expect_string(size_t offset) {
-  parse_t callback = {
+error_code_e adapter_string(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	char **target = (char **)((char *)(dest) + data->offset);
+	if (target && *target) {
+		free(*target);
+		*target = NULL;
+	}
+	return parse_string(ctx, target);
+}
+
+parse_t expect_string(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_string,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_uint32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  uint64_t value = 0;
-  int status = parse_uint64(ctx, UINT32_MAX, &value);
-  *(uint32_t *)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_uint32(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	uint64_t value = 0;
+	int status = parse_uint64(ctx, UINT32_MAX, &value);
+	*(uint32_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_uint32(size_t offset) {
-  parse_t callback = {
+parse_t expect_uint32(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_uint32,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_uint64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  uint64_t value = 0;
-  int status = parse_uint64(ctx, UINT64_MAX, &value);
-  *(uint64_t *)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_uint64(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	uint64_t value = 0;
+	int status = parse_uint64(ctx, UINT64_MAX, &value);
+	*(uint64_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_uint64(size_t offset) {
-  parse_t callback = {
+parse_t expect_uint64(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_uint64,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_uint16(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  uint64_t value = 0;
-  int status = parse_uint64(ctx, UINT16_MAX, &value);
-  *(uint16_t *)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_uint16(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	uint64_t value = 0;
+	int status = parse_uint64(ctx, UINT16_MAX, &value);
+	*(uint16_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_uint16(size_t offset) {
-  parse_t callback = {
+parse_t expect_uint16(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_uint16,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_uint8(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  uint64_t value = 0;
-  int status = parse_uint64(ctx, UINT8_MAX, &value);
-  *(uint16_t *)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_uint8(parse_context_t *ctx, const char *start,
+			   types_u *data, void *dest)
+{
+	uint64_t value = 0;
+	int status = parse_uint64(ctx, UINT8_MAX, &value);
+	*(uint16_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_uint8(size_t offset) {
-  parse_t callback = {
+parse_t expect_uint8(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_uint8,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_int64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  int64_t value = 0;
-  int status = parse_int64(ctx, INT64_MIN, INT64_MAX, &value);
-  *(int64_t*)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_int64(parse_context_t *ctx, const char *start,
+			   types_u *data, void *dest)
+{
+	int64_t value = 0;
+	int status = parse_int64(ctx, INT64_MIN, INT64_MAX, &value);
+	*(int64_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_int64(size_t offset) {
-  parse_t callback = {
+parse_t expect_int64(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_int64,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_int32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  int64_t value = 0;
-  int status = parse_int64(ctx, INT32_MIN, INT32_MAX, &value);
-  *(int32_t*)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_int32(parse_context_t *ctx, const char *start,
+			   types_u *data, void *dest)
+{
+	int64_t value = 0;
+	int status = parse_int64(ctx, INT32_MIN, INT32_MAX, &value);
+	*(int32_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_int32(size_t offset) {
-  parse_t callback = {
+parse_t expect_int32(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_int32,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_int16(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  int64_t value = 0;
-  int status = parse_int64(ctx, INT16_MIN, INT16_MAX, &value);
-  *(int16_t*)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_int16(parse_context_t *ctx, const char *start,
+			   types_u *data, void *dest)
+{
+	int64_t value = 0;
+	int status = parse_int64(ctx, INT16_MIN, INT16_MAX, &value);
+	*(int16_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_int16(size_t offset) {
-  parse_t callback = {
+parse_t expect_int16(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_int16,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_int8(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  int64_t value = 0;
-  int status = parse_int64(ctx, INT8_MIN, INT8_MAX, &value);
-  *(int8_t*)((char*)(dest) + data->offset) = value;
-  return status;
+error_code_e adapter_int8(parse_context_t *ctx, const char *start,
+			  types_u *data, void *dest)
+{
+	int64_t value = 0;
+	int status = parse_int64(ctx, INT8_MIN, INT8_MAX, &value);
+	*(int8_t *)((char *)(dest) + data->offset) = value;
+	return status;
 }
 
-parse_t expect_int8(size_t offset) {
-  parse_t callback = {
+parse_t expect_int8(size_t offset)
+{
+	parse_t callback = {
       .function = adapter_int8,
       .data = {
         .offset = offset,
       }, 
   };
-  return callback;
+	return callback;
 }
 
 typedef struct {
-  size_t len;
-  const char* ptr;
+	size_t len;
+	const char *ptr;
 } option_t;
 
 /* In static context, only const expressions are allowed.
@@ -259,88 +296,118 @@ typedef struct {
  * This macro is, however, VERY UNSAFE. name should be
  * a static string, don't even think about passing any
  * sort of expression in. */
-#define OPTION_CONST(name) {sizeof(name) - 1, name}
-#define OPTION_END {0, NULL}
+#define OPTION_CONST(name)                                                     \
+	{                                                                      \
+		sizeof(name) - 1, name                                         \
+	}
+#define OPTION_END                                                             \
+	{                                                                      \
+		0, NULL                                                        \
+	}
 
-int find_option_prefix(const option_t* options, const char* start) {
-  for (int i = 0; options[i].ptr; ++i) {
-    if (!strncmp(options[i].ptr, start, options[i].len)) return i;
-  }
-  return -1;
+int find_option_prefix(const option_t *options, const char *start)
+{
+	for (int i = 0; options[i].ptr; ++i) {
+		if (!strncmp(options[i].ptr, start, options[i].len))
+			return i;
+	}
+	return -1;
 }
 
-  static const option_t trues[] = {
-	  OPTION_CONST("True"),
-    	  OPTION_CONST("true"),
-    	  OPTION_CONST("yes"),
-    	  OPTION_CONST("on"),
-	  OPTION_END,
-  };
+static const option_t trues[] = {
+	OPTION_CONST("True"), OPTION_CONST("true"), OPTION_CONST("yes"),
+	OPTION_CONST("on"),   OPTION_END,
+};
 
-  static const option_t falses[] = {
-	  OPTION_CONST("False"),
-    	  OPTION_CONST("false"),
-    	  OPTION_CONST("no"),
-    	  OPTION_CONST("off"),
-	  OPTION_END,
-  };
+static const option_t falses[] = {
+	OPTION_CONST("False"),
+	OPTION_CONST("false"),
+	OPTION_CONST("no"),
+	OPTION_CONST("off"),
+	OPTION_END,
+};
 
-error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit, uint32_t flipbit, uint32_t *dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
+error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit,
+			  uint32_t flipbit, uint32_t *dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  int option = 0;
-  if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
-    *dest = assign_bits(*dest, seenbit | flipbit, seenbit | flipbit);
-    ctx->cursor += trues[option].len;
-  } else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
-    *dest = assign_bits(*dest, seenbit, seenbit | flipbit);
-    ctx->cursor += falses[option].len;
-  } else {
-    return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "was expecting a field - found end of config");
-  }
+	int option = 0;
+	if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
+		*dest = assign_bits(*dest, seenbit | flipbit,
+				    seenbit | flipbit);
+		ctx->cursor += trues[option].len;
+	} else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
+		*dest = assign_bits(*dest, seenbit, seenbit | flipbit);
+		ctx->cursor += falses[option].len;
+	} else {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_BOOL, &ctx->line,
+			"was expecting a field - found end of config");
+	}
 
-  if (!*ctx->cursor || isspace(*ctx->cursor)) return 0;
-  return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "unexpected character after bool %c", *ctx->cursor);
+	if (!*ctx->cursor || isspace(*ctx->cursor))
+		return 0;
+	return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line,
+			       "unexpected character after bool %c",
+			       *ctx->cursor);
 }
 
-error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit, uint64_t flipbit, uint64_t *dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
+error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit,
+			  uint64_t flipbit, uint64_t *dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  int option = 0;
-  if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
-    *dest = assign_bits(*dest, seenbit | flipbit, seenbit | flipbit);
-    ctx->cursor += trues[option].len;
-  } else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
-    *dest = assign_bits(*dest, seenbit, seenbit | flipbit);
-    ctx->cursor += falses[option].len;
-  } else {
-    return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "was expecting a field - found end of config");
-  }
+	int option = 0;
+	if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
+		*dest = assign_bits(*dest, seenbit | flipbit,
+				    seenbit | flipbit);
+		ctx->cursor += trues[option].len;
+	} else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
+		*dest = assign_bits(*dest, seenbit, seenbit | flipbit);
+		ctx->cursor += falses[option].len;
+	} else {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_BOOL, &ctx->line,
+			"was expecting a field - found end of config");
+	}
 
-  if (!*ctx->cursor || isspace(*ctx->cursor)) return 0;
-  return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "unexpected character after bool %c", *ctx->cursor);
+	if (!*ctx->cursor || isspace(*ctx->cursor))
+		return 0;
+	return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line,
+			       "unexpected character after bool %c",
+			       *ctx->cursor);
 }
 
-error_code_e adapter_bool32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  size_t offset = data->ints[0];
-  uint32_t seenbit = data->ints[1];
-  uint32_t flipbit = data->ints[2];
-  
-  return parse_bool32(ctx, seenbit, flipbit, (uint32_t *)((char*)(dest) + offset));
+error_code_e adapter_bool32(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	size_t offset = data->ints[0];
+	uint32_t seenbit = data->ints[1];
+	uint32_t flipbit = data->ints[2];
+
+	return parse_bool32(ctx, seenbit, flipbit,
+			    (uint32_t *)((char *)(dest) + offset));
 }
 
-error_code_e adapter_bool64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  size_t offset = data->ints[0];
-  uint64_t seenbit = data->ints[1];
-  uint64_t flipbit = data->ints[2];
-  
-  return parse_bool64(ctx, seenbit, flipbit, (uint64_t *)((char*)(dest) + offset));
+error_code_e adapter_bool64(parse_context_t *ctx, const char *start,
+			    types_u *data, void *dest)
+{
+	size_t offset = data->ints[0];
+	uint64_t seenbit = data->ints[1];
+	uint64_t flipbit = data->ints[2];
+
+	return parse_bool64(ctx, seenbit, flipbit,
+			    (uint64_t *)((char *)(dest) + offset));
 }
 
-parse_t expect_bool64(size_t offset, uint64_t seenbit, uint64_t flipbit) {
-  parse_t callback = {
+parse_t expect_bool64(size_t offset, uint64_t seenbit, uint64_t flipbit)
+{
+	parse_t callback = {
       .function = adapter_bool64,
       .data = {
 	.ints = {
@@ -350,13 +417,12 @@ parse_t expect_bool64(size_t offset, uint64_t seenbit, uint64_t flipbit) {
 	},
       }, 
   };
-  return callback;
+	return callback;
 }
 
-
-
-parse_t expect_bool32(size_t offset, uint32_t seenbit, uint32_t flipbit) {
-  parse_t callback = {
+parse_t expect_bool32(size_t offset, uint32_t seenbit, uint32_t flipbit)
+{
+	parse_t callback = {
       .function = adapter_bool32,
       .data = {
 	.ints = {
@@ -366,36 +432,42 @@ parse_t expect_bool32(size_t offset, uint32_t seenbit, uint32_t flipbit) {
 	},
       }, 
   };
-  return callback;
+	return callback;
 }
 
-error_code_e adapter_nothing(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  return CPE_SUCCESS;
+error_code_e adapter_nothing(parse_context_t *ctx, const char *start,
+			     types_u *data, void *dest)
+{
+	return CPE_SUCCESS;
 }
 
-parse_t expect_nothing() {
-  parse_t callback = {
-      .function = adapter_nothing,
-  };
-  return callback;
+parse_t expect_nothing()
+{
+	parse_t callback = {
+		.function = adapter_nothing,
+	};
+	return callback;
 }
 
-error_code_e adapter_section(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
-  statement_t* statements = (statement_t*)(data->ptrs[0]);
-  /* ISO C forbids conversion of object pointer to function pointer. */
-  adder_f adder;
-  *(void**)(&adder) = data->ptrs[1];
+error_code_e adapter_section(parse_context_t *ctx, const char *start,
+			     types_u *data, void *dest)
+{
+	statement_t *statements = (statement_t *)(data->ptrs[0]);
+	/* ISO C forbids conversion of object pointer to function pointer. */
+	adder_f adder;
+	*(void **)(&adder) = data->ptrs[1];
 
-  if (adder) {
-    dest = adder(dest);
-  }
+	if (adder) {
+		dest = adder(dest);
+	}
 
-  ctx->cursor = start;
-  return parse_section(ctx, statements, dest);
+	ctx->cursor = start;
+	return parse_section(ctx, statements, dest);
 }
 
-parse_t expect_section(statement_t* statements, adder_f adder) {
-  parse_t callback = {
+parse_t expect_section(statement_t *statements, adder_f adder)
+{
+	parse_t callback = {
       .function = adapter_section,
       .data = {
         .ptrs = {
@@ -404,112 +476,142 @@ parse_t expect_section(statement_t* statements, adder_f adder) {
 	},
       },
   };
-  return callback;
+	return callback;
 }
 
-error_code_e parse_ctx_error(parse_context_t* ctx, error_code_e code, const line_t* line, const char* fmt, ...) {
-  char prefix[64];
-  snprintf(prefix, sizeof(prefix), "line %d, char %td: ", line->number + 1, ctx->cursor - line->start);
+error_code_e parse_ctx_error(parse_context_t *ctx, error_code_e code,
+			     const line_t *line, const char *fmt, ...)
+{
+	char prefix[64];
+	snprintf(prefix, sizeof(prefix),
+		 "line %d, char %td: ", line->number + 1,
+		 ctx->cursor - line->start);
 
-  va_list args;
-  va_start(args, fmt);
-  int result = verrorp(ctx->err, prefix, fmt, args);
-  va_end(args);
+	va_list args;
+	va_start(args, fmt);
+	int result = verrorp(ctx->err, prefix, fmt, args);
+	va_end(args);
 
-  if (code < 0) return code;
-  return result;
+	if (code < 0)
+		return code;
+	return result;
 }
 
-void parse_ctx_newline(parse_context_t* ctx) {
-  ctx->line.start = ctx->cursor + 1;
-  (ctx->line.number)++;
+void parse_ctx_newline(parse_context_t *ctx)
+{
+	ctx->line.start = ctx->cursor + 1;
+	(ctx->line.number)++;
 }
 
 /* skip_line_spaces moves the cursor past any 'line' space.
  *
  * A line space is any spacing chcaracter that can typically be found
  * on a single line of text, ' ' or '\t', but not '\r', '\n' or '\v'. */
-void skip_line_spaces(parse_context_t* ctx) {
-  for(; *ctx->cursor && (*ctx->cursor == ' ' || *ctx->cursor == '\t'); ++(ctx->cursor))
-    ;
+void skip_line_spaces(parse_context_t *ctx)
+{
+	for (; *ctx->cursor && (*ctx->cursor == ' ' || *ctx->cursor == '\t');
+	     ++(ctx->cursor))
+		;
 }
 
 /* skip_until_field moves the cursor at the beginning of the first field.
  *
  * This is a convenience wrapper around skip_line_spaces that sets an
  * error in case no field can be found. */
-error_code_e skip_until_field(parse_context_t* ctx) {
-  skip_line_spaces(ctx);
-  if (!*ctx->cursor) return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "was expecting a field - found end of config");
-  if (isspace(*ctx->cursor)) return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "was expecting a field - found a new line? unexpected space");
-  return 0;
+error_code_e skip_until_field(parse_context_t *ctx)
+{
+	skip_line_spaces(ctx);
+	if (!*ctx->cursor)
+		return parse_ctx_error(
+			ctx, CPE_UNEXPECTED, &ctx->line,
+			"was expecting a field - found end of config");
+	if (isspace(*ctx->cursor))
+		return parse_ctx_error(
+			ctx, CPE_UNEXPECTED, &ctx->line,
+			"was expecting a field - found a new line? unexpected space");
+	return 0;
 }
 
 /* skip_until_eol moves the cursor to the end of the current line. */
-void skip_until_eol(parse_context_t* ctx) {
-  for(; *ctx->cursor && *ctx->cursor != '\n'; ++(ctx->cursor))
-    ;
+void skip_until_eol(parse_context_t *ctx)
+{
+	for (; *ctx->cursor && *ctx->cursor != '\n'; ++(ctx->cursor))
+		;
 }
 
 /* parse_quoted_string parses a string enclosed in quotes (").
  *
  * The string can contain space characters, newlines, and can escape
  * quotes by using \", and escape \ itself with \\. */
-error_code_e parse_quoted_string(parse_context_t* ctx, char** dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
-  
-  if (*ctx->cursor != '\"') return parse_ctx_error(ctx, CPE_PARSE_QUOTE, &ctx->line, "was expecting a quoted string, starting with '\"', found '%c'", *ctx->cursor);
+error_code_e parse_quoted_string(parse_context_t *ctx, char **dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  line_t line = ctx->line;
-  const char* start = (ctx->cursor) + 1;
-  unsigned escapes = 0;
-  while(1) {
-    if (*++(ctx->cursor) == '\0')
-      return parse_ctx_error(ctx, CPE_UNEXPECTED, &line, "reached end of file, without finding the closing '\"'");
+	if (*ctx->cursor != '\"')
+		return parse_ctx_error(
+			ctx, CPE_PARSE_QUOTE, &ctx->line,
+			"was expecting a quoted string, starting with '\"', found '%c'",
+			*ctx->cursor);
 
-    if (*ctx->cursor == '"') {
-      (ctx->cursor)++;
-      break;
-    }
+	line_t line = ctx->line;
+	const char *start = (ctx->cursor) + 1;
+	unsigned escapes = 0;
+	while (1) {
+		if (*++(ctx->cursor) == '\0')
+			return parse_ctx_error(
+				ctx, CPE_UNEXPECTED, &line,
+				"reached end of file, without finding the closing '\"'");
 
-    if (*ctx->cursor == '\n') {
-      parse_ctx_newline(ctx);
-      continue;
-    }
+		if (*ctx->cursor == '"') {
+			(ctx->cursor)++;
+			break;
+		}
 
-    if (*ctx->cursor != '\\') {
-      continue;
-    }
+		if (*ctx->cursor == '\n') {
+			parse_ctx_newline(ctx);
+			continue;
+		}
 
-    if (*(ctx->cursor + 1) == '\0')
-      return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "reached end of file, while processing escape '\\'");
+		if (*ctx->cursor != '\\') {
+			continue;
+		}
 
-    if (*(ctx->cursor + 1) != '"' && *(ctx->cursor + 1) != '\\')
-      return parse_ctx_error(ctx, CPE_PARSE_QUOTE, &ctx->line, "escape sequence '\\%c' is unknown - only \\\\ and \\\" supported", *(ctx->cursor + 1));
+		if (*(ctx->cursor + 1) == '\0')
+			return parse_ctx_error(
+				ctx, CPE_UNEXPECTED, &ctx->line,
+				"reached end of file, while processing escape '\\'");
 
-    /* we found a valid escape sequence, skip it. */
-    escapes++;
-    (ctx->cursor)++;
-  }
+		if (*(ctx->cursor + 1) != '"' && *(ctx->cursor + 1) != '\\')
+			return parse_ctx_error(
+				ctx, CPE_PARSE_QUOTE, &ctx->line,
+				"escape sequence '\\%c' is unknown - only \\\\ and \\\" supported",
+				*(ctx->cursor + 1));
 
-  if (!dest) return CPE_SUCCESS;
+		/* we found a valid escape sequence, skip it. */
+		escapes++;
+		(ctx->cursor)++;
+	}
 
-  if (!escapes) {
-    *dest = strndup(start, ctx->cursor - start - 1);
-    return CPE_SUCCESS;
-  }
+	if (!dest)
+		return CPE_SUCCESS;
 
-  /* Code here can assume that the input is correct. */
-  *dest = malloc(ctx->cursor - start - escapes);
-  for (char* cursor = *dest; start < ctx->cursor - 1; ++start) {
-    if (*start == '\\') {
-      *cursor++ = *++start;
-    } else {
-      *cursor++ = *start;
-    }
-  }
-  return CPE_SUCCESS;
+	if (!escapes) {
+		*dest = strndup(start, ctx->cursor - start - 1);
+		return CPE_SUCCESS;
+	}
+
+	/* Code here can assume that the input is correct. */
+	*dest = malloc(ctx->cursor - start - escapes);
+	for (char *cursor = *dest; start < ctx->cursor - 1; ++start) {
+		if (*start == '\\') {
+			*cursor++ = *++start;
+		} else {
+			*cursor++ = *start;
+		}
+	}
+	return CPE_SUCCESS;
 }
 
 /* parse_string parses a string.
@@ -517,68 +619,97 @@ error_code_e parse_quoted_string(parse_context_t* ctx, char** dest) {
  * The string can either be in quotes, like "foo bar", or just be a naked
  * string, with no quotes. When the string has no quotes, parsing stops at
  * the first whitespace character. */
-error_code_e parse_string(parse_context_t* ctx, char** dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
+error_code_e parse_string(parse_context_t *ctx, char **dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  if (*ctx->cursor == '\"')
-    return parse_quoted_string(ctx, dest);
+	if (*ctx->cursor == '\"')
+		return parse_quoted_string(ctx, dest);
 
-  const char* start = ctx->cursor;
-  for(; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
-    ;
+	const char *start = ctx->cursor;
+	for (; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
+		;
 
-  if (dest) *dest = strndup(start, ctx->cursor - start);
-  return CPE_SUCCESS;
+	if (dest)
+		*dest = strndup(start, ctx->cursor - start);
+	return CPE_SUCCESS;
 }
 
-error_code_e parse_uint64(parse_context_t* ctx, uint64_t limit, uint64_t* dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
+error_code_e parse_uint64(parse_context_t *ctx, uint64_t limit, uint64_t *dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  if (!isdigit(*ctx->cursor) && *ctx->cursor != '+')
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a digit, found '%c'", *ctx->cursor);
+	if (!isdigit(*ctx->cursor) && *ctx->cursor != '+')
+		return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line,
+				       "was expecting a digit, found '%c'",
+				       *ctx->cursor);
 
-  static_assert(sizeof(unsigned long long int) >= sizeof(uint64_t),
-    "strtoull on your system does not support 64 bit integers");
+	static_assert(
+		sizeof(unsigned long long int) >= sizeof(uint64_t),
+		"strtoull on your system does not support 64 bit integers");
 
-  unsigned long long int parsed = strtoull(ctx->cursor, (char**)(&ctx->cursor), 0);
-  if (*ctx->cursor && !isspace(*ctx->cursor)) {
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a number, found invalid '%c'", *ctx->cursor);
-  }
+	unsigned long long int parsed =
+		strtoull(ctx->cursor, (char **)(&ctx->cursor), 0);
+	if (*ctx->cursor && !isspace(*ctx->cursor)) {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_INT, &ctx->line,
+			"was expecting a number, found invalid '%c'",
+			*ctx->cursor);
+	}
 
-  if (parsed > limit) {
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "specified number is too large (max: %"PRIu64")", limit);
-  }
+	if (parsed > limit) {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_INT, &ctx->line,
+			"specified number is too large (max: %" PRIu64 ")",
+			limit);
+	}
 
-  if (dest) *dest = (uint64_t)parsed;
-  return CPE_SUCCESS;
+	if (dest)
+		*dest = (uint64_t)parsed;
+	return CPE_SUCCESS;
 }
 
-error_code_e parse_int64(parse_context_t* ctx, int64_t min, int64_t max, int64_t* dest) {
-  int result = skip_until_field(ctx);
-  if (result < 0) return result;
+error_code_e parse_int64(parse_context_t *ctx, int64_t min, int64_t max,
+			 int64_t *dest)
+{
+	int result = skip_until_field(ctx);
+	if (result < 0)
+		return result;
 
-  if (!isdigit(*ctx->cursor) && *ctx->cursor != '+' && *ctx->cursor != '-')
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a digit, found '%c'", *ctx->cursor);
+	if (!isdigit(*ctx->cursor) && *ctx->cursor != '+' &&
+	    *ctx->cursor != '-')
+		return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line,
+				       "was expecting a digit, found '%c'",
+				       *ctx->cursor);
 
-  static_assert(sizeof(unsigned long long int) >= sizeof(uint64_t),
-    "strtoull on your system does not support 64 bit integers");
+	static_assert(
+		sizeof(unsigned long long int) >= sizeof(uint64_t),
+		"strtoull on your system does not support 64 bit integers");
 
-  long long int parsed = strtoll(ctx->cursor, (char**)(&ctx->cursor), 0);
-  if (*ctx->cursor && !isspace(*ctx->cursor)) {
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a number, found invalid '%c'", *ctx->cursor);
-  }
+	long long int parsed = strtoll(ctx->cursor, (char **)(&ctx->cursor), 0);
+	if (*ctx->cursor && !isspace(*ctx->cursor)) {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_INT, &ctx->line,
+			"was expecting a number, found invalid '%c'",
+			*ctx->cursor);
+	}
 
-  if (parsed < min || parsed > max) {
-    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "specified number is outside valid range (min:%"PRId64", max: %"PRId64"): %"PRId64, min, max, parsed);
-  }
+	if (parsed < min || parsed > max) {
+		return parse_ctx_error(
+			ctx, CPE_PARSE_INT, &ctx->line,
+			"specified number is outside valid range (min:%" PRId64
+			", max: %" PRId64 "): %" PRId64,
+			min, max, parsed);
+	}
 
-  if (dest) *dest = (int64_t)parsed;
-  return CPE_SUCCESS;
+	if (dest)
+		*dest = (int64_t)parsed;
+	return CPE_SUCCESS;
 }
-
-
 
 /* parse_section parses and executes the supplied statements.
  *
@@ -588,87 +719,104 @@ error_code_e parse_int64(parse_context_t* ctx, int64_t min, int64_t max, int64_t
  *
  * Returns -1 whenever a recognized statement is encountered that however
  * has invalid parameters or configurations. */
-error_code_e parse_section(parse_context_t* ctx, statement_t* language, void* dest) {
-  bool command = true; /* indicates if we are expecting to find a command. */
+error_code_e parse_section(parse_context_t *ctx, statement_t *language,
+			   void *dest)
+{
+	bool command =
+		true; /* indicates if we are expecting to find a command. */
 
-  /* Initialize the per-statement parsing state. */
-  int statements = 0; /* Total # of statements. */
-  int required = 0; /* Total # of required statements. */
-  for (; language[statements].match.name != NULL; ++statements)
-    if (language[statements].options & OPT_MUST)
-      required += 1;
-  enum {
-    STATE_SEEN = 1 << 0, /* If set, the command was seen before. */
-  };
-  uint8_t state[statements];
-  memset(state, 0, sizeof(*state) * statements);
+	/* Initialize the per-statement parsing state. */
+	int statements = 0; /* Total # of statements. */
+	int required = 0; /* Total # of required statements. */
+	for (; language[statements].match.name != NULL; ++statements)
+		if (language[statements].options & OPT_MUST)
+			required += 1;
+	enum { STATE_SEEN = 1 << 0, /* If set, the command was seen before. */
+	};
+	uint8_t state[statements];
+	memset(state, 0, sizeof(*state) * statements);
 
-  int status = CPE_COMMAND; /* What to return if a command cannot be found. */
-  int executed = 0; /* Number of statements successfully executed. */
-  while (*ctx->cursor) {
-    skip_line_spaces(ctx);
+	int status =
+		CPE_COMMAND; /* What to return if a command cannot be found. */
+	int executed = 0; /* Number of statements successfully executed. */
+	while (*ctx->cursor) {
+		skip_line_spaces(ctx);
 
-    if (*ctx->cursor == '\n') {
-      parse_ctx_newline(ctx);
-      (ctx->cursor)++;
-      command = true;
-      continue;
-    }
+		if (*ctx->cursor == '\n') {
+			parse_ctx_newline(ctx);
+			(ctx->cursor)++;
+			command = true;
+			continue;
+		}
 
-    /* Could be a \r, or a \v, ... */
-    if (isspace(*ctx->cursor)) {
-      (ctx->cursor)++;
-      continue;
-    }
+		/* Could be a \r, or a \v, ... */
+		if (isspace(*ctx->cursor)) {
+			(ctx->cursor)++;
+			continue;
+		}
 
-    if (*ctx->cursor == '#') {
-      skip_until_eol(ctx);
-      continue;
-    }
+		if (*ctx->cursor == '#') {
+			skip_until_eol(ctx);
+			continue;
+		}
 
-    if (!command) {
-      return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "'%16s...' is being parsed as command", ctx->cursor);
-    }
+		if (!command) {
+			return parse_ctx_error(
+				ctx, CPE_UNEXPECTED, &ctx->line,
+				"'%16s...' is being parsed as command",
+				ctx->cursor);
+		}
 
-    const char* start = ctx->cursor;
-    for (; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
-      ;
+		const char *start = ctx->cursor;
+		for (; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
+			;
 
-    int plen = ctx->cursor - start; /* Parsed length. */
-    for (int statement = 0; ; ++statement) {
-      statement_t* s = &language[statement];
-      uint8_t* flags = &state[statement];
+		int plen = ctx->cursor - start; /* Parsed length. */
+		for (int statement = 0;; ++statement) {
+			statement_t *s = &language[statement];
+			uint8_t *flags = &state[statement];
 
-      if (s->match.name == NULL) {
-	ctx->cursor = start;
-	if (required)
-	  return parse_ctx_error(ctx, CPE_REQUIRED, &ctx->line, "%d mandatory commands were not specified", required);
+			if (s->match.name == NULL) {
+				ctx->cursor = start;
+				if (required)
+					return parse_ctx_error(
+						ctx, CPE_REQUIRED, &ctx->line,
+						"%d mandatory commands were not specified",
+						required);
 
-	return status;
-      }
+				return status;
+			}
 
-      if (!*s->match.name || (plen == s->match.len && !memcmp(start, s->match.name, plen))) {
-	if (executed && s->options & OPT_START) {
-	  ctx->cursor = start;
-          return CPE_COMMAND;
-	}
+			if (!*s->match.name ||
+			    (plen == s->match.len &&
+			     !memcmp(start, s->match.name, plen))) {
+				if (executed && s->options & OPT_START) {
+					ctx->cursor = start;
+					return CPE_COMMAND;
+				}
 
-	if ((*flags) & STATE_SEEN) {
-  	  if (!(s->options & OPT_MULTI)) {
-	    if (required)
-	      return parse_ctx_error(ctx, CPE_REQUIRED, &ctx->line,"%d mandatory options were not specified", required);
+				if ((*flags) & STATE_SEEN) {
+					if (!(s->options & OPT_MULTI)) {
+						if (required)
+							return parse_ctx_error(
+								ctx,
+								CPE_REQUIRED,
+								&ctx->line,
+								"%d mandatory options were not specified",
+								required);
 
-	    ctx->cursor = start;
-	    return CPE_REPEATED;
-	  }
-	} else {
-	  (*flags) |= STATE_SEEN;
-	  if (s->options & OPT_MUST)
-	    required--;
-        }
+						ctx->cursor = start;
+						return CPE_REPEATED;
+					}
+				} else {
+					(*flags) |= STATE_SEEN;
+					if (s->options & OPT_MUST)
+						required--;
+				}
 
-	int result = s->parse.function(ctx, start, &s->parse.data, dest);
-	/* There are 4 possible outcomes from a parse function:
+				int result = s->parse.function(
+					ctx, start, &s->parse.data, dest);
+				/* There are 4 possible outcomes from a parse function:
 	 *
 	 * 1) There was some real error, that the code couldn't really handle.
 	 *
@@ -695,53 +843,67 @@ error_code_e parse_section(parse_context_t* ctx, statement_t* language, void* de
 	 *    cursor is still stuck where it was before. We need to look for
 	 *    the next parsing function in the list, as none of the ones before
 	 *    succeeded. */
-	if (result < 0 && result != CPE_COMMAND && result != CPE_REPEATED) return result;
+				if (result < 0 && result != CPE_COMMAND &&
+				    result != CPE_REPEATED)
+					return result;
 
-	if (result >= 0) {
-	  status = CPE_COMMAND;
-	  executed += 1;
-	  command = false;
-	  break;
-	}
+				if (result >= 0) {
+					status = CPE_COMMAND;
+					executed += 1;
+					command = false;
+					break;
+				}
 
-	status = result;
-	if (ctx->cursor != start) {
-	  executed =+ 1;
-	  break;
+				status = result;
+				if (ctx->cursor != start) {
+					executed = +1;
+					break;
+				}
+			}
+		}
 	}
-      }
-    }
-  }
-  return CPE_SUCCESS;
+	return CPE_SUCCESS;
 }
 
-error_code_e parse_buffer(const char* buffer, statement_t* language, void* dest, perror_t* err) {
-  parse_context_t ctx = context_from_buffer(buffer, err);
-  int result = parse_section(&ctx, language, dest);
-  if (result < 0) {
-    if (err == NULL) return result;
+error_code_e parse_buffer(const char *buffer, statement_t *language, void *dest,
+			  perror_t *err)
+{
+	parse_context_t ctx = context_from_buffer(buffer, err);
+	int result = parse_section(&ctx, language, dest);
+	if (result < 0) {
+		if (err == NULL)
+			return result;
 
-    if (result == CPE_COMMAND)
-      return parse_ctx_error(&ctx, CPE_COMMAND, &ctx.line, "unknonw command found around '%16s...'", ctx.cursor);
-    if (result == CPE_REPEATED)
-      return parse_ctx_error(&ctx, CPE_REPEATED, &ctx.line, "command can only appear once");
+		if (result == CPE_COMMAND)
+			return parse_ctx_error(
+				&ctx, CPE_COMMAND, &ctx.line,
+				"unknonw command found around '%16s...'",
+				ctx.cursor);
+		if (result == CPE_REPEATED)
+			return parse_ctx_error(&ctx, CPE_REPEATED, &ctx.line,
+					       "command can only appear once");
 
-    return result;
-  }
+		return result;
+	}
 
-  if (*ctx.cursor != '\0')
-    return parse_ctx_error(&ctx, CPE_UNEXPECTED, &ctx.line, "unknonw parameter found around '%16s...'", ctx.cursor);
+	if (*ctx.cursor != '\0')
+		return parse_ctx_error(
+			&ctx, CPE_UNEXPECTED, &ctx.line,
+			"unknonw parameter found around '%16s...'", ctx.cursor);
 
-  return 0;
+	return 0;
 }
 
-error_code_e parse_file(const char* path, statement_t* language, void* dest, perror_t* err) {
-  char* buffer = NULL;
-  if (read_file(path, &buffer) < 0) {
-    return error(err, CPE_READ, "error reading %s: %s", path, strerror(errno));
-  }
+error_code_e parse_file(const char *path, statement_t *language, void *dest,
+			perror_t *err)
+{
+	char *buffer = NULL;
+	if (read_file(path, &buffer) < 0) {
+		return error(err, CPE_READ, "error reading %s: %s", path,
+			     strerror(errno));
+	}
 
-  int result = parse_buffer(buffer, language, dest, err);
-  free(buffer);
-  return result;
+	int result = parse_buffer(buffer, language, dest, err);
+	free(buffer);
+	return result;
 }

--- a/proxy/nss/confparse/confparse.c
+++ b/proxy/nss/confparse/confparse.c
@@ -1,0 +1,747 @@
+#include <nss.h>
+#include <pwd.h>
+#include <shadow.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <ctype.h>
+#include <stdbool.h>
+
+#include "confparse.h"
+
+/* read_file reads an entire file in memory in a single operation.
+ *
+ * The file must be seekable(), so this does not work with /proc, /sys,
+ * fifos, or sockets.
+ *
+ * The returned buffer is '\0' terminated, and must be freed with
+ * free() unless an error is returned.
+ *
+ * Returns -1 in case of error, or the amount of bytes read. */
+static ssize_t read_file(const char* path, char** buffer) {
+  FILE* f = fopen(path, "rb");
+  if (!f) return -1;
+
+  fseek(f, 0, SEEK_END);
+  long size = ftell(f);
+  fseek (f, 0, SEEK_SET);
+  if (!buffer) {
+    fclose(f);
+    return -1;
+  }
+
+  *buffer = malloc(size + 1);
+  size_t got = fread(*buffer, 1, size, f);
+  fclose (f);
+
+  if (got < size) {
+    free(*buffer);
+    *buffer = NULL;
+    return -1;
+  }
+  (*buffer)[size] = '\0';
+  return size;
+}
+
+/* verrorp is just like error() below, but takes a va_list and prefix. */
+error_code_e verrorp(perror_t* error, const char* prefix, const char* fmt, va_list input) {
+  if (!error) return CPE_SUCCESS;
+  perror_free(error);
+
+  va_list args;
+  va_copy(args, input);
+  size_t size = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+  
+  if (size <= 0)
+    return CPE_INTERNAL;
+
+  int plen = 0;
+  if (prefix)
+    plen = strlen(prefix);
+
+  error->message = malloc(plen + size + 1);
+
+  if (prefix)
+    strcpy(error->message, prefix);
+
+  va_copy(args, input);
+  size = vsnprintf(error->message + plen, size + 1, fmt, args);
+  va_end(args);
+
+  /* In the unlikely case vsnprintf failed, we don't want to return
+   * a buffer containing garbage to the user. */
+  if (size < 0) {
+    perror_free(error);
+  }
+
+  return CPE_SUCCESS;
+}
+ 
+int error(perror_t* error, error_code_e code, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  int result = verrorp(error, "", fmt, args);
+  va_end(args);
+
+  if (code < 0) return code;
+  return result;
+}
+
+error_code_e adapter_string(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  char** target = (char **)((char*)(dest) + data->offset);
+  if (target && *target) { free(*target); *target = NULL; }
+  return parse_string(ctx, target);
+}
+
+parse_t expect_string(size_t offset) {
+  parse_t callback = {
+      .function = adapter_string,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_uint32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  uint64_t value = 0;
+  int status = parse_uint64(ctx, UINT32_MAX, &value);
+  *(uint32_t *)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_uint32(size_t offset) {
+  parse_t callback = {
+      .function = adapter_uint32,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_uint64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  uint64_t value = 0;
+  int status = parse_uint64(ctx, UINT64_MAX, &value);
+  *(uint64_t *)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_uint64(size_t offset) {
+  parse_t callback = {
+      .function = adapter_uint64,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_uint16(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  uint64_t value = 0;
+  int status = parse_uint64(ctx, UINT16_MAX, &value);
+  *(uint16_t *)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_uint16(size_t offset) {
+  parse_t callback = {
+      .function = adapter_uint16,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_uint8(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  uint64_t value = 0;
+  int status = parse_uint64(ctx, UINT8_MAX, &value);
+  *(uint16_t *)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_uint8(size_t offset) {
+  parse_t callback = {
+      .function = adapter_uint8,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_int64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  int64_t value = 0;
+  int status = parse_int64(ctx, INT64_MIN, INT64_MAX, &value);
+  *(int64_t*)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_int64(size_t offset) {
+  parse_t callback = {
+      .function = adapter_int64,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_int32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  int64_t value = 0;
+  int status = parse_int64(ctx, INT32_MIN, INT32_MAX, &value);
+  *(int32_t*)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_int32(size_t offset) {
+  parse_t callback = {
+      .function = adapter_int32,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_int16(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  int64_t value = 0;
+  int status = parse_int64(ctx, INT16_MIN, INT16_MAX, &value);
+  *(int16_t*)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_int16(size_t offset) {
+  parse_t callback = {
+      .function = adapter_int16,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_int8(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  int64_t value = 0;
+  int status = parse_int64(ctx, INT8_MIN, INT8_MAX, &value);
+  *(int8_t*)((char*)(dest) + data->offset) = value;
+  return status;
+}
+
+parse_t expect_int8(size_t offset) {
+  parse_t callback = {
+      .function = adapter_int8,
+      .data = {
+        .offset = offset,
+      }, 
+  };
+  return callback;
+}
+
+typedef struct {
+  size_t len;
+  const char* ptr;
+} option_t;
+
+/* In static context, only const expressions are allowed.
+ * strlen, inline functions are not considered const.
+ *
+ * This macro is, however, VERY UNSAFE. name should be
+ * a static string, don't even think about passing any
+ * sort of expression in. */
+#define OPTION_CONST(name) {sizeof(name) - 1, name}
+#define OPTION_END {0, NULL}
+
+int find_option_prefix(const option_t* options, const char* start) {
+  for (int i = 0; options[i].ptr; ++i) {
+    if (!strncmp(options[i].ptr, start, options[i].len)) return i;
+  }
+  return -1;
+}
+
+  static const option_t trues[] = {
+	  OPTION_CONST("True"),
+    	  OPTION_CONST("true"),
+    	  OPTION_CONST("yes"),
+    	  OPTION_CONST("on"),
+	  OPTION_END,
+  };
+
+  static const option_t falses[] = {
+	  OPTION_CONST("False"),
+    	  OPTION_CONST("false"),
+    	  OPTION_CONST("no"),
+    	  OPTION_CONST("off"),
+	  OPTION_END,
+  };
+
+error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit, uint32_t flipbit, uint32_t *dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+
+  int option = 0;
+  if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
+    *dest = assign_bits(*dest, seenbit | flipbit, seenbit | flipbit);
+    ctx->cursor += trues[option].len;
+  } else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
+    *dest = assign_bits(*dest, seenbit, seenbit | flipbit);
+    ctx->cursor += falses[option].len;
+  } else {
+    return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "was expecting a field - found end of config");
+  }
+
+  if (!*ctx->cursor || isspace(*ctx->cursor)) return 0;
+  return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "unexpected character after bool %c", *ctx->cursor);
+}
+
+error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit, uint64_t flipbit, uint64_t *dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+
+  int option = 0;
+  if ((option = find_option_prefix(trues, ctx->cursor)) >= 0) {
+    *dest = assign_bits(*dest, seenbit | flipbit, seenbit | flipbit);
+    ctx->cursor += trues[option].len;
+  } else if ((option = find_option_prefix(falses, ctx->cursor)) >= 0) {
+    *dest = assign_bits(*dest, seenbit, seenbit | flipbit);
+    ctx->cursor += falses[option].len;
+  } else {
+    return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "was expecting a field - found end of config");
+  }
+
+  if (!*ctx->cursor || isspace(*ctx->cursor)) return 0;
+  return parse_ctx_error(ctx, CPE_PARSE_BOOL, &ctx->line, "unexpected character after bool %c", *ctx->cursor);
+}
+
+error_code_e adapter_bool32(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  size_t offset = data->ints[0];
+  uint32_t seenbit = data->ints[1];
+  uint32_t flipbit = data->ints[2];
+  
+  return parse_bool32(ctx, seenbit, flipbit, (uint32_t *)((char*)(dest) + offset));
+}
+
+error_code_e adapter_bool64(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  size_t offset = data->ints[0];
+  uint64_t seenbit = data->ints[1];
+  uint64_t flipbit = data->ints[2];
+  
+  return parse_bool64(ctx, seenbit, flipbit, (uint64_t *)((char*)(dest) + offset));
+}
+
+parse_t expect_bool64(size_t offset, uint64_t seenbit, uint64_t flipbit) {
+  parse_t callback = {
+      .function = adapter_bool64,
+      .data = {
+	.ints = {
+	  offset,
+          seenbit,
+	  flipbit,
+	},
+      }, 
+  };
+  return callback;
+}
+
+
+
+parse_t expect_bool32(size_t offset, uint32_t seenbit, uint32_t flipbit) {
+  parse_t callback = {
+      .function = adapter_bool32,
+      .data = {
+	.ints = {
+	  offset,
+          seenbit,
+	  flipbit,
+	},
+      }, 
+  };
+  return callback;
+}
+
+error_code_e adapter_nothing(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  return CPE_SUCCESS;
+}
+
+parse_t expect_nothing() {
+  parse_t callback = {
+      .function = adapter_nothing,
+  };
+  return callback;
+}
+
+error_code_e adapter_section(parse_context_t* ctx, const char* start, types_u* data, void* dest) {
+  statement_t* statements = (statement_t*)(data->ptrs[0]);
+  /* ISO C forbids conversion of object pointer to function pointer. */
+  adder_f adder;
+  *(void**)(&adder) = data->ptrs[1];
+
+  if (adder) {
+    dest = adder(dest);
+  }
+
+  ctx->cursor = start;
+  return parse_section(ctx, statements, dest);
+}
+
+parse_t expect_section(statement_t* statements, adder_f adder) {
+  parse_t callback = {
+      .function = adapter_section,
+      .data = {
+        .ptrs = {
+	  statements,
+	  *(void**)(&adder),
+	},
+      },
+  };
+  return callback;
+}
+
+error_code_e parse_ctx_error(parse_context_t* ctx, error_code_e code, const line_t* line, const char* fmt, ...) {
+  char prefix[64];
+  snprintf(prefix, sizeof(prefix), "line %d, char %td: ", line->number + 1, ctx->cursor - line->start);
+
+  va_list args;
+  va_start(args, fmt);
+  int result = verrorp(ctx->err, prefix, fmt, args);
+  va_end(args);
+
+  if (code < 0) return code;
+  return result;
+}
+
+void parse_ctx_newline(parse_context_t* ctx) {
+  ctx->line.start = ctx->cursor + 1;
+  (ctx->line.number)++;
+}
+
+/* skip_line_spaces moves the cursor past any 'line' space.
+ *
+ * A line space is any spacing chcaracter that can typically be found
+ * on a single line of text, ' ' or '\t', but not '\r', '\n' or '\v'. */
+void skip_line_spaces(parse_context_t* ctx) {
+  for(; *ctx->cursor && (*ctx->cursor == ' ' || *ctx->cursor == '\t'); ++(ctx->cursor))
+    ;
+}
+
+/* skip_until_field moves the cursor at the beginning of the first field.
+ *
+ * This is a convenience wrapper around skip_line_spaces that sets an
+ * error in case no field can be found. */
+error_code_e skip_until_field(parse_context_t* ctx) {
+  skip_line_spaces(ctx);
+  if (!*ctx->cursor) return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "was expecting a field - found end of config");
+  if (isspace(*ctx->cursor)) return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "was expecting a field - found a new line? unexpected space");
+  return 0;
+}
+
+/* skip_until_eol moves the cursor to the end of the current line. */
+void skip_until_eol(parse_context_t* ctx) {
+  for(; *ctx->cursor && *ctx->cursor != '\n'; ++(ctx->cursor))
+    ;
+}
+
+/* parse_quoted_string parses a string enclosed in quotes (").
+ *
+ * The string can contain space characters, newlines, and can escape
+ * quotes by using \", and escape \ itself with \\. */
+error_code_e parse_quoted_string(parse_context_t* ctx, char** dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+  
+  if (*ctx->cursor != '\"') return parse_ctx_error(ctx, CPE_PARSE_QUOTE, &ctx->line, "was expecting a quoted string, starting with '\"', found '%c'", *ctx->cursor);
+
+  line_t line = ctx->line;
+  const char* start = (ctx->cursor) + 1;
+  unsigned escapes = 0;
+  while(1) {
+    if (*++(ctx->cursor) == '\0')
+      return parse_ctx_error(ctx, CPE_UNEXPECTED, &line, "reached end of file, without finding the closing '\"'");
+
+    if (*ctx->cursor == '"') {
+      (ctx->cursor)++;
+      break;
+    }
+
+    if (*ctx->cursor == '\n') {
+      parse_ctx_newline(ctx);
+      continue;
+    }
+
+    if (*ctx->cursor != '\\') {
+      continue;
+    }
+
+    if (*(ctx->cursor + 1) == '\0')
+      return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "reached end of file, while processing escape '\\'");
+
+    if (*(ctx->cursor + 1) != '"' && *(ctx->cursor + 1) != '\\')
+      return parse_ctx_error(ctx, CPE_PARSE_QUOTE, &ctx->line, "escape sequence '\\%c' is unknown - only \\\\ and \\\" supported", *(ctx->cursor + 1));
+
+    /* we found a valid escape sequence, skip it. */
+    escapes++;
+    (ctx->cursor)++;
+  }
+
+  if (!dest) return CPE_SUCCESS;
+
+  if (!escapes) {
+    *dest = strndup(start, ctx->cursor - start - 1);
+    return CPE_SUCCESS;
+  }
+
+  /* Code here can assume that the input is correct. */
+  *dest = malloc(ctx->cursor - start - escapes);
+  for (char* cursor = *dest; start < ctx->cursor - 1; ++start) {
+    if (*start == '\\') {
+      *cursor++ = *++start;
+    } else {
+      *cursor++ = *start;
+    }
+  }
+  return CPE_SUCCESS;
+}
+
+/* parse_string parses a string.
+ *
+ * The string can either be in quotes, like "foo bar", or just be a naked
+ * string, with no quotes. When the string has no quotes, parsing stops at
+ * the first whitespace character. */
+error_code_e parse_string(parse_context_t* ctx, char** dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+
+  if (*ctx->cursor == '\"')
+    return parse_quoted_string(ctx, dest);
+
+  const char* start = ctx->cursor;
+  for(; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
+    ;
+
+  if (dest) *dest = strndup(start, ctx->cursor - start);
+  return CPE_SUCCESS;
+}
+
+error_code_e parse_uint64(parse_context_t* ctx, uint64_t limit, uint64_t* dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+
+  if (!isdigit(*ctx->cursor) && *ctx->cursor != '+')
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a digit, found '%c'", *ctx->cursor);
+
+  static_assert(sizeof(unsigned long long int) >= sizeof(uint64_t),
+    "strtoull on your system does not support 64 bit integers");
+
+  unsigned long long int parsed = strtoull(ctx->cursor, (char**)(&ctx->cursor), 0);
+  if (*ctx->cursor && !isspace(*ctx->cursor)) {
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a number, found invalid '%c'", *ctx->cursor);
+  }
+
+  if (parsed > limit) {
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "specified number is too large (max: %"PRIu64")", limit);
+  }
+
+  if (dest) *dest = (uint64_t)parsed;
+  return CPE_SUCCESS;
+}
+
+error_code_e parse_int64(parse_context_t* ctx, int64_t min, int64_t max, int64_t* dest) {
+  int result = skip_until_field(ctx);
+  if (result < 0) return result;
+
+  if (!isdigit(*ctx->cursor) && *ctx->cursor != '+' && *ctx->cursor != '-')
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a digit, found '%c'", *ctx->cursor);
+
+  static_assert(sizeof(unsigned long long int) >= sizeof(uint64_t),
+    "strtoull on your system does not support 64 bit integers");
+
+  long long int parsed = strtoll(ctx->cursor, (char**)(&ctx->cursor), 0);
+  if (*ctx->cursor && !isspace(*ctx->cursor)) {
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "was expecting a number, found invalid '%c'", *ctx->cursor);
+  }
+
+  if (parsed < min || parsed > max) {
+    return parse_ctx_error(ctx, CPE_PARSE_INT, &ctx->line, "specified number is outside valid range (min:%"PRId64", max: %"PRId64"): %"PRId64, min, max, parsed);
+  }
+
+  if (dest) *dest = (int64_t)parsed;
+  return CPE_SUCCESS;
+}
+
+
+
+/* parse_section parses and executes the supplied statements.
+ *
+ * parse_section will stop the parsing and return success when either
+ * the end of the buffer is reached, or the first unknown statement is
+ * encountered.
+ *
+ * Returns -1 whenever a recognized statement is encountered that however
+ * has invalid parameters or configurations. */
+error_code_e parse_section(parse_context_t* ctx, statement_t* language, void* dest) {
+  bool command = true; /* indicates if we are expecting to find a command. */
+
+  /* Initialize the per-statement parsing state. */
+  int statements = 0; /* Total # of statements. */
+  int required = 0; /* Total # of required statements. */
+  for (; language[statements].match.name != NULL; ++statements)
+    if (language[statements].options & OPT_MUST)
+      required += 1;
+  enum {
+    STATE_SEEN = 1 << 0, /* If set, the command was seen before. */
+  };
+  uint8_t state[statements];
+  memset(state, 0, sizeof(*state) * statements);
+
+  int status = CPE_COMMAND; /* What to return if a command cannot be found. */
+  int executed = 0; /* Number of statements successfully executed. */
+  while (*ctx->cursor) {
+    skip_line_spaces(ctx);
+
+    if (*ctx->cursor == '\n') {
+      parse_ctx_newline(ctx);
+      (ctx->cursor)++;
+      command = true;
+      continue;
+    }
+
+    /* Could be a \r, or a \v, ... */
+    if (isspace(*ctx->cursor)) {
+      (ctx->cursor)++;
+      continue;
+    }
+
+    if (*ctx->cursor == '#') {
+      skip_until_eol(ctx);
+      continue;
+    }
+
+    if (!command) {
+      return parse_ctx_error(ctx, CPE_UNEXPECTED, &ctx->line, "'%16s...' is being parsed as command", ctx->cursor);
+    }
+
+    const char* start = ctx->cursor;
+    for (; *ctx->cursor && !isspace(*ctx->cursor); ++(ctx->cursor))
+      ;
+
+    int plen = ctx->cursor - start; /* Parsed length. */
+    for (int statement = 0; ; ++statement) {
+      statement_t* s = &language[statement];
+      uint8_t* flags = &state[statement];
+
+      if (s->match.name == NULL) {
+	ctx->cursor = start;
+	if (required)
+	  return parse_ctx_error(ctx, CPE_REQUIRED, &ctx->line, "%d mandatory commands were not specified", required);
+
+	return status;
+      }
+
+      if (!*s->match.name || (plen == s->match.len && !memcmp(start, s->match.name, plen))) {
+	if (executed && s->options & OPT_START) {
+	  ctx->cursor = start;
+          return CPE_COMMAND;
+	}
+
+	if ((*flags) & STATE_SEEN) {
+  	  if (!(s->options & OPT_MULTI)) {
+	    if (required)
+	      return parse_ctx_error(ctx, CPE_REQUIRED, &ctx->line,"%d mandatory options were not specified", required);
+
+	    ctx->cursor = start;
+	    return CPE_REPEATED;
+	  }
+	} else {
+	  (*flags) |= STATE_SEEN;
+	  if (s->options & OPT_MUST)
+	    required--;
+        }
+
+	int result = s->parse.function(ctx, start, &s->parse.data, dest);
+	/* There are 4 possible outcomes from a parse function:
+	 *
+	 * 1) There was some real error, that the code couldn't really handle.
+	 *
+	 *    Result is < 0, and != CPE_COMMAND and != CPE_REPEATED.
+	 *
+	 * 2) It processed the command and all its arguments, and possibly more
+	 *    statements. Processing is now complete.
+	 *
+	 *    Result is 0, cursor may or may not have moved forward (depending
+	 *    on arguments), no more commands are expected until EOL (command=false).
+	 *
+	 * 3) It processed the command and a bunch of other statements, but it
+	 *    got to a point where the next statement was unknown (or repeated).
+	 *    Nothing more it can do. 
+	 *
+	 *    Result is CPE_COMMAND (unknown command) or CPE_REPEATED, the
+	 *    cursor moved forward, as a few statements were processed, cursor
+	 *    is already on the next command (command=true).
+	 *
+	 * 4) It turns out the command is unknown to the parser after all, cannot
+	 *    really understand or parse it. Processing did not move forward.
+	 *
+	 *    Result is CPE_COMMAND (unknown command) or CPE_REPEATED, and the
+	 *    cursor is still stuck where it was before. We need to look for
+	 *    the next parsing function in the list, as none of the ones before
+	 *    succeeded. */
+	if (result < 0 && result != CPE_COMMAND && result != CPE_REPEATED) return result;
+
+	if (result >= 0) {
+	  status = CPE_COMMAND;
+	  executed += 1;
+	  command = false;
+	  break;
+	}
+
+	status = result;
+	if (ctx->cursor != start) {
+	  executed =+ 1;
+	  break;
+	}
+      }
+    }
+  }
+  return CPE_SUCCESS;
+}
+
+error_code_e parse_buffer(const char* buffer, statement_t* language, void* dest, perror_t* err) {
+  parse_context_t ctx = context_from_buffer(buffer, err);
+  int result = parse_section(&ctx, language, dest);
+  if (result < 0) {
+    if (err == NULL) return result;
+
+    if (result == CPE_COMMAND)
+      return parse_ctx_error(&ctx, CPE_COMMAND, &ctx.line, "unknonw command found around '%16s...'", ctx.cursor);
+    if (result == CPE_REPEATED)
+      return parse_ctx_error(&ctx, CPE_REPEATED, &ctx.line, "command can only appear once");
+
+    return result;
+  }
+
+  if (*ctx.cursor != '\0')
+    return parse_ctx_error(&ctx, CPE_UNEXPECTED, &ctx.line, "unknonw parameter found around '%16s...'", ctx.cursor);
+
+  return 0;
+}
+
+error_code_e parse_file(const char* path, statement_t* language, void* dest, perror_t* err) {
+  char* buffer = NULL;
+  if (read_file(path, &buffer) < 0) {
+    return error(err, CPE_READ, "error reading %s: %s", path, strerror(errno));
+  }
+
+  int result = parse_buffer(buffer, language, dest, err);
+  free(buffer);
+  return result;
+}

--- a/proxy/nss/confparse/confparse.h
+++ b/proxy/nss/confparse/confparse.h
@@ -1,0 +1,207 @@
+#ifndef CONFPARSE_H_
+# define CONFPARSE_H_
+
+/* Any value < 0 is an error. */
+typedef enum {
+  CPE_SUCCESS = 0,      /* No error - everything is good. */
+  CPE_FAILURE = -1,     /* Generic/Unspecified error. */
+  CPE_INTERNAL = -2,    /* Something happened in the library internals (snprintf, malloc, ...). */
+  CPE_READ = -3,        /* Could not read file (disk error, read, ...). */
+  CPE_UNEXPECTED = -4,  /* The wrong thing was found (was expecting a field, found \0). */
+  CPE_COMMAND = -5,     /* Command is unknown. */
+  CPE_REPEATED = -6,    /* Command repated, when allowed only once. */
+  CPE_REQUIRED = -7,    /* Required command was not found. */
+  CPE_PARSE_INT = -8,   /* Could not parse an integer. */
+  CPE_PARSE_QUOTE = -9, /* Could not parse quotes. */
+  CPE_PARSE_BOOL = -10, /* Could not parse bool. */
+
+  CPE_CUSTOM_START = -100, /* Use values < -100 to define custom errors. */
+} error_code_e;
+
+/* perror_t represents an error message.
+ * Initialize with perror_init() always free it with perror_free().
+ * If message is != NULL, there is an error messsage. */
+typedef struct {
+  char* message;
+} perror_t;
+
+static inline perror_t perror_init();
+static inline void perror_free(perror_t *perror);
+
+/* assign_bits64 is an utility function able to set a few bits in the
+ * middle of another integer.
+ *
+ * mask indicates which bits to set.
+ * source contains the bits to copy.
+ * dest is the destination integer.
+ *
+ * The modified value is returned. */
+static inline uint64_t assign_bits(uint64_t dest, uint64_t source, uint64_t mask);
+
+typedef struct {
+  const char* start; /* Start of the line being processed. */
+  int number;        /* Line number, starting from 0. */
+} line_t;
+
+typedef struct {
+  const char* cursor;
+
+  line_t line;
+  perror_t *err;
+} parse_context_t;
+
+typedef union {
+  size_t offset;
+  void* ptr;
+
+  void* ptrs[8];
+  uint64_t ints[8];
+} types_u;
+
+typedef error_code_e (*parse_f)(parse_context_t* ctx, const char* start, types_u* data, void* dest);
+
+typedef struct {
+  parse_f function;
+  types_u data;
+} parse_t;
+
+typedef struct {
+  const char* name;
+  size_t len;
+} match_t;
+
+typedef enum {
+  /* No specific options.
+   * This means that the statement can appear once, and is optional. */
+  OPT_NONE = 0,
+  /* The statement MUST be supplied in the config - not optional. */
+  OPT_MUST = 1<<0,
+  /* The statement can appear multiple times - new values override old. */ 
+  OPT_MULTI = 1<<1,
+  /* This statement always starts a new section.
+   * Causes the parser to create a new section, unless the statement is first. */
+  OPT_START = 1<<2,
+} options_e;
+
+typedef struct {
+  uint32_t options;
+  match_t match;
+  parse_t parse;
+} statement_t;
+
+#define STATEMENTS_END { OPT_NONE, { .name = NULL } }
+
+
+static inline parse_context_t context_from_buffer(const char* buffer, perror_t* err);
+
+/* match_exact instructs the parser to look for a command by the specified name. */
+static inline match_t match_exact(const char* name); 
+static inline match_t match_any();
+
+extern parse_t expect_nothing();
+extern parse_t expect_string(size_t offset);
+
+/* expect_bool32 parses a "True/true/yes/on" or "False/false/no/off" string into a bit.
+ *
+ * Based on the string, it will set the bit indicated by the flipbit mask
+ * accordingly. Additionally, if seenbit is != 0, the corresponding bits will
+ * be set to 1 in the mask whenever a value is stored, indicating that the
+ * value was set. This is useful to distinguish between default values,
+ * and values explicitly set by the user. */
+extern parse_t expect_bool32(size_t offset, uint32_t seenbit, uint32_t flipbit);
+extern parse_t expect_bool64(size_t offset, uint64_t seenbit, uint64_t flipbit);
+
+extern parse_t expect_int8(size_t offset);
+extern parse_t expect_uint8(size_t offset);
+extern parse_t expect_int16(size_t offset);
+extern parse_t expect_uint16(size_t offset);
+extern parse_t expect_int32(size_t offset);
+extern parse_t expect_uint32(size_t offset);
+extern parse_t expect_int64(size_t offset);
+extern parse_t expect_uint64(size_t offset);
+
+typedef void* (*adder_f)(void*);
+extern parse_t expect_section(statement_t *statements, adder_f adder);
+
+extern error_code_e parse_buffer(const char *buffer, statement_t *language, void *dest, perror_t *err);
+extern error_code_e parse_file(const char *path, statement_t *language, void *dest, perror_t *err);
+
+extern error_code_e adapter_bool32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_bool64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_uint64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_uint32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_uint16(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_uint8(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_int64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_int32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_int16(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_int8(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+
+extern error_code_e adapter_string(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_section(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+
+extern error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit, uint32_t flipbit, uint32_t *dest);
+extern error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit, uint64_t flipbit, uint64_t *dest);
+extern error_code_e parse_uint64(parse_context_t *ctx, uint64_t max, uint64_t *dest);
+extern error_code_e parse_int64(parse_context_t* ctx, int64_t min, int64_t max, int64_t* dest);
+extern error_code_e parse_quoted_string(parse_context_t *ctx, char **dest);
+extern error_code_e parse_string(parse_context_t *ctx, char **dest);
+extern error_code_e parse_section(parse_context_t *ctx, statement_t *language, void *dest);
+
+extern void skip_line_spaces(parse_context_t *ctx);
+extern void skip_until_eol(parse_context_t *ctx);
+extern error_code_e skip_until_field(parse_context_t *ctx);
+
+extern error_code_e parse_ctx_error(parse_context_t *ctx, error_code_e code, const line_t *line, const char *fmt, ...);
+extern void parse_ctx_newline(parse_context_t *ctx);
+
+extern error_code_e error(perror_t *error, error_code_e code, const char *fmt, ...);
+
+/***************************************************************************/
+/****************** Some inline definitions. *******************************/
+
+static inline match_t match_exact(const char* name) {
+  match_t match = {
+    .name = name,
+    .len = strlen(name),
+  };
+  return match;
+}
+
+static inline match_t match_any() {
+  match_t match = {
+    .name = "",
+    .len = 0,
+  };
+  return match;
+}
+
+static inline parse_context_t context_from_buffer(const char* buffer, perror_t* err) {
+  parse_context_t context = {
+    .cursor = buffer,
+    .line = {
+      .start = buffer,
+      .number = 0,
+    },
+    .err = err,
+  };
+  return context;
+}
+
+static inline void perror_free(perror_t *perror) {
+  if (!perror) return;
+
+  free(perror->message);
+  perror->message = NULL;
+}
+
+static inline perror_t perror_init() {
+  perror_t error = { .message = NULL };
+  return error;
+}
+
+static inline uint64_t assign_bits(uint64_t dest, uint64_t source, uint64_t mask) {
+  return dest ^ ((dest ^ source) & mask);
+}
+
+#endif

--- a/proxy/nss/confparse/confparse.h
+++ b/proxy/nss/confparse/confparse.h
@@ -1,28 +1,30 @@
 #ifndef CONFPARSE_H_
-# define CONFPARSE_H_
+#define CONFPARSE_H_
 
 /* Any value < 0 is an error. */
 typedef enum {
-  CPE_SUCCESS = 0,      /* No error - everything is good. */
-  CPE_FAILURE = -1,     /* Generic/Unspecified error. */
-  CPE_INTERNAL = -2,    /* Something happened in the library internals (snprintf, malloc, ...). */
-  CPE_READ = -3,        /* Could not read file (disk error, read, ...). */
-  CPE_UNEXPECTED = -4,  /* The wrong thing was found (was expecting a field, found \0). */
-  CPE_COMMAND = -5,     /* Command is unknown. */
-  CPE_REPEATED = -6,    /* Command repated, when allowed only once. */
-  CPE_REQUIRED = -7,    /* Required command was not found. */
-  CPE_PARSE_INT = -8,   /* Could not parse an integer. */
-  CPE_PARSE_QUOTE = -9, /* Could not parse quotes. */
-  CPE_PARSE_BOOL = -10, /* Could not parse bool. */
-
-  CPE_CUSTOM_START = -100, /* Use values < -100 to define custom errors. */
+	CPE_SUCCESS = 0, /* No error - everything is good. */
+	CPE_FAILURE = -1, /* Generic/Unspecified error. */
+	/* Something happened in the library internals (snprintf, malloc, ...). */
+	CPE_INTERNAL = -2,
+	CPE_READ = -3, /* Could not read file (disk error, read, ...). */
+	/* The wrong thing was found (was expecting a field, found \0). */
+	CPE_UNEXPECTED = -4,
+	CPE_COMMAND = -5, /* Command is unknown. */
+	CPE_REPEATED = -6, /* Command repated, when allowed only once. */
+	CPE_REQUIRED = -7, /* Required command was not found. */
+	CPE_PARSE_INT = -8, /* Could not parse an integer. */
+	CPE_PARSE_QUOTE = -9, /* Could not parse quotes. */
+	CPE_PARSE_BOOL = -10, /* Could not parse bool. */
+	/* Use values < -100 to define custom errors. */
+	CPE_CUSTOM_START = -100,
 } error_code_e;
 
 /* perror_t represents an error message.
  * Initialize with perror_init() always free it with perror_free().
  * If message is != NULL, there is an error messsage. */
 typedef struct {
-  char* message;
+	char *message;
 } perror_t;
 
 static inline perror_t perror_init();
@@ -36,66 +38,74 @@ static inline void perror_free(perror_t *perror);
  * dest is the destination integer.
  *
  * The modified value is returned. */
-static inline uint64_t assign_bits(uint64_t dest, uint64_t source, uint64_t mask);
+static inline uint64_t assign_bits(uint64_t dest, uint64_t source,
+				   uint64_t mask);
 
 typedef struct {
-  const char* start; /* Start of the line being processed. */
-  int number;        /* Line number, starting from 0. */
+	const char *start; /* Start of the line being processed. */
+	int number; /* Line number, starting from 0. */
 } line_t;
 
 typedef struct {
-  const char* cursor;
+	const char *cursor;
 
-  line_t line;
-  perror_t *err;
+	line_t line;
+	perror_t *err;
 } parse_context_t;
 
 typedef union {
-  size_t offset;
-  void* ptr;
+	size_t offset;
+	void *ptr;
 
-  void* ptrs[8];
-  uint64_t ints[8];
+	void *ptrs[8];
+	uint64_t ints[8];
 } types_u;
 
-typedef error_code_e (*parse_f)(parse_context_t* ctx, const char* start, types_u* data, void* dest);
+typedef error_code_e (*parse_f)(parse_context_t *ctx, const char *start,
+				types_u *data, void *dest);
 
 typedef struct {
-  parse_f function;
-  types_u data;
+	parse_f function;
+	types_u data;
 } parse_t;
 
 typedef struct {
-  const char* name;
-  size_t len;
+	const char *name;
+	size_t len;
 } match_t;
 
 typedef enum {
-  /* No specific options.
+	/* No specific options.
    * This means that the statement can appear once, and is optional. */
-  OPT_NONE = 0,
-  /* The statement MUST be supplied in the config - not optional. */
-  OPT_MUST = 1<<0,
-  /* The statement can appear multiple times - new values override old. */ 
-  OPT_MULTI = 1<<1,
-  /* This statement always starts a new section.
+	OPT_NONE = 0,
+	/* The statement MUST be supplied in the config - not optional. */
+	OPT_MUST = 1 << 0,
+	/* The statement can appear multiple times - new values override old. */
+	OPT_MULTI = 1 << 1,
+	/* This statement always starts a new section.
    * Causes the parser to create a new section, unless the statement is first. */
-  OPT_START = 1<<2,
+	OPT_START = 1 << 2,
 } options_e;
 
 typedef struct {
-  uint32_t options;
-  match_t match;
-  parse_t parse;
+	uint32_t options;
+	match_t match;
+	parse_t parse;
 } statement_t;
 
-#define STATEMENTS_END { OPT_NONE, { .name = NULL } }
+#define STATEMENTS_END                                                         \
+	{                                                                      \
+		OPT_NONE,                                                      \
+		{                                                              \
+			.name = NULL                                           \
+		}                                                              \
+	}
 
-
-static inline parse_context_t context_from_buffer(const char* buffer, perror_t* err);
+static inline parse_context_t context_from_buffer(const char *buffer,
+						  perror_t *err);
 
 /* match_exact instructs the parser to look for a command by the specified name. */
-static inline match_t match_exact(const char* name); 
+static inline match_t match_exact(const char *name);
 static inline match_t match_any();
 
 extern parse_t expect_nothing();
@@ -120,64 +130,89 @@ extern parse_t expect_uint32(size_t offset);
 extern parse_t expect_int64(size_t offset);
 extern parse_t expect_uint64(size_t offset);
 
-typedef void* (*adder_f)(void*);
+typedef void *(*adder_f)(void *);
 extern parse_t expect_section(statement_t *statements, adder_f adder);
 
-extern error_code_e parse_buffer(const char *buffer, statement_t *language, void *dest, perror_t *err);
-extern error_code_e parse_file(const char *path, statement_t *language, void *dest, perror_t *err);
+extern error_code_e parse_buffer(const char *buffer, statement_t *language,
+				 void *dest, perror_t *err);
+extern error_code_e parse_file(const char *path, statement_t *language,
+			       void *dest, perror_t *err);
 
-extern error_code_e adapter_bool32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_bool64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_uint64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_uint32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_uint16(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_uint8(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_int64(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_int32(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_int16(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_int8(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_bool32(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_bool64(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_uint64(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_uint32(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_uint16(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_uint8(parse_context_t *ctx, const char *start,
+				  types_u *data, void *dest);
+extern error_code_e adapter_int64(parse_context_t *ctx, const char *start,
+				  types_u *data, void *dest);
+extern error_code_e adapter_int32(parse_context_t *ctx, const char *start,
+				  types_u *data, void *dest);
+extern error_code_e adapter_int16(parse_context_t *ctx, const char *start,
+				  types_u *data, void *dest);
+extern error_code_e adapter_int8(parse_context_t *ctx, const char *start,
+				 types_u *data, void *dest);
 
-extern error_code_e adapter_string(parse_context_t *ctx, const char* start, types_u *data, void *dest);
-extern error_code_e adapter_section(parse_context_t *ctx, const char* start, types_u *data, void *dest);
+extern error_code_e adapter_string(parse_context_t *ctx, const char *start,
+				   types_u *data, void *dest);
+extern error_code_e adapter_section(parse_context_t *ctx, const char *start,
+				    types_u *data, void *dest);
 
-extern error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit, uint32_t flipbit, uint32_t *dest);
-extern error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit, uint64_t flipbit, uint64_t *dest);
-extern error_code_e parse_uint64(parse_context_t *ctx, uint64_t max, uint64_t *dest);
-extern error_code_e parse_int64(parse_context_t* ctx, int64_t min, int64_t max, int64_t* dest);
+extern error_code_e parse_bool32(parse_context_t *ctx, uint32_t seenbit,
+				 uint32_t flipbit, uint32_t *dest);
+extern error_code_e parse_bool64(parse_context_t *ctx, uint64_t seenbit,
+				 uint64_t flipbit, uint64_t *dest);
+extern error_code_e parse_uint64(parse_context_t *ctx, uint64_t max,
+				 uint64_t *dest);
+extern error_code_e parse_int64(parse_context_t *ctx, int64_t min, int64_t max,
+				int64_t *dest);
 extern error_code_e parse_quoted_string(parse_context_t *ctx, char **dest);
 extern error_code_e parse_string(parse_context_t *ctx, char **dest);
-extern error_code_e parse_section(parse_context_t *ctx, statement_t *language, void *dest);
+extern error_code_e parse_section(parse_context_t *ctx, statement_t *language,
+				  void *dest);
 
 extern void skip_line_spaces(parse_context_t *ctx);
 extern void skip_until_eol(parse_context_t *ctx);
 extern error_code_e skip_until_field(parse_context_t *ctx);
 
-extern error_code_e parse_ctx_error(parse_context_t *ctx, error_code_e code, const line_t *line, const char *fmt, ...);
+extern error_code_e parse_ctx_error(parse_context_t *ctx, error_code_e code,
+				    const line_t *line, const char *fmt, ...);
 extern void parse_ctx_newline(parse_context_t *ctx);
 
-extern error_code_e error(perror_t *error, error_code_e code, const char *fmt, ...);
+extern error_code_e error(perror_t *error, error_code_e code, const char *fmt,
+			  ...);
 
 /***************************************************************************/
 /****************** Some inline definitions. *******************************/
 
-static inline match_t match_exact(const char* name) {
-  match_t match = {
-    .name = name,
-    .len = strlen(name),
-  };
-  return match;
+static inline match_t match_exact(const char *name)
+{
+	match_t match = {
+		.name = name,
+		.len = strlen(name),
+	};
+	return match;
 }
 
-static inline match_t match_any() {
-  match_t match = {
-    .name = "",
-    .len = 0,
-  };
-  return match;
+static inline match_t match_any()
+{
+	match_t match = {
+		.name = "",
+		.len = 0,
+	};
+	return match;
 }
 
-static inline parse_context_t context_from_buffer(const char* buffer, perror_t* err) {
-  parse_context_t context = {
+static inline parse_context_t context_from_buffer(const char *buffer,
+						  perror_t *err)
+{
+	parse_context_t context = {
     .cursor = buffer,
     .line = {
       .start = buffer,
@@ -185,23 +220,28 @@ static inline parse_context_t context_from_buffer(const char* buffer, perror_t* 
     },
     .err = err,
   };
-  return context;
+	return context;
 }
 
-static inline void perror_free(perror_t *perror) {
-  if (!perror) return;
+static inline void perror_free(perror_t *perror)
+{
+	if (!perror)
+		return;
 
-  free(perror->message);
-  perror->message = NULL;
+	free(perror->message);
+	perror->message = NULL;
 }
 
-static inline perror_t perror_init() {
-  perror_t error = { .message = NULL };
-  return error;
+static inline perror_t perror_init()
+{
+	perror_t error = { .message = NULL };
+	return error;
 }
 
-static inline uint64_t assign_bits(uint64_t dest, uint64_t source, uint64_t mask) {
-  return dest ^ ((dest ^ source) & mask);
+static inline uint64_t assign_bits(uint64_t dest, uint64_t source,
+				   uint64_t mask)
+{
+	return dest ^ ((dest ^ source) & mask);
 }
 
 #endif

--- a/proxy/nss/confparse/confparse_test.cc
+++ b/proxy/nss/confparse/confparse_test.cc
@@ -1,0 +1,532 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "confparse.h"
+}
+
+TEST(SkipLineSpaces, All) {
+  perror_t error = {};
+
+  const char* buffer = "Success is not final";
+  auto ctx = context_from_buffer(buffer, &error);
+  skip_line_spaces(&ctx);
+  EXPECT_EQ('S', *ctx.cursor);
+
+  buffer = "\t\t  Failure is not final";
+  ctx = context_from_buffer(buffer, &error);
+  skip_line_spaces(&ctx);
+  EXPECT_EQ('F', *ctx.cursor);
+
+  buffer = "   \r It is the courage to continue that counts";
+  ctx = context_from_buffer(buffer, &error);
+  skip_line_spaces(&ctx);
+  EXPECT_EQ('\r', *ctx.cursor);
+
+  buffer = "";
+  ctx = context_from_buffer(buffer, &error);
+  skip_line_spaces(&ctx);
+  EXPECT_EQ('\0', *ctx.cursor);
+  perror_free(&error);
+}
+
+TEST(SkipUntilEOL, All) {
+  perror_t error = {};
+
+  const char* buffer = "Success is not final";
+  auto ctx = context_from_buffer(buffer, &error);
+  skip_until_eol(&ctx);
+  EXPECT_EQ('\0', *ctx.cursor);
+
+  buffer = "";
+  ctx = context_from_buffer(buffer, &error);
+  skip_until_eol(&ctx);
+  EXPECT_EQ('\0', *ctx.cursor);
+
+  buffer = "   \r It is the courage\n to continue that counts";
+  ctx = context_from_buffer(buffer, &error);
+  skip_until_eol(&ctx);
+  EXPECT_EQ('\n', *ctx.cursor);
+  EXPECT_EQ(" to continue that counts", std::string_view(ctx.cursor + 1));
+
+  buffer = "   \rit\nis\nthe";
+  ctx = context_from_buffer(buffer, &error);
+  skip_until_eol(&ctx);
+  EXPECT_EQ('\n', *ctx.cursor);
+  EXPECT_EQ("is\nthe", std::string_view(ctx.cursor + 1));
+  perror_free(&error);
+}
+
+TEST(SkipUntilField, All) {
+  perror_t error = {};
+  const char* buffer = "Success is not final";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, skip_until_field(&ctx));
+  EXPECT_EQ('S', *ctx.cursor);
+
+  buffer = " \t   Success";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, skip_until_field(&ctx));
+  EXPECT_EQ('S', *ctx.cursor);
+
+  buffer = "";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, skip_until_field(&ctx));
+  EXPECT_EQ('\0', *ctx.cursor);
+
+  buffer = "    \n   fuffa";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, skip_until_field(&ctx));
+  EXPECT_EQ('\n', *ctx.cursor);
+  perror_free(&error);
+}
+
+TEST(ParseBool32, All) {
+  perror_t error = {};
+  uint32_t result = 0;
+
+  const char* buffer = "";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+
+  buffer = "of";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+
+  buffer = "   True";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x11, result);
+
+  buffer = "true";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x11, result);
+
+  buffer = "on ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x11, result);
+
+  result = 0x1000;
+  buffer = "yes blah";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1011, result);
+
+  buffer = " yesyes";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1011, result);
+
+  result = 0x1111;
+  buffer = "no";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1110, result);
+
+  buffer = "off ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1110, result);
+
+  buffer = "false ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1110, result);
+
+  buffer = "False ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_bool32(&ctx, 0x10, 0x1, &result));
+  EXPECT_EQ(0x1110, result);
+
+  perror_free(&error);
+}
+
+TEST(ParseUint32, All) {
+  perror_t error = {};
+  uint64_t result = 0;
+
+  const char* buffer = "";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_uint64(&ctx, UINT32_MAX, &result));
+
+  buffer = "   16";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_uint64(&ctx, UINT32_MAX, &result));
+  EXPECT_EQ(16, result);
+  EXPECT_EQ('\0', *ctx.cursor);
+
+  buffer = "   0x10  ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_uint64(&ctx, UINT32_MAX, &result));
+  EXPECT_EQ(16, result);
+  EXPECT_EQ(' ', *ctx.cursor);
+
+  result = 0;
+  buffer = "   0x1g  ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_uint64(&ctx, UINT32_MAX, &result));
+  EXPECT_EQ(0, result);
+  EXPECT_EQ('g', *ctx.cursor);
+
+  buffer = "   0x10\n";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_uint64(&ctx, UINT32_MAX, &result));
+  EXPECT_EQ(16, result);
+  EXPECT_EQ('\n', *ctx.cursor);
+  perror_free(&error);
+}
+
+TEST(ParseQuotedString, All) {
+  perror_t error = {};
+  char* result = nullptr;
+
+  const char* buffer = "";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_quoted_string(&ctx, &result));
+
+  buffer = "\"";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_quoted_string(&ctx, &result));
+
+  buffer = "\"foo \n  ";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_quoted_string(&ctx, &result));
+
+  buffer = "   \"foo\"";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_quoted_string(&ctx, &result));
+  EXPECT_EQ("foo", std::string_view(result));
+  EXPECT_EQ('\0', *ctx.cursor);
+  free(result);
+
+  buffer = "   \"foo\nbar    baz buz\"U";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_quoted_string(&ctx, &result));
+  EXPECT_EQ("foo\nbar    baz buz", std::string_view(result));
+  EXPECT_EQ('U', *ctx.cursor);
+  free(result);
+
+  // Invalid escape, \o is not supported!
+  buffer = "\"f\\oo\"";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_quoted_string(&ctx, &result));
+
+  buffer = "\"\\"; // escape at end of buffer.
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_quoted_string(&ctx, &result));
+
+  buffer = "\"\\\\\""; // valid escape, 1 byte.
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_quoted_string(&ctx, &result));
+  EXPECT_EQ("\\", std::string_view(result));
+  EXPECT_EQ('\0', *ctx.cursor);
+  free(result);
+
+  buffer = "  \"\\\\foo\\\"bar\\\\ goo\"uff"; // escapepalooza.
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_quoted_string(&ctx, &result));
+  EXPECT_EQ("\\foo\"bar\\ goo", std::string_view(result));
+  EXPECT_EQ('u', *ctx.cursor);
+  free(result);
+
+  perror_free(&error);
+}
+
+TEST(ParseString, All) {
+  perror_t error = {};
+  char* result = nullptr;
+
+  const char* buffer = "";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_GE(0, parse_string(&ctx, &result));
+  EXPECT_EQ(nullptr, result);
+
+  buffer = "a";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, &result));
+  EXPECT_EQ("a", std::string_view(result));
+  EXPECT_EQ('\0', *ctx.cursor);
+  free(result);
+
+  buffer = "   pluto";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, &result));
+  EXPECT_EQ("pluto", std::string_view(result));
+  EXPECT_EQ('\0', *ctx.cursor);
+  free(result);
+
+  buffer = "   pluto topolino";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, &result));
+  EXPECT_EQ("pluto", std::string_view(result));
+  EXPECT_EQ(' ', *ctx.cursor);
+  free(result);
+
+  buffer = "   pluto\ntopolino";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, &result));
+  EXPECT_EQ("pluto", std::string_view(result));
+  EXPECT_EQ('\n', *ctx.cursor);
+  free(result);
+
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, nullptr));
+
+  // quoting is allowed in plain strings.
+  buffer = "   \"plu to\nto\"polino";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_string(&ctx, &result));
+  EXPECT_EQ("plu to\nto", std::string_view(result));
+  EXPECT_EQ('p', *ctx.cursor);
+  free(result);
+
+  perror_free(&error);
+}
+
+TEST(ParseSection, Simple) {
+  perror_t error = {};
+
+  struct test {
+    char* key;
+    uint32_t value;
+  } result = {};
+
+  statement_t stats[] = {
+	  { OPT_NONE, match_exact("Key"), expect_string(offsetof(test, key))},
+	  { OPT_NONE, match_exact("Value"), expect_uint32(offsetof(test, value))},
+    STATEMENTS_END,
+  };
+
+  const char* buffer = "";
+  auto ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_section(&ctx, stats, &result));
+  EXPECT_EQ(nullptr, result.key);
+  EXPECT_EQ(0, result.value);
+
+  // Simple valid config.
+  buffer =
+"   # this is a full fledged config\n"
+" Key \"test key\"\n"
+" Value 0x10 # I love this value";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(0, parse_section(&ctx, stats, &result)) << error.message;
+  EXPECT_EQ("test key", std::string_view(result.key));
+  EXPECT_EQ(16, result.value);
+
+  // Invalid config, Value is repeated.
+  buffer =
+"   # this is a full fledged config\n"
+" Key \"test\n key\"\n"
+" Value 0x10 # I love this value\n"
+" Value";
+  ctx = context_from_buffer(buffer, &error);
+  EXPECT_EQ(CPE_REPEATED, parse_section(&ctx, stats, &result));
+
+  perror_free(&error);
+}
+
+typedef struct {
+    char* key;
+    uint32_t value;
+} kv_t;
+
+typedef struct {
+    kv_t* kv;
+    int kvn;
+} result_t;
+
+void *result_add_kv(result_t* result) {
+  result->kv = (kv_t*)(reallocarray(result->kv, result->kvn + 1, sizeof(kv_t)));
+
+  kv_t* entry = &result->kv[(result->kvn)++];
+  entry->key = NULL;
+  entry->value = 0;
+  return entry;
+}
+
+TEST(ParseSection, SimpleRecursive) {
+  perror_t error = {};
+
+  result_t result = {
+    .kv = NULL,
+    .kvn = 0,
+  };
+
+  statement_t kv[] = {
+	  { OPT_NONE, match_exact("Mapping"), expect_nothing() },
+	  { OPT_NONE, match_exact("Key"), expect_string(offsetof(kv_t, key)) },
+	  { OPT_NONE, match_exact("Value"), expect_uint32(offsetof(kv_t, value)) },
+    STATEMENTS_END,
+  };
+
+  statement_t object[] = {
+	  { OPT_MULTI, match_exact("Mapping"), expect_section(kv, (adder_f)(result_add_kv)) },
+    STATEMENTS_END,
+  };
+
+  const char* buffer = "";
+  EXPECT_EQ(0, parse_buffer(buffer, object, &result, &error));
+  EXPECT_EQ(0, result.kvn);
+  EXPECT_EQ(NULL, result.kv);
+
+  buffer =
+" # wow, this is a complex one\n"
+"Mapping\n"
+"  Key \"foo bar\" # a key\n"
+"  Value 0x10\n"
+"\n # A second mapping\n"
+"Mapping\n"
+"  Key meh # a key\n"
+"  Value 0x100\n"
+	;
+  EXPECT_EQ(0, parse_buffer(buffer, object, &result, &error)) << error.message;
+  ASSERT_EQ(2, result.kvn);
+  EXPECT_STREQ("foo bar", result.kv[0].key);
+  EXPECT_EQ(16, result.kv[0].value);
+  EXPECT_STREQ("meh", result.kv[1].key);
+  EXPECT_EQ(256, result.kv[1].value);
+
+  perror_free(&error);
+}
+
+  typedef struct {
+    const char* argv;
+    const char* suffix;
+  
+    const char* shell;
+    const char* home;
+    const char* gecos;
+    uid_t min_uid;
+    uid_t max_uid;
+    gid_t gid;
+  } autouser_match_t;
+
+  typedef struct {
+    const char* seed;
+  
+    autouser_match_t *match;
+    size_t matchn;
+  } autouser_config_t;
+
+
+void *add_autouser_match(autouser_config_t* config) {
+  config->match = (autouser_match_t*)(reallocarray(config->match, config->matchn + 1, sizeof(autouser_match_t)));
+  autouser_match_t* entry = &config->match[(config->matchn)++];
+  *entry = {};
+
+  fprintf(stderr, "ADDING\n");
+  return entry;
+}
+
+
+TEST(ParseSection, NssExample) {
+  perror_t error = {};
+
+  statement_t suffix[] = {
+	  { OPT_START, match_exact("Suffix"), expect_string(offsetof(autouser_match_t, suffix))},
+    	  { OPT_NONE, match_exact("Shell"), expect_string(offsetof(autouser_match_t, shell))},
+    	  { OPT_NONE, match_exact("Home"), expect_string(offsetof(autouser_match_t, home))},
+    	  { OPT_NONE, match_exact("Gecos"), expect_string(offsetof(autouser_match_t, gecos))},
+
+    	  { OPT_NONE, match_exact("MinUid"), expect_uint32(offsetof(autouser_match_t, min_uid))},
+    	  { OPT_NONE, match_exact("MaxUid"), expect_uint32(offsetof(autouser_match_t, max_uid))},
+    	  { OPT_NONE, match_exact("Gid"), expect_uint32(offsetof(autouser_match_t, gid))},
+    STATEMENTS_END,
+  };
+
+  statement_t match[] = {
+	  { OPT_START, match_exact("Match"), expect_string(offsetof(autouser_match_t, argv))}, // eat token or not
+    	  { OPT_NONE, match_any(), expect_section(suffix, NULL)}, // enter section or not
+    STATEMENTS_END,
+  };
+
+  statement_t root[] = {
+	  { OPT_NONE, match_exact("Seed"), expect_string(offsetof(autouser_config_t, seed))},
+    	  { OPT_MULTI, match_any(), expect_section(match, (adder_f)(add_autouser_match))}, // enter section or not
+    STATEMENTS_END,
+  };
+
+  autouser_config_t result = {};
+
+  const char* buffer = "";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error));
+
+  buffer = "Seed foobarbaz";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error));
+  ASSERT_EQ(0, result.matchn);
+  EXPECT_STREQ("foobarbaz", result.seed);
+
+  buffer = "Seed foobarbaz\n"
+    "MinUid 32";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error));
+  EXPECT_STREQ("foobarbaz", result.seed);
+  ASSERT_EQ(1, result.matchn);
+  EXPECT_EQ(result.match[0].min_uid, 32);
+
+  free(result.match);
+  result.matchn = 0;
+  buffer = "Seed foobarbaz\n"
+    "MinUid 32\n"
+    "MinUid 33";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error));
+  EXPECT_STREQ("foobarbaz", result.seed);
+  ASSERT_EQ(2, result.matchn);
+  EXPECT_EQ(32, result.match[0].min_uid);
+  EXPECT_EQ(33, result.match[1].min_uid);
+
+  free(result.match);
+  result.matchn = 0;
+  buffer = "Seed foobarbaz\n"
+    "  # this should end up a default match.\n"
+    "MinUid 32\n"
+    "# Here we create a match.\n"
+    "Match match # well, what can we do.\n"
+    "  \tMinUid 33";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error)) << error.message;
+  EXPECT_STREQ("foobarbaz", result.seed);
+  ASSERT_EQ(2, result.matchn);
+  EXPECT_EQ(NULL, result.match[0].argv);
+  EXPECT_EQ(32, result.match[0].min_uid);
+  EXPECT_STREQ("match", result.match[1].argv);
+  EXPECT_EQ(33, result.match[1].min_uid);
+
+  free(result.match);
+  result.matchn = 0;
+  buffer = "Seed foobarbaz\n"
+    "  # this should end up a default match.\n"
+    "MinUid 32\n"
+    "MaxUid 3201\n"
+    "Shell foo\n"
+    "# Here we create a match.\n"
+    "Match match # well, what can we do.\n"
+    "  \tMinUid 33\n"
+    "Suffix one\n"
+    "  Shell 14\n"
+    "  MaxUid 5608\n"
+    "Suffix two\n"
+    "  Shell 15\n";
+  EXPECT_EQ(0, parse_buffer(buffer, root, &result, &error)) << error.message;
+  EXPECT_STREQ("foobarbaz", result.seed);
+  ASSERT_EQ(4, result.matchn);
+
+  EXPECT_EQ(NULL, result.match[0].argv);
+  EXPECT_EQ(32, result.match[0].min_uid);
+  EXPECT_EQ(3201, result.match[0].max_uid);
+  EXPECT_STREQ("foo", result.match[0].shell);
+
+  EXPECT_STREQ("match", result.match[1].argv);
+  EXPECT_EQ(33, result.match[1].min_uid);
+
+  EXPECT_STREQ(NULL, result.match[2].argv);
+  EXPECT_EQ(5608, result.match[2].max_uid);
+  EXPECT_STREQ("14", result.match[2].shell);
+  EXPECT_STREQ("one", result.match[2].suffix);
+
+  EXPECT_STREQ(NULL, result.match[3].argv);
+  EXPECT_STREQ("15", result.match[3].shell);
+  EXPECT_STREQ("two", result.match[3].suffix);
+
+  perror_free(&error);
+}

--- a/proxy/nss/nss-autouser.c
+++ b/proxy/nss/nss-autouser.c
@@ -1,0 +1,549 @@
+#include <nss.h>
+#include <pwd.h>
+#include <shadow.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <threads.h>
+#include <stdbool.h>
+#include <fnmatch.h>
+
+#include "proxy/nss/confparse/confparse.h"
+#include "proxy/nss/nss-autouser.h"
+
+#ifndef AU_CONFIG_PATH
+# define AU_CONFIG_PATH "/etc/nss-autouser.conf"
+#endif
+
+#ifndef AU_HASH_ATTEMPTS
+# define AU_HASH_ATTEMPTS 10
+#endif
+
+#ifndef AU_LOG_BUFFER_SIZE
+# define AU_LOG_BUFFER_SIZE 512
+#endif
+
+#ifndef AU_DEFAULT_SHELL
+# define AU_DEFAULT_SHELL "/bin/bash"
+#endif
+
+static char** process_argv = NULL;
+static char** process_env = NULL;
+static int process_argc = 0;
+
+/* vdebug saves a log line in a debug file in a way that's safe
+ * even if multiple processes are accessing the file. */
+static void vdebug(const char* debug, const char* fmt, va_list ap) {
+  if (!debug) return;
+
+  FILE *f = fopen(debug, "a");
+  if (!f) return;
+  /* Line buffering to prevent corruption with multiple
+   * multiple instances of the code running. */
+  setvbuf(f, NULL, _IOLBF, 0);
+
+  vfprintf(f, fmt, ap);
+  fclose(f);
+}
+
+__attribute__ ((format (printf, 2, 3)))
+static void debug(const char* debug, const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vdebug(debug, fmt, ap);
+  va_end(ap);
+}
+
+/* mlog will save all messages to a debug log file, if one is passed,
+ * while also sending messages of LOG_INFO or above to syslog. */
+__attribute__ ((format (printf, 3, 4)))
+static void mlog(const char* path, int priority, const char* fmt, ...) {
+  if (!path && priority > LOG_INFO) return;
+
+  size_t bsize = AU_LOG_BUFFER_SIZE;
+  char bdata[bsize];
+  char* buffer = bdata;
+  va_list ap;
+
+  int len = snprintf(buffer, bsize, "nss-autouser for pid %d (%s) - ",
+		     getpid(), process_argv ? process_argv[0] : "unknown");
+  if (len < bsize) {
+    buffer += len;
+    bsize -= len;
+  }
+
+  va_start(ap, fmt);
+  vsnprintf(buffer, bsize, fmt, ap);
+  va_end(ap);
+
+  bdata[sizeof(bdata) - 1] = '\0';
+
+  va_start(ap, fmt);
+  debug(path, "%s\n", bdata); 
+  va_end(ap);
+
+  if (priority <= LOG_INFO)
+    syslog(priority, "%s", bdata);
+}
+
+static void config_free(autouser_config_t* config) {
+  if (!config) return;
+  free((void*)config->seed);
+  for (int i = 0; i < config->matchn; ++i) {
+    autouser_match_t* match = &config->match[i];
+    free((void*)match->argv);
+    free((void*)match->suffix);
+    free((void*)match->shell);
+    free((void*)match->home);
+    free((void*)match->gecos);
+  }
+  free(config->match);
+  memset(config, 0, sizeof(*config));
+}
+
+void *add_autouser_match(autouser_config_t* config) {
+  config->match = (autouser_match_t*)(realloc(config->match, (config->matchn + 1) * sizeof(autouser_match_t)));
+  autouser_match_t* entry = &config->match[config->matchn];
+  memset(entry, 0, sizeof(*entry));
+  if (config->matchn >= 1 && config->match[config->matchn - 1].argv)
+    entry->argv = strdup(config->match[config->matchn - 1].argv);
+
+  ++(config->matchn);
+  return entry;
+}
+
+/* config_parse parses a libnss_autouser configuration file. */
+static int config_parse(const char* path, autouser_config_t* config) {
+  perror_t err = perror_init();
+
+  statement_t suffix[] = {
+	  { OPT_START, match_exact("Suffix"), expect_string(offsetof(autouser_match_t, suffix))},
+    	  { OPT_NONE, match_exact("Shell"), expect_string(offsetof(autouser_match_t, shell))},
+    	  { OPT_NONE, match_exact("Home"), expect_string(offsetof(autouser_match_t, home))},
+    	  { OPT_NONE, match_exact("Gecos"), expect_string(offsetof(autouser_match_t, gecos))},
+
+    	  { OPT_NONE, match_exact("MinUid"), expect_uint32(offsetof(autouser_match_t, min_uid))},
+    	  { OPT_NONE, match_exact("MaxUid"), expect_uint32(offsetof(autouser_match_t, max_uid))},
+    	  { OPT_NONE, match_exact("Gid"), expect_uint32(offsetof(autouser_match_t, gid))},
+
+    	  { OPT_NONE, match_exact("PropagatePassword"), expect_bool32(offsetof(autouser_match_t, flags), MATCH_SET_PASSWORD, MATCH_USE_PASSWORD)},
+    	  { OPT_NONE, match_exact("FullHomePath"), expect_bool32(offsetof(autouser_match_t, flags), MATCH_SET_FULL_HOME, MATCH_USE_FULL_HOME)},
+    STATEMENTS_END,
+  };
+
+  statement_t match[] = {
+	  { OPT_START, match_exact("Match"), expect_string(offsetof(autouser_match_t, argv))},
+    	  { OPT_NONE, match_any(), expect_section(suffix, NULL)},
+    STATEMENTS_END,
+  };
+
+  statement_t root[] = {
+	  { OPT_NONE, match_exact("Seed"), expect_string(offsetof(autouser_config_t, seed))},
+	  { OPT_NONE, match_exact("DebugLog"), expect_string(offsetof(autouser_config_t, debug))},
+    	  { OPT_MULTI, match_any(), expect_section(match, (adder_f)(add_autouser_match))},
+    STATEMENTS_END,
+  };
+
+  int status = parse_file(path, root, config, &err);
+  if (status < 0) {
+    mlog(NULL, LOG_ERR, "error %d parsing configuration file '%s': %s", status, path, err.message);
+  }
+
+  perror_free(&err);
+  return status;
+}
+
+
+/* add appends strings to a buffer, for as long as the string won't
+ * exceed the end of the buffer.
+ *
+ * Returns the address of the string within the buffer, or NULL
+ * if for any reason the source str could not be copied.
+ *
+ * If the buffer fills, the destination pointer is set to NULL,
+ * to force future addition to fail. */
+static char* add(char** dest, const char* end, const char* str) {
+  char* start = *dest;
+  if (!start) return NULL;
+  if (!str) return NULL;
+
+  size_t len = strlen(str);
+  if (start + len >= end) {
+    (*dest) = NULL;
+    return NULL;
+  }
+
+  memcpy(start, str, len + 1);
+  (*dest) += len + 1;
+  return start;
+}
+
+/* Simple FNV-1a implementation.
+ *
+ * A cryptographically secure hash would be preferrable here, but
+ * with < 32 bits of space and the birthday paradox, finding
+ * collisions would still be relatively easy, and the impact
+ * of clashes is low (user still needs to authenticate, users
+ * cannot pick an arbitrary number of usernames, ...). */
+static uint64_t seed(const char* seed) {
+  uint64_t hash = 0xcbf29ce484222325ULL;
+  for (; *seed; ++seed) {
+    hash ^= *(unsigned char*)(seed);
+    hash *= 0x100000001b3ULL;
+  }
+  return hash;
+}
+
+static uint64_t hash(uint64_t seed, const char* data) {
+  for (; *data; ++data) {
+    seed ^= *(unsigned char*)(data);
+    seed *= 0x100000001b3ULL;
+  }
+  return seed;
+}
+
+/* compute_uid computes a consistent UID from the hash of a username.
+ *
+ * The function checks if the computed UID is free before returning
+ * it, and computes a different hash if it detects a collision.
+ *
+ * pseed is used as a seed for the hash function.
+ * min uid and max uid define the range of valid uids returned.
+ * attempts is the maximum number of tries to find a free uid.
+ *
+ * Returns 0 if no UID can be found.
+ * 0 was intentionally picked to force the caller to have code rejecting
+ * 0 as a valid UID - even if it was returned by mistake.
+ *
+ * WARNING: this function is inherently racy. Until the UID is added
+ * to the system database (and this function does NOT add the UID),
+ * the same UID could be assigned to a different, concurrent, user.
+ *
+ * Before authorizing an user for login, ALWAYS ALWAYS create the
+ * corresponding record in the user database - to lock in the
+ * mapping between UID <-> user. Failure to add should result in
+ * rejecting the user. */
+static uid_t compute_uid(const char* pseed, const char* name, uid_t min, uid_t max, int attempts) {
+  static_assert(
+    sizeof(uint32_t) == sizeof(uid_t),
+    "uid_t is not an uint32_t, hash function assumes 32 bit uids");
+
+  uint64_t hvalue = seed(pseed);
+  for (int i = 0; i < attempts; i++) {
+    hvalue = hash(hvalue, name);
+
+    uid_t uid = min + (hvalue % (max - min + 1));
+    if (!getpwuid(uid)) return uid;
+  }
+
+  return 0;
+}
+
+/* suffix_index returns the index where the specified suffix starts
+ * in the input string.
+ *
+ * Returns -1 in case the suffix cannot be found. */
+static int suffix_index(const char* input, const char* suffix) {
+  size_t inputl = strlen(input);
+  size_t suffixl = strlen(suffix);
+
+  if (suffixl > inputl || strcmp(input + (inputl - suffixl), suffix))
+    return -1;
+
+  return inputl - suffixl;
+}
+
+static void config_merge(autouser_match_t* dest, autouser_match_t* source) {
+  if (!source || !dest) return;
+
+  if (source->argv != NULL && *source->argv) dest->argv = source->argv;
+  if (source->suffix != NULL && *source->suffix) dest->suffix = source->suffix;
+  if (source->shell != NULL && *source->shell) dest->shell = source->shell;
+  if (source->home != NULL && *source->home) dest->home = source->home;
+  if (source->gecos != NULL && *source->gecos) dest->gecos = source->gecos;
+
+  if (source->min_uid > 0) dest->min_uid = source->min_uid;
+  if (source->max_uid > 0) dest->max_uid = source->max_uid;
+  if (source->gid > 0) dest->gid = source->gid;
+
+  if (source->flags & MATCH_SET_PASSWORD)
+    dest->flags = assign_bits(dest->flags, source->flags,  MATCH_SET_PASSWORD | MATCH_USE_PASSWORD);
+  if (source->flags & MATCH_SET_FULL_HOME)
+    dest->flags = assign_bits(dest->flags, source->flags,  MATCH_SET_FULL_HOME | MATCH_USE_FULL_HOME);
+}
+
+static int config_apply(const autouser_config_t* config, const char* process, const char* name, autouser_match_t *result) {
+  autouser_match_t* def_process_def_user = NULL;
+  autouser_match_t* def_process_set_user = NULL;
+  autouser_match_t* set_process_def_user = NULL;
+  autouser_match_t* set_process_set_user = NULL;
+
+  int def_suffix_offset = -1;
+  int set_suffix_offset = -1;
+  for (int i = 0; i < config->matchn; ++i) {
+    autouser_match_t* m = &config->match[i];
+    int offset = 0;
+    if (!m->argv || !*m->argv) {
+      if (!m->suffix || !*m->suffix) {
+        def_process_def_user = m;
+      } else if ((offset = suffix_index(name, m->suffix)) >= 0) {
+	def_process_set_user = m;
+	def_suffix_offset = offset;
+      }
+    } else if (!fnmatch(m->argv, process, FNM_PATHNAME)) {
+      if (!m->suffix || !*m->suffix) {
+        set_process_def_user = m;
+      } else if ((offset = suffix_index(name, m->suffix)) >= 0) {
+	set_process_set_user = m;
+	set_suffix_offset = offset;
+      }
+    }
+  }
+
+  config_merge(result, def_process_def_user);
+  config_merge(result, def_process_set_user);
+  config_merge(result, set_process_def_user);
+  config_merge(result, set_process_set_user);
+
+  return set_suffix_offset >= 0 ? set_suffix_offset : def_suffix_offset;
+}
+
+typedef enum {
+  SR_FULL_DIR = 1<<0,
+  SR_AUTO_GEN = 1<<1,
+} store_result_flags_e;
+
+int store_result(const char* original, const char* name, uid_t uid, autouser_match_t* match, const char* password, char* buffer, size_t buflen, struct passwd* pwd, uint32_t flags) {
+  char* cursor = buffer;
+  const char* end = cursor + buflen;
+
+  pwd->pw_uid = uid;
+  pwd->pw_gid = match->gid ? match->gid : uid;
+
+  pwd->pw_name = add(&cursor, end, name);
+  pwd->pw_passwd = add(&cursor, end, password ? password : "*");
+  pwd->pw_gecos = add(&cursor, end, match->gecos ? match->gecos : "");
+  pwd->pw_shell = add(&cursor, end, (match->shell && *match->shell) ? match->shell : AU_DEFAULT_SHELL);
+
+  if (!cursor) return -1;
+
+  if (match->home && *match->home && (flags & SR_FULL_DIR)) {
+    pwd->pw_dir = add(&cursor, end, match->home);
+    if (!cursor) return -1;
+  } else {
+    const char* home = (match->home && *match->home) ? match->home : "/home";
+    if (!cursor || snprintf(cursor, end - cursor, "%s/%s", home, name) >= end-cursor) {
+            return -1;
+    }
+    pwd->pw_dir = cursor;
+  }
+
+  static_assert(
+    sizeof(uint32_t) == sizeof(uid_t),
+    "uid_t is not an uint32_t, printf casts uid_t to uint32_t");
+
+  setenv("AUTOUSER_ORIGINAL", original, 1);
+  setenv("AUTOUSER_NAME", pwd->pw_name, 1);
+  setenv("AUTOUSER_SHELL", pwd->pw_shell, 1);
+  setenv("AUTOUSER_HOME", pwd->pw_dir, 1);
+  setenv("AUTOUSER_GECOS", pwd->pw_gecos, 1);
+  if (flags & SR_AUTO_GEN)
+    setenv("AUTOUSER_AUTOGEN", "true", 1);
+  else
+    setenv("AUTOUSER_AUTOGEN", "false", 1);
+
+  char ibuffer[32];
+  snprintf(ibuffer, sizeof(ibuffer), "%"PRIu32, (uint32_t)(pwd->pw_uid));
+  setenv("AUTOUSER_UID", ibuffer, 1);
+  snprintf(ibuffer, sizeof(ibuffer), "%"PRIu32, (uint32_t)(pwd->pw_gid));
+  setenv("AUTOUSER_GID", ibuffer, 1);
+
+  return 0;
+}
+
+static void config_dump_match(autouser_config_t* config, autouser_match_t* match) {
+  mlog(config->debug, LOG_INFO, "config:   argv %s", match->argv);
+  mlog(config->debug, LOG_INFO, "config:   suffix %s", match->suffix);
+  mlog(config->debug, LOG_INFO, "config:   shell %s", match->shell);
+  mlog(config->debug, LOG_INFO, "config:   home %s", match->home);
+  mlog(config->debug, LOG_INFO, "config:   gecos %s", match->gecos);
+  mlog(config->debug, LOG_INFO, "config:   min_uid %" PRIu32, match->min_uid);
+  mlog(config->debug, LOG_INFO, "config:   max_uid %" PRIu32, match->max_uid);
+  mlog(config->debug, LOG_INFO, "config:   gid %" PRIu32, match->gid);
+  mlog(config->debug, LOG_INFO, "config:   flags %08x", match->flags);
+}
+
+static void config_dump(autouser_config_t* config) {
+  mlog(config->debug, LOG_INFO, "config: DebugLog %s", config->debug);
+  mlog(config->debug, LOG_INFO, "config: Seed %s", config->seed ? "(set but hidden)" : "(unset)");
+  for (int i = 0; i < config->matchn; ++i) {
+    mlog(config->debug, LOG_INFO, "config: Entry %d:", i);
+    config_dump_match(config, &config->match[i]);
+  }
+}
+
+/* Return values are based on:
+ *   https://www.gnu.org/software/libc/manual/html_node/NSS-Modules-Interface.html */
+enum nss_status _nss_autouser_getpwnam_r(
+    const char *name, struct passwd *pwd, char *buffer, size_t buflen, int *errnop) {
+  static thread_local bool nesting = false;
+  if (nesting) {
+    if (errnop) *errnop = 0;
+    return NSS_STATUS_NOTFOUND;
+  }
+
+  autouser_config_t config = {
+    .seed = NULL,
+  };
+
+  if (config_parse(AU_CONFIG_PATH, &config) < 0) { 
+    if (errnop) *errnop = ENOENT;
+    return NSS_STATUS_UNAVAIL;
+  }
+
+  if (config.debug) config_dump(&config);
+
+  int ierrno = 0; /* internal errno. */
+  int status = NSS_STATUS_SUCCESS;
+  const char *namedup = NULL, *original = name;
+  if (config.matchn <= 0) {
+    mlog(config.debug, LOG_ERR, "no rules specified in %s - disabled", AU_CONFIG_PATH);
+    ierrno = ENOENT;
+    status = NSS_STATUS_UNAVAIL;
+    goto exit;
+  }
+
+  if (process_argc <= 0 || process_argv == NULL || process_argv[0] == NULL) {
+    mlog(config.debug, LOG_ERR, "argv could not be detected - disabled - "
+		  "this often indicates a glibc incompatibility");
+    ierrno = ENOENT;
+    status = NSS_STATUS_UNAVAIL;
+    goto exit;
+  }
+
+  autouser_match_t match = {NULL};
+  int index = config_apply(&config, process_argv[0], name, &match);
+
+  if (config.debug) {
+    mlog(config.debug, LOG_INFO, "computed configuration for user:'%s' process:'%s'", name, process_argv[0]);
+    config_dump_match(&config, &match);
+  }
+
+  if (index >= 0) {
+    if (!match.min_uid && !match.max_uid && !match.gid) {
+      mlog(config.debug, LOG_WARNING, "user:%s has a policy that does not specify MinUid, MaxUid, nor Gid - ignoring", name);
+      ierrno = EINVAL;
+      status = NSS_STATUS_NOTFOUND;
+      goto exit;
+    }
+
+    // Necessary as we can't shove a \0 in the middle of a user supplied buffer.
+    namedup = name = strndup(name, index);
+
+    char tmpbuffer[buflen];
+    memset(tmpbuffer, 0, buflen);
+
+    nesting = true;
+    struct passwd* result = NULL;
+    int gp = getpwnam_r(name, pwd, tmpbuffer, buflen, &result);
+    nesting = false;
+
+    mlog(config.debug, LOG_DEBUG,
+	 "user:%s - setting config based on prefix - %p - %s", name, (void*)result, match.shell);
+
+    if (gp == 0 && result != NULL)  {
+      if (((match.min_uid || match.max_uid) && (result->pw_uid < match.min_uid || result->pw_uid > match.max_uid)) ||
+	  (match.gid && result->pw_gid != match.gid)) {
+        mlog(config.debug, LOG_INFO, "user:%s - refusing to apply policy - uid:%"PRIu32"or gid:%"PRIu32" not allowed", name, result->pw_uid, result->pw_gid);
+        ierrno = EINVAL;
+        status = NSS_STATUS_NOTFOUND;
+        goto exit;
+      }
+
+      match.gid = result->pw_gid;
+
+      if (!match.shell || !*match.shell) match.shell = pwd->pw_shell;
+      if (!match.home || !*match.home) match.home = pwd->pw_dir;
+      if (!match.gecos || !*match.gecos) match.gecos = pwd->pw_gecos;
+
+      const char* passwd = match.flags & MATCH_USE_PASSWORD ? pwd->pw_passwd : NULL;
+      if (store_result(original, name, result->pw_uid, &match, passwd, buffer, buflen, pwd, SR_FULL_DIR) != 0) {
+	mlog(config.debug, LOG_DEBUG, "user:%s - in suffix handler - buffer too small %zu, could not store result", name, buflen);
+        ierrno = ERANGE;
+        status = NSS_STATUS_TRYAGAIN;
+      }
+
+      goto exit;
+    }
+  }
+
+  /* Never ever allow a root UID. */
+  if (match.min_uid <= 0 || match.max_uid <= 0) {
+    mlog(config.debug, LOG_DEBUG, "%s - no uid set - ignoring", name);
+    /* Lookup and configuration was successful, but the configuration
+     * tells us not to do anything for this user. */
+    ierrno = 0;
+    status = NSS_STATUS_NOTFOUND;
+    goto exit;
+  }
+
+  uid_t uid = compute_uid(
+      config.seed ? config.seed : "default-seed", name,
+      match.min_uid, match.max_uid, AU_HASH_ATTEMPTS);
+  /* Never ever allow a root UID. 0 indicates failure. */
+  if (!uid) {
+    mlog(config.debug, LOG_ERR, "hashing '%s' generated clashing uids for %d times", name, AU_HASH_ATTEMPTS);
+    ierrno = ENOENT;
+    status = NSS_STATUS_NOTFOUND;
+    goto exit;
+  }
+  
+  uint32_t flags = match.flags & MATCH_USE_FULL_HOME ? SR_FULL_DIR : 0;
+  if (store_result(original, name, uid, &match, NULL, buffer, buflen, pwd, SR_AUTO_GEN | flags) != 0) {
+    mlog(config.debug, LOG_DEBUG, "in auto handler - could not store result for %s", name);
+    ierrno = ERANGE;
+    status = NSS_STATUS_TRYAGAIN;
+  }
+
+exit:
+  if (status == NSS_STATUS_SUCCESS) {
+    mlog(config.debug, LOG_DEBUG,
+	 "user:%s - status:%d errno:%d uid:%" PRIu32 " gid:%" PRIu32 " home:%s gecos:%s shell:%s",
+         name, status, ierrno, pwd->pw_uid, pwd->pw_gid, pwd->pw_dir, pwd->pw_gecos, pwd->pw_shell);
+  } else {
+    mlog(config.debug, LOG_DEBUG, "user:%s - status:%d errno:%d", name, status, ierrno);
+  }
+
+  free((void*)namedup);
+  config_free(&config);
+
+  if (errnop) *errnop = ierrno;
+  return status;
+}
+
+static int load(int argc, char** argv, char** env) {
+  if (argv) process_argv = argv;
+  if (argc) process_argc = argc;
+  if (env) process_env = env;
+  return 0;
+}
+
+/* According to ELF specification, .init_array contains a vector of functions
+ * to invoke when the .so file is loaded.
+ *
+ * glibc and a few other libraries provide those functions a pointer to the
+ * original argc, argv, and env that was passed to the program.
+ * We use this to our benefit. */
+__attribute__((section(".init_array"))) __attribute__((used))
+    static int (*init)(int argc, char** argv, char** env) = &load;

--- a/proxy/nss/nss-autouser.c
+++ b/proxy/nss/nss-autouser.c
@@ -23,147 +23,176 @@
 #include "proxy/nss/nss-autouser.h"
 
 #ifndef AU_CONFIG_PATH
-# define AU_CONFIG_PATH "/etc/nss-autouser.conf"
+#define AU_CONFIG_PATH "/etc/nss-autouser.conf"
 #endif
 
 #ifndef AU_HASH_ATTEMPTS
-# define AU_HASH_ATTEMPTS 10
+#define AU_HASH_ATTEMPTS 10
 #endif
 
 #ifndef AU_LOG_BUFFER_SIZE
-# define AU_LOG_BUFFER_SIZE 512
+#define AU_LOG_BUFFER_SIZE 512
 #endif
 
 #ifndef AU_DEFAULT_SHELL
-# define AU_DEFAULT_SHELL "/bin/bash"
+#define AU_DEFAULT_SHELL "/bin/bash"
 #endif
 
-static char** process_argv = NULL;
-static char** process_env = NULL;
+static char **process_argv = NULL;
+static char **process_env = NULL;
 static int process_argc = 0;
 
 /* vdebug saves a log line in a debug file in a way that's safe
  * even if multiple processes are accessing the file. */
-static void vdebug(const char* debug, const char* fmt, va_list ap) {
-  if (!debug) return;
+static void vdebug(const char *debug, const char *fmt, va_list ap)
+{
+	if (!debug)
+		return;
 
-  FILE *f = fopen(debug, "a");
-  if (!f) return;
-  /* Line buffering to prevent corruption with multiple
+	FILE *f = fopen(debug, "a");
+	if (!f)
+		return;
+	/* Line buffering to prevent corruption with multiple
    * multiple instances of the code running. */
-  setvbuf(f, NULL, _IOLBF, 0);
+	setvbuf(f, NULL, _IOLBF, 0);
 
-  vfprintf(f, fmt, ap);
-  fclose(f);
+	vfprintf(f, fmt, ap);
+	fclose(f);
 }
 
-__attribute__ ((format (printf, 2, 3)))
-static void debug(const char* debug, const char* fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  vdebug(debug, fmt, ap);
-  va_end(ap);
+__attribute__((format(printf, 2, 3))) static void debug(const char *debug,
+							const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	vdebug(debug, fmt, ap);
+	va_end(ap);
 }
 
 /* mlog will save all messages to a debug log file, if one is passed,
  * while also sending messages of LOG_INFO or above to syslog. */
-__attribute__ ((format (printf, 3, 4)))
-static void mlog(const char* path, int priority, const char* fmt, ...) {
-  if (!path && priority > LOG_INFO) return;
+__attribute__((format(printf, 3, 4))) static void
+mlog(const char *path, int priority, const char *fmt, ...)
+{
+	if (!path && priority > LOG_INFO)
+		return;
 
-  size_t bsize = AU_LOG_BUFFER_SIZE;
-  char bdata[bsize];
-  char* buffer = bdata;
-  va_list ap;
+	size_t bsize = AU_LOG_BUFFER_SIZE;
+	char bdata[bsize];
+	char *buffer = bdata;
+	va_list ap;
 
-  int len = snprintf(buffer, bsize, "nss-autouser for pid %d (%s) - ",
-		     getpid(), process_argv ? process_argv[0] : "unknown");
-  if (len < bsize) {
-    buffer += len;
-    bsize -= len;
-  }
+	int len =
+		snprintf(buffer, bsize, "nss-autouser for pid %d (%s) - ",
+			 getpid(), process_argv ? process_argv[0] : "unknown");
+	if (len < bsize) {
+		buffer += len;
+		bsize -= len;
+	}
 
-  va_start(ap, fmt);
-  vsnprintf(buffer, bsize, fmt, ap);
-  va_end(ap);
+	va_start(ap, fmt);
+	vsnprintf(buffer, bsize, fmt, ap);
+	va_end(ap);
 
-  bdata[sizeof(bdata) - 1] = '\0';
+	bdata[sizeof(bdata) - 1] = '\0';
 
-  va_start(ap, fmt);
-  debug(path, "%s\n", bdata); 
-  va_end(ap);
+	va_start(ap, fmt);
+	debug(path, "%s\n", bdata);
+	va_end(ap);
 
-  if (priority <= LOG_INFO)
-    syslog(priority, "%s", bdata);
+	if (priority <= LOG_INFO)
+		syslog(priority, "%s", bdata);
 }
 
-static void config_free(autouser_config_t* config) {
-  if (!config) return;
-  free((void*)config->seed);
-  for (int i = 0; i < config->matchn; ++i) {
-    autouser_match_t* match = &config->match[i];
-    free((void*)match->argv);
-    free((void*)match->suffix);
-    free((void*)match->shell);
-    free((void*)match->home);
-    free((void*)match->gecos);
-  }
-  free(config->match);
-  memset(config, 0, sizeof(*config));
+static void config_free(autouser_config_t *config)
+{
+	if (!config)
+		return;
+	free((void *)config->seed);
+	for (int i = 0; i < config->matchn; ++i) {
+		autouser_match_t *match = &config->match[i];
+		free((void *)match->argv);
+		free((void *)match->suffix);
+		free((void *)match->shell);
+		free((void *)match->home);
+		free((void *)match->gecos);
+	}
+	free(config->match);
+	memset(config, 0, sizeof(*config));
 }
 
-void *add_autouser_match(autouser_config_t* config) {
-  config->match = (autouser_match_t*)(realloc(config->match, (config->matchn + 1) * sizeof(autouser_match_t)));
-  autouser_match_t* entry = &config->match[config->matchn];
-  memset(entry, 0, sizeof(*entry));
-  if (config->matchn >= 1 && config->match[config->matchn - 1].argv)
-    entry->argv = strdup(config->match[config->matchn - 1].argv);
+void *add_autouser_match(autouser_config_t *config)
+{
+	config->match = (autouser_match_t *)(realloc(
+		config->match,
+		(config->matchn + 1) * sizeof(autouser_match_t)));
+	autouser_match_t *entry = &config->match[config->matchn];
+	memset(entry, 0, sizeof(*entry));
+	if (config->matchn >= 1 && config->match[config->matchn - 1].argv)
+		entry->argv = strdup(config->match[config->matchn - 1].argv);
 
-  ++(config->matchn);
-  return entry;
+	++(config->matchn);
+	return entry;
 }
 
 /* config_parse parses a libnss_autouser configuration file. */
-static int config_parse(const char* path, autouser_config_t* config) {
-  perror_t err = perror_init();
+static int config_parse(const char *path, autouser_config_t *config)
+{
+	perror_t err = perror_init();
 
-  statement_t suffix[] = {
-	  { OPT_START, match_exact("Suffix"), expect_string(offsetof(autouser_match_t, suffix))},
-    	  { OPT_NONE, match_exact("Shell"), expect_string(offsetof(autouser_match_t, shell))},
-    	  { OPT_NONE, match_exact("Home"), expect_string(offsetof(autouser_match_t, home))},
-    	  { OPT_NONE, match_exact("Gecos"), expect_string(offsetof(autouser_match_t, gecos))},
+	statement_t suffix[] = {
+		{ OPT_START, match_exact("Suffix"),
+		  expect_string(offsetof(autouser_match_t, suffix)) },
+		{ OPT_NONE, match_exact("Shell"),
+		  expect_string(offsetof(autouser_match_t, shell)) },
+		{ OPT_NONE, match_exact("Home"),
+		  expect_string(offsetof(autouser_match_t, home)) },
+		{ OPT_NONE, match_exact("Gecos"),
+		  expect_string(offsetof(autouser_match_t, gecos)) },
 
-    	  { OPT_NONE, match_exact("MinUid"), expect_uint32(offsetof(autouser_match_t, min_uid))},
-    	  { OPT_NONE, match_exact("MaxUid"), expect_uint32(offsetof(autouser_match_t, max_uid))},
-    	  { OPT_NONE, match_exact("Gid"), expect_uint32(offsetof(autouser_match_t, gid))},
+		{ OPT_NONE, match_exact("MinUid"),
+		  expect_uint32(offsetof(autouser_match_t, min_uid)) },
+		{ OPT_NONE, match_exact("MaxUid"),
+		  expect_uint32(offsetof(autouser_match_t, max_uid)) },
+		{ OPT_NONE, match_exact("Gid"),
+		  expect_uint32(offsetof(autouser_match_t, gid)) },
 
-    	  { OPT_NONE, match_exact("PropagatePassword"), expect_bool32(offsetof(autouser_match_t, flags), MATCH_SET_PASSWORD, MATCH_USE_PASSWORD)},
-    	  { OPT_NONE, match_exact("FullHomePath"), expect_bool32(offsetof(autouser_match_t, flags), MATCH_SET_FULL_HOME, MATCH_USE_FULL_HOME)},
-    STATEMENTS_END,
-  };
+		{ OPT_NONE, match_exact("PropagatePassword"),
+		  expect_bool32(offsetof(autouser_match_t, flags),
+				MATCH_SET_PASSWORD, MATCH_USE_PASSWORD) },
+		{ OPT_NONE, match_exact("FullHomePath"),
+		  expect_bool32(offsetof(autouser_match_t, flags),
+				MATCH_SET_FULL_HOME, MATCH_USE_FULL_HOME) },
+		STATEMENTS_END,
+	};
 
-  statement_t match[] = {
-	  { OPT_START, match_exact("Match"), expect_string(offsetof(autouser_match_t, argv))},
-    	  { OPT_NONE, match_any(), expect_section(suffix, NULL)},
-    STATEMENTS_END,
-  };
+	statement_t match[] = {
+		{ OPT_START, match_exact("Match"),
+		  expect_string(offsetof(autouser_match_t, argv)) },
+		{ OPT_NONE, match_any(), expect_section(suffix, NULL) },
+		STATEMENTS_END,
+	};
 
-  statement_t root[] = {
-	  { OPT_NONE, match_exact("Seed"), expect_string(offsetof(autouser_config_t, seed))},
-	  { OPT_NONE, match_exact("DebugLog"), expect_string(offsetof(autouser_config_t, debug))},
-    	  { OPT_MULTI, match_any(), expect_section(match, (adder_f)(add_autouser_match))},
-    STATEMENTS_END,
-  };
+	statement_t root[] = {
+		{ OPT_NONE, match_exact("Seed"),
+		  expect_string(offsetof(autouser_config_t, seed)) },
+		{ OPT_NONE, match_exact("DebugLog"),
+		  expect_string(offsetof(autouser_config_t, debug)) },
+		{ OPT_MULTI, match_any(),
+		  expect_section(match, (adder_f)(add_autouser_match)) },
+		STATEMENTS_END,
+	};
 
-  int status = parse_file(path, root, config, &err);
-  if (status < 0) {
-    mlog(NULL, LOG_ERR, "error %d parsing configuration file '%s': %s", status, path, err.message);
-  }
+	int status = parse_file(path, root, config, &err);
+	if (status < 0) {
+		mlog(NULL, LOG_ERR,
+		     "error %d parsing configuration file '%s': %s", status,
+		     path, err.message);
+	}
 
-  perror_free(&err);
-  return status;
+	perror_free(&err);
+	return status;
 }
-
 
 /* add appends strings to a buffer, for as long as the string won't
  * exceed the end of the buffer.
@@ -173,20 +202,23 @@ static int config_parse(const char* path, autouser_config_t* config) {
  *
  * If the buffer fills, the destination pointer is set to NULL,
  * to force future addition to fail. */
-static char* add(char** dest, const char* end, const char* str) {
-  char* start = *dest;
-  if (!start) return NULL;
-  if (!str) return NULL;
+static char *add(char **dest, const char *end, const char *str)
+{
+	char *start = *dest;
+	if (!start)
+		return NULL;
+	if (!str)
+		return NULL;
 
-  size_t len = strlen(str);
-  if (start + len >= end) {
-    (*dest) = NULL;
-    return NULL;
-  }
+	size_t len = strlen(str);
+	if (start + len >= end) {
+		(*dest) = NULL;
+		return NULL;
+	}
 
-  memcpy(start, str, len + 1);
-  (*dest) += len + 1;
-  return start;
+	memcpy(start, str, len + 1);
+	(*dest) += len + 1;
+	return start;
 }
 
 /* Simple FNV-1a implementation.
@@ -196,21 +228,23 @@ static char* add(char** dest, const char* end, const char* str) {
  * collisions would still be relatively easy, and the impact
  * of clashes is low (user still needs to authenticate, users
  * cannot pick an arbitrary number of usernames, ...). */
-static uint64_t seed(const char* seed) {
-  uint64_t hash = 0xcbf29ce484222325ULL;
-  for (; *seed; ++seed) {
-    hash ^= *(unsigned char*)(seed);
-    hash *= 0x100000001b3ULL;
-  }
-  return hash;
+static uint64_t seed(const char *seed)
+{
+	uint64_t hash = 0xcbf29ce484222325ULL;
+	for (; *seed; ++seed) {
+		hash ^= *(unsigned char *)(seed);
+		hash *= 0x100000001b3ULL;
+	}
+	return hash;
 }
 
-static uint64_t hash(uint64_t seed, const char* data) {
-  for (; *data; ++data) {
-    seed ^= *(unsigned char*)(data);
-    seed *= 0x100000001b3ULL;
-  }
-  return seed;
+static uint64_t hash(uint64_t seed, const char *data)
+{
+	for (; *data; ++data) {
+		seed ^= *(unsigned char *)(data);
+		seed *= 0x100000001b3ULL;
+	}
+	return seed;
 }
 
 /* compute_uid computes a consistent UID from the hash of a username.
@@ -234,309 +268,386 @@ static uint64_t hash(uint64_t seed, const char* data) {
  * corresponding record in the user database - to lock in the
  * mapping between UID <-> user. Failure to add should result in
  * rejecting the user. */
-static uid_t compute_uid(const char* pseed, const char* name, uid_t min, uid_t max, int attempts) {
-  static_assert(
-    sizeof(uint32_t) == sizeof(uid_t),
-    "uid_t is not an uint32_t, hash function assumes 32 bit uids");
+static uid_t compute_uid(const char *pseed, const char *name, uid_t min,
+			 uid_t max, int attempts)
+{
+	static_assert(
+		sizeof(uint32_t) == sizeof(uid_t),
+		"uid_t is not an uint32_t, hash function assumes 32 bit uids");
 
-  uint64_t hvalue = seed(pseed);
-  for (int i = 0; i < attempts; i++) {
-    hvalue = hash(hvalue, name);
+	uint64_t hvalue = seed(pseed);
+	for (int i = 0; i < attempts; i++) {
+		hvalue = hash(hvalue, name);
 
-    uid_t uid = min + (hvalue % (max - min + 1));
-    if (!getpwuid(uid)) return uid;
-  }
+		uid_t uid = min + (hvalue % (max - min + 1));
+		if (!getpwuid(uid))
+			return uid;
+	}
 
-  return 0;
+	return 0;
 }
 
 /* suffix_index returns the index where the specified suffix starts
  * in the input string.
  *
  * Returns -1 in case the suffix cannot be found. */
-static int suffix_index(const char* input, const char* suffix) {
-  size_t inputl = strlen(input);
-  size_t suffixl = strlen(suffix);
+static int suffix_index(const char *input, const char *suffix)
+{
+	size_t inputl = strlen(input);
+	size_t suffixl = strlen(suffix);
 
-  if (suffixl > inputl || strcmp(input + (inputl - suffixl), suffix))
-    return -1;
+	if (suffixl > inputl || strcmp(input + (inputl - suffixl), suffix))
+		return -1;
 
-  return inputl - suffixl;
+	return inputl - suffixl;
 }
 
-static void config_merge(autouser_match_t* dest, autouser_match_t* source) {
-  if (!source || !dest) return;
+static void config_merge(autouser_match_t *dest, autouser_match_t *source)
+{
+	if (!source || !dest)
+		return;
 
-  if (source->argv != NULL && *source->argv) dest->argv = source->argv;
-  if (source->suffix != NULL && *source->suffix) dest->suffix = source->suffix;
-  if (source->shell != NULL && *source->shell) dest->shell = source->shell;
-  if (source->home != NULL && *source->home) dest->home = source->home;
-  if (source->gecos != NULL && *source->gecos) dest->gecos = source->gecos;
+	if (source->argv != NULL && *source->argv)
+		dest->argv = source->argv;
+	if (source->suffix != NULL && *source->suffix)
+		dest->suffix = source->suffix;
+	if (source->shell != NULL && *source->shell)
+		dest->shell = source->shell;
+	if (source->home != NULL && *source->home)
+		dest->home = source->home;
+	if (source->gecos != NULL && *source->gecos)
+		dest->gecos = source->gecos;
 
-  if (source->min_uid > 0) dest->min_uid = source->min_uid;
-  if (source->max_uid > 0) dest->max_uid = source->max_uid;
-  if (source->gid > 0) dest->gid = source->gid;
+	if (source->min_uid > 0)
+		dest->min_uid = source->min_uid;
+	if (source->max_uid > 0)
+		dest->max_uid = source->max_uid;
+	if (source->gid > 0)
+		dest->gid = source->gid;
 
-  if (source->flags & MATCH_SET_PASSWORD)
-    dest->flags = assign_bits(dest->flags, source->flags,  MATCH_SET_PASSWORD | MATCH_USE_PASSWORD);
-  if (source->flags & MATCH_SET_FULL_HOME)
-    dest->flags = assign_bits(dest->flags, source->flags,  MATCH_SET_FULL_HOME | MATCH_USE_FULL_HOME);
+	if (source->flags & MATCH_SET_PASSWORD)
+		dest->flags =
+			assign_bits(dest->flags, source->flags,
+				    MATCH_SET_PASSWORD | MATCH_USE_PASSWORD);
+	if (source->flags & MATCH_SET_FULL_HOME)
+		dest->flags =
+			assign_bits(dest->flags, source->flags,
+				    MATCH_SET_FULL_HOME | MATCH_USE_FULL_HOME);
 }
 
-static int config_apply(const autouser_config_t* config, const char* process, const char* name, autouser_match_t *result) {
-  autouser_match_t* def_process_def_user = NULL;
-  autouser_match_t* def_process_set_user = NULL;
-  autouser_match_t* set_process_def_user = NULL;
-  autouser_match_t* set_process_set_user = NULL;
+static int config_apply(const autouser_config_t *config, const char *process,
+			const char *name, autouser_match_t *result)
+{
+	autouser_match_t *def_process_def_user = NULL;
+	autouser_match_t *def_process_set_user = NULL;
+	autouser_match_t *set_process_def_user = NULL;
+	autouser_match_t *set_process_set_user = NULL;
 
-  int def_suffix_offset = -1;
-  int set_suffix_offset = -1;
-  for (int i = 0; i < config->matchn; ++i) {
-    autouser_match_t* m = &config->match[i];
-    int offset = 0;
-    if (!m->argv || !*m->argv) {
-      if (!m->suffix || !*m->suffix) {
-        def_process_def_user = m;
-      } else if ((offset = suffix_index(name, m->suffix)) >= 0) {
-	def_process_set_user = m;
-	def_suffix_offset = offset;
-      }
-    } else if (!fnmatch(m->argv, process, FNM_PATHNAME)) {
-      if (!m->suffix || !*m->suffix) {
-        set_process_def_user = m;
-      } else if ((offset = suffix_index(name, m->suffix)) >= 0) {
-	set_process_set_user = m;
-	set_suffix_offset = offset;
-      }
-    }
-  }
+	int def_suffix_offset = -1;
+	int set_suffix_offset = -1;
+	for (int i = 0; i < config->matchn; ++i) {
+		autouser_match_t *m = &config->match[i];
+		int offset = 0;
+		if (!m->argv || !*m->argv) {
+			if (!m->suffix || !*m->suffix) {
+				def_process_def_user = m;
+			} else if ((offset = suffix_index(name, m->suffix)) >=
+				   0) {
+				def_process_set_user = m;
+				def_suffix_offset = offset;
+			}
+		} else if (!fnmatch(m->argv, process, FNM_PATHNAME)) {
+			if (!m->suffix || !*m->suffix) {
+				set_process_def_user = m;
+			} else if ((offset = suffix_index(name, m->suffix)) >=
+				   0) {
+				set_process_set_user = m;
+				set_suffix_offset = offset;
+			}
+		}
+	}
 
-  config_merge(result, def_process_def_user);
-  config_merge(result, def_process_set_user);
-  config_merge(result, set_process_def_user);
-  config_merge(result, set_process_set_user);
+	config_merge(result, def_process_def_user);
+	config_merge(result, def_process_set_user);
+	config_merge(result, set_process_def_user);
+	config_merge(result, set_process_set_user);
 
-  return set_suffix_offset >= 0 ? set_suffix_offset : def_suffix_offset;
+	return set_suffix_offset >= 0 ? set_suffix_offset : def_suffix_offset;
 }
 
 typedef enum {
-  SR_FULL_DIR = 1<<0,
-  SR_AUTO_GEN = 1<<1,
+	SR_FULL_DIR = 1 << 0,
+	SR_AUTO_GEN = 1 << 1,
 } store_result_flags_e;
 
-int store_result(const char* original, const char* name, uid_t uid, autouser_match_t* match, const char* password, char* buffer, size_t buflen, struct passwd* pwd, uint32_t flags) {
-  char* cursor = buffer;
-  const char* end = cursor + buflen;
+int store_result(const char *original, const char *name, uid_t uid,
+		 autouser_match_t *match, const char *password, char *buffer,
+		 size_t buflen, struct passwd *pwd, uint32_t flags)
+{
+	char *cursor = buffer;
+	const char *end = cursor + buflen;
 
-  pwd->pw_uid = uid;
-  pwd->pw_gid = match->gid ? match->gid : uid;
+	pwd->pw_uid = uid;
+	pwd->pw_gid = match->gid ? match->gid : uid;
 
-  pwd->pw_name = add(&cursor, end, name);
-  pwd->pw_passwd = add(&cursor, end, password ? password : "*");
-  pwd->pw_gecos = add(&cursor, end, match->gecos ? match->gecos : "");
-  pwd->pw_shell = add(&cursor, end, (match->shell && *match->shell) ? match->shell : AU_DEFAULT_SHELL);
+	pwd->pw_name = add(&cursor, end, name);
+	pwd->pw_passwd = add(&cursor, end, password ? password : "*");
+	pwd->pw_gecos = add(&cursor, end, match->gecos ? match->gecos : "");
+	pwd->pw_shell = add(&cursor, end,
+			    (match->shell && *match->shell) ? match->shell :
+							      AU_DEFAULT_SHELL);
 
-  if (!cursor) return -1;
+	if (!cursor)
+		return -1;
 
-  if (match->home && *match->home && (flags & SR_FULL_DIR)) {
-    pwd->pw_dir = add(&cursor, end, match->home);
-    if (!cursor) return -1;
-  } else {
-    const char* home = (match->home && *match->home) ? match->home : "/home";
-    if (!cursor || snprintf(cursor, end - cursor, "%s/%s", home, name) >= end-cursor) {
-            return -1;
-    }
-    pwd->pw_dir = cursor;
-  }
+	if (match->home && *match->home && (flags & SR_FULL_DIR)) {
+		pwd->pw_dir = add(&cursor, end, match->home);
+		if (!cursor)
+			return -1;
+	} else {
+		const char *home =
+			(match->home && *match->home) ? match->home : "/home";
+		if (!cursor || snprintf(cursor, end - cursor, "%s/%s", home,
+					name) >= end - cursor) {
+			return -1;
+		}
+		pwd->pw_dir = cursor;
+	}
 
-  static_assert(
-    sizeof(uint32_t) == sizeof(uid_t),
-    "uid_t is not an uint32_t, printf casts uid_t to uint32_t");
+	static_assert(
+		sizeof(uint32_t) == sizeof(uid_t),
+		"uid_t is not an uint32_t, printf casts uid_t to uint32_t");
 
-  setenv("AUTOUSER_ORIGINAL", original, 1);
-  setenv("AUTOUSER_NAME", pwd->pw_name, 1);
-  setenv("AUTOUSER_SHELL", pwd->pw_shell, 1);
-  setenv("AUTOUSER_HOME", pwd->pw_dir, 1);
-  setenv("AUTOUSER_GECOS", pwd->pw_gecos, 1);
-  if (flags & SR_AUTO_GEN)
-    setenv("AUTOUSER_AUTOGEN", "true", 1);
-  else
-    setenv("AUTOUSER_AUTOGEN", "false", 1);
+	setenv("AUTOUSER_ORIGINAL", original, 1);
+	setenv("AUTOUSER_NAME", pwd->pw_name, 1);
+	setenv("AUTOUSER_SHELL", pwd->pw_shell, 1);
+	setenv("AUTOUSER_HOME", pwd->pw_dir, 1);
+	setenv("AUTOUSER_GECOS", pwd->pw_gecos, 1);
+	if (flags & SR_AUTO_GEN)
+		setenv("AUTOUSER_AUTOGEN", "true", 1);
+	else
+		setenv("AUTOUSER_AUTOGEN", "false", 1);
 
-  char ibuffer[32];
-  snprintf(ibuffer, sizeof(ibuffer), "%"PRIu32, (uint32_t)(pwd->pw_uid));
-  setenv("AUTOUSER_UID", ibuffer, 1);
-  snprintf(ibuffer, sizeof(ibuffer), "%"PRIu32, (uint32_t)(pwd->pw_gid));
-  setenv("AUTOUSER_GID", ibuffer, 1);
+	char ibuffer[32];
+	snprintf(ibuffer, sizeof(ibuffer), "%" PRIu32, (uint32_t)(pwd->pw_uid));
+	setenv("AUTOUSER_UID", ibuffer, 1);
+	snprintf(ibuffer, sizeof(ibuffer), "%" PRIu32, (uint32_t)(pwd->pw_gid));
+	setenv("AUTOUSER_GID", ibuffer, 1);
 
-  return 0;
+	return 0;
 }
 
-static void config_dump_match(autouser_config_t* config, autouser_match_t* match) {
-  mlog(config->debug, LOG_INFO, "config:   argv %s", match->argv);
-  mlog(config->debug, LOG_INFO, "config:   suffix %s", match->suffix);
-  mlog(config->debug, LOG_INFO, "config:   shell %s", match->shell);
-  mlog(config->debug, LOG_INFO, "config:   home %s", match->home);
-  mlog(config->debug, LOG_INFO, "config:   gecos %s", match->gecos);
-  mlog(config->debug, LOG_INFO, "config:   min_uid %" PRIu32, match->min_uid);
-  mlog(config->debug, LOG_INFO, "config:   max_uid %" PRIu32, match->max_uid);
-  mlog(config->debug, LOG_INFO, "config:   gid %" PRIu32, match->gid);
-  mlog(config->debug, LOG_INFO, "config:   flags %08x", match->flags);
+static void config_dump_match(autouser_config_t *config,
+			      autouser_match_t *match)
+{
+	mlog(config->debug, LOG_INFO, "config:   argv %s", match->argv);
+	mlog(config->debug, LOG_INFO, "config:   suffix %s", match->suffix);
+	mlog(config->debug, LOG_INFO, "config:   shell %s", match->shell);
+	mlog(config->debug, LOG_INFO, "config:   home %s", match->home);
+	mlog(config->debug, LOG_INFO, "config:   gecos %s", match->gecos);
+	mlog(config->debug, LOG_INFO, "config:   min_uid %" PRIu32,
+	     match->min_uid);
+	mlog(config->debug, LOG_INFO, "config:   max_uid %" PRIu32,
+	     match->max_uid);
+	mlog(config->debug, LOG_INFO, "config:   gid %" PRIu32, match->gid);
+	mlog(config->debug, LOG_INFO, "config:   flags %08x", match->flags);
 }
 
-static void config_dump(autouser_config_t* config) {
-  mlog(config->debug, LOG_INFO, "config: DebugLog %s", config->debug);
-  mlog(config->debug, LOG_INFO, "config: Seed %s", config->seed ? "(set but hidden)" : "(unset)");
-  for (int i = 0; i < config->matchn; ++i) {
-    mlog(config->debug, LOG_INFO, "config: Entry %d:", i);
-    config_dump_match(config, &config->match[i]);
-  }
+static void config_dump(autouser_config_t *config)
+{
+	mlog(config->debug, LOG_INFO, "config: DebugLog %s", config->debug);
+	mlog(config->debug, LOG_INFO, "config: Seed %s",
+	     config->seed ? "(set but hidden)" : "(unset)");
+	for (int i = 0; i < config->matchn; ++i) {
+		mlog(config->debug, LOG_INFO, "config: Entry %d:", i);
+		config_dump_match(config, &config->match[i]);
+	}
 }
 
 /* Return values are based on:
  *   https://www.gnu.org/software/libc/manual/html_node/NSS-Modules-Interface.html */
-enum nss_status _nss_autouser_getpwnam_r(
-    const char *name, struct passwd *pwd, char *buffer, size_t buflen, int *errnop) {
-  static thread_local bool nesting = false;
-  if (nesting) {
-    if (errnop) *errnop = 0;
-    return NSS_STATUS_NOTFOUND;
-  }
+enum nss_status _nss_autouser_getpwnam_r(const char *name, struct passwd *pwd,
+					 char *buffer, size_t buflen,
+					 int *errnop)
+{
+	static thread_local bool nesting = false;
+	if (nesting) {
+		if (errnop)
+			*errnop = 0;
+		return NSS_STATUS_NOTFOUND;
+	}
 
-  autouser_config_t config = {
-    .seed = NULL,
-  };
+	autouser_config_t config = {
+		.seed = NULL,
+	};
 
-  if (config_parse(AU_CONFIG_PATH, &config) < 0) { 
-    if (errnop) *errnop = ENOENT;
-    return NSS_STATUS_UNAVAIL;
-  }
+	if (config_parse(AU_CONFIG_PATH, &config) < 0) {
+		if (errnop)
+			*errnop = ENOENT;
+		return NSS_STATUS_UNAVAIL;
+	}
 
-  if (config.debug) config_dump(&config);
+	if (config.debug)
+		config_dump(&config);
 
-  int ierrno = 0; /* internal errno. */
-  int status = NSS_STATUS_SUCCESS;
-  const char *namedup = NULL, *original = name;
-  if (config.matchn <= 0) {
-    mlog(config.debug, LOG_ERR, "no rules specified in %s - disabled", AU_CONFIG_PATH);
-    ierrno = ENOENT;
-    status = NSS_STATUS_UNAVAIL;
-    goto exit;
-  }
+	int ierrno = 0; /* internal errno. */
+	int status = NSS_STATUS_SUCCESS;
+	const char *namedup = NULL, *original = name;
+	if (config.matchn <= 0) {
+		mlog(config.debug, LOG_ERR,
+		     "no rules specified in %s - disabled", AU_CONFIG_PATH);
+		ierrno = ENOENT;
+		status = NSS_STATUS_UNAVAIL;
+		goto exit;
+	}
 
-  if (process_argc <= 0 || process_argv == NULL || process_argv[0] == NULL) {
-    mlog(config.debug, LOG_ERR, "argv could not be detected - disabled - "
-		  "this often indicates a glibc incompatibility");
-    ierrno = ENOENT;
-    status = NSS_STATUS_UNAVAIL;
-    goto exit;
-  }
+	if (process_argc <= 0 || process_argv == NULL ||
+	    process_argv[0] == NULL) {
+		mlog(config.debug, LOG_ERR,
+		     "argv could not be detected - disabled - "
+		     "this often indicates a glibc incompatibility");
+		ierrno = ENOENT;
+		status = NSS_STATUS_UNAVAIL;
+		goto exit;
+	}
 
-  autouser_match_t match = {NULL};
-  int index = config_apply(&config, process_argv[0], name, &match);
+	autouser_match_t match = { NULL };
+	int index = config_apply(&config, process_argv[0], name, &match);
 
-  if (config.debug) {
-    mlog(config.debug, LOG_INFO, "computed configuration for user:'%s' process:'%s'", name, process_argv[0]);
-    config_dump_match(&config, &match);
-  }
+	if (config.debug) {
+		mlog(config.debug, LOG_INFO,
+		     "computed configuration for user:'%s' process:'%s'", name,
+		     process_argv[0]);
+		config_dump_match(&config, &match);
+	}
 
-  if (index >= 0) {
-    if (!match.min_uid && !match.max_uid && !match.gid) {
-      mlog(config.debug, LOG_WARNING, "user:%s has a policy that does not specify MinUid, MaxUid, nor Gid - ignoring", name);
-      ierrno = EINVAL;
-      status = NSS_STATUS_NOTFOUND;
-      goto exit;
-    }
+	if (index >= 0) {
+		if (!match.min_uid && !match.max_uid && !match.gid) {
+			mlog(config.debug, LOG_WARNING,
+			     "user:%s has a policy that does not specify MinUid, MaxUid, nor Gid - ignoring",
+			     name);
+			ierrno = EINVAL;
+			status = NSS_STATUS_NOTFOUND;
+			goto exit;
+		}
 
-    // Necessary as we can't shove a \0 in the middle of a user supplied buffer.
-    namedup = name = strndup(name, index);
+		// Necessary as we can't shove a \0 in the middle of a user supplied buffer.
+		namedup = name = strndup(name, index);
 
-    char tmpbuffer[buflen];
-    memset(tmpbuffer, 0, buflen);
+		char tmpbuffer[buflen];
+		memset(tmpbuffer, 0, buflen);
 
-    nesting = true;
-    struct passwd* result = NULL;
-    int gp = getpwnam_r(name, pwd, tmpbuffer, buflen, &result);
-    nesting = false;
+		nesting = true;
+		struct passwd *result = NULL;
+		int gp = getpwnam_r(name, pwd, tmpbuffer, buflen, &result);
+		nesting = false;
 
-    mlog(config.debug, LOG_DEBUG,
-	 "user:%s - setting config based on prefix - %p - %s", name, (void*)result, match.shell);
+		mlog(config.debug, LOG_DEBUG,
+		     "user:%s - setting config based on prefix - %p - %s", name,
+		     (void *)result, match.shell);
 
-    if (gp == 0 && result != NULL)  {
-      if (((match.min_uid || match.max_uid) && (result->pw_uid < match.min_uid || result->pw_uid > match.max_uid)) ||
-	  (match.gid && result->pw_gid != match.gid)) {
-        mlog(config.debug, LOG_INFO, "user:%s - refusing to apply policy - uid:%"PRIu32"or gid:%"PRIu32" not allowed", name, result->pw_uid, result->pw_gid);
-        ierrno = EINVAL;
-        status = NSS_STATUS_NOTFOUND;
-        goto exit;
-      }
+		if (gp == 0 && result != NULL) {
+			if (((match.min_uid || match.max_uid) &&
+			     (result->pw_uid < match.min_uid ||
+			      result->pw_uid > match.max_uid)) ||
+			    (match.gid && result->pw_gid != match.gid)) {
+				mlog(config.debug, LOG_INFO,
+				     "user:%s - refusing to apply policy - uid:%" PRIu32
+				     "or gid:%" PRIu32 " not allowed",
+				     name, result->pw_uid, result->pw_gid);
+				ierrno = EINVAL;
+				status = NSS_STATUS_NOTFOUND;
+				goto exit;
+			}
 
-      match.gid = result->pw_gid;
+			match.gid = result->pw_gid;
 
-      if (!match.shell || !*match.shell) match.shell = pwd->pw_shell;
-      if (!match.home || !*match.home) match.home = pwd->pw_dir;
-      if (!match.gecos || !*match.gecos) match.gecos = pwd->pw_gecos;
+			if (!match.shell || !*match.shell)
+				match.shell = pwd->pw_shell;
+			if (!match.home || !*match.home)
+				match.home = pwd->pw_dir;
+			if (!match.gecos || !*match.gecos)
+				match.gecos = pwd->pw_gecos;
 
-      const char* passwd = match.flags & MATCH_USE_PASSWORD ? pwd->pw_passwd : NULL;
-      if (store_result(original, name, result->pw_uid, &match, passwd, buffer, buflen, pwd, SR_FULL_DIR) != 0) {
-	mlog(config.debug, LOG_DEBUG, "user:%s - in suffix handler - buffer too small %zu, could not store result", name, buflen);
-        ierrno = ERANGE;
-        status = NSS_STATUS_TRYAGAIN;
-      }
+			const char *passwd = match.flags & MATCH_USE_PASSWORD ?
+						     pwd->pw_passwd :
+						     NULL;
+			if (store_result(original, name, result->pw_uid, &match,
+					 passwd, buffer, buflen, pwd,
+					 SR_FULL_DIR) != 0) {
+				mlog(config.debug, LOG_DEBUG,
+				     "user:%s - in suffix handler - buffer too small %zu, could not store result",
+				     name, buflen);
+				ierrno = ERANGE;
+				status = NSS_STATUS_TRYAGAIN;
+			}
 
-      goto exit;
-    }
-  }
+			goto exit;
+		}
+	}
 
-  /* Never ever allow a root UID. */
-  if (match.min_uid <= 0 || match.max_uid <= 0) {
-    mlog(config.debug, LOG_DEBUG, "%s - no uid set - ignoring", name);
-    /* Lookup and configuration was successful, but the configuration
+	/* Never ever allow a root UID. */
+	if (match.min_uid <= 0 || match.max_uid <= 0) {
+		mlog(config.debug, LOG_DEBUG, "%s - no uid set - ignoring",
+		     name);
+		/* Lookup and configuration was successful, but the configuration
      * tells us not to do anything for this user. */
-    ierrno = 0;
-    status = NSS_STATUS_NOTFOUND;
-    goto exit;
-  }
+		ierrno = 0;
+		status = NSS_STATUS_NOTFOUND;
+		goto exit;
+	}
 
-  uid_t uid = compute_uid(
-      config.seed ? config.seed : "default-seed", name,
-      match.min_uid, match.max_uid, AU_HASH_ATTEMPTS);
-  /* Never ever allow a root UID. 0 indicates failure. */
-  if (!uid) {
-    mlog(config.debug, LOG_ERR, "hashing '%s' generated clashing uids for %d times", name, AU_HASH_ATTEMPTS);
-    ierrno = ENOENT;
-    status = NSS_STATUS_NOTFOUND;
-    goto exit;
-  }
-  
-  uint32_t flags = match.flags & MATCH_USE_FULL_HOME ? SR_FULL_DIR : 0;
-  if (store_result(original, name, uid, &match, NULL, buffer, buflen, pwd, SR_AUTO_GEN | flags) != 0) {
-    mlog(config.debug, LOG_DEBUG, "in auto handler - could not store result for %s", name);
-    ierrno = ERANGE;
-    status = NSS_STATUS_TRYAGAIN;
-  }
+	uid_t uid =
+		compute_uid(config.seed ? config.seed : "default-seed", name,
+			    match.min_uid, match.max_uid, AU_HASH_ATTEMPTS);
+	/* Never ever allow a root UID. 0 indicates failure. */
+	if (!uid) {
+		mlog(config.debug, LOG_ERR,
+		     "hashing '%s' generated clashing uids for %d times", name,
+		     AU_HASH_ATTEMPTS);
+		ierrno = ENOENT;
+		status = NSS_STATUS_NOTFOUND;
+		goto exit;
+	}
+
+	uint32_t flags = match.flags & MATCH_USE_FULL_HOME ? SR_FULL_DIR : 0;
+	if (store_result(original, name, uid, &match, NULL, buffer, buflen, pwd,
+			 SR_AUTO_GEN | flags) != 0) {
+		mlog(config.debug, LOG_DEBUG,
+		     "in auto handler - could not store result for %s", name);
+		ierrno = ERANGE;
+		status = NSS_STATUS_TRYAGAIN;
+	}
 
 exit:
-  if (status == NSS_STATUS_SUCCESS) {
-    mlog(config.debug, LOG_DEBUG,
-	 "user:%s - status:%d errno:%d uid:%" PRIu32 " gid:%" PRIu32 " home:%s gecos:%s shell:%s",
-         name, status, ierrno, pwd->pw_uid, pwd->pw_gid, pwd->pw_dir, pwd->pw_gecos, pwd->pw_shell);
-  } else {
-    mlog(config.debug, LOG_DEBUG, "user:%s - status:%d errno:%d", name, status, ierrno);
-  }
+	if (status == NSS_STATUS_SUCCESS) {
+		mlog(config.debug, LOG_DEBUG,
+		     "user:%s - status:%d errno:%d uid:%" PRIu32 " gid:%" PRIu32
+		     " home:%s gecos:%s shell:%s",
+		     name, status, ierrno, pwd->pw_uid, pwd->pw_gid,
+		     pwd->pw_dir, pwd->pw_gecos, pwd->pw_shell);
+	} else {
+		mlog(config.debug, LOG_DEBUG, "user:%s - status:%d errno:%d",
+		     name, status, ierrno);
+	}
 
-  free((void*)namedup);
-  config_free(&config);
+	free((void *)namedup);
+	config_free(&config);
 
-  if (errnop) *errnop = ierrno;
-  return status;
+	if (errnop)
+		*errnop = ierrno;
+	return status;
 }
 
-static int load(int argc, char** argv, char** env) {
-  if (argv) process_argv = argv;
-  if (argc) process_argc = argc;
-  if (env) process_env = env;
-  return 0;
+static int load(int argc, char **argv, char **env)
+{
+	if (argv)
+		process_argv = argv;
+	if (argc)
+		process_argc = argc;
+	if (env)
+		process_env = env;
+	return 0;
 }
 
 /* According to ELF specification, .init_array contains a vector of functions
@@ -545,5 +656,6 @@ static int load(int argc, char** argv, char** env) {
  * glibc and a few other libraries provide those functions a pointer to the
  * original argc, argv, and env that was passed to the program.
  * We use this to our benefit. */
-__attribute__((section(".init_array"))) __attribute__((used))
-    static int (*init)(int argc, char** argv, char** env) = &load;
+__attribute__((section(".init_array")))
+__attribute__((used)) static int (*init)(int argc, char **argv,
+					 char **env) = &load;

--- a/proxy/nss/nss-autouser.h
+++ b/proxy/nss/nss-autouser.h
@@ -1,0 +1,40 @@
+#ifndef NSS_AUTOUSER_H
+# define NSS_AUTOUSER_H
+
+typedef enum {
+  // The path of the home directory is the full path, no need to append /$USER.
+  MATCH_USE_FULL_HOME = 1<<0,
+  MATCH_SET_FULL_HOME = 1<<1,
+
+  // If a user is found on the system already, keep the password configured on
+  // the system rather than disabling it.
+  MATCH_USE_PASSWORD = 1<<4,
+  MATCH_SET_PASSWORD = 1<<5,
+} match_flag_e;
+
+typedef struct autouser_config_s autouser_config_t;
+
+typedef struct {
+  const char* argv;
+  const char* suffix;
+
+  const char* shell;
+  const char* home;
+  const char* gecos;
+
+  uid_t min_uid;
+  uid_t max_uid;
+  gid_t gid;
+
+  uint32_t flags;
+} autouser_match_t;
+
+struct autouser_config_s {
+  const char* seed;
+  const char* debug;
+
+  autouser_match_t *match;
+  size_t matchn;
+};
+
+#endif

--- a/proxy/nss/nss-autouser.h
+++ b/proxy/nss/nss-autouser.h
@@ -1,40 +1,40 @@
 #ifndef NSS_AUTOUSER_H
-# define NSS_AUTOUSER_H
+#define NSS_AUTOUSER_H
 
 typedef enum {
-  // The path of the home directory is the full path, no need to append /$USER.
-  MATCH_USE_FULL_HOME = 1<<0,
-  MATCH_SET_FULL_HOME = 1<<1,
+	// The path of the home directory is the full path, no need to append /$USER.
+	MATCH_USE_FULL_HOME = 1 << 0,
+	MATCH_SET_FULL_HOME = 1 << 1,
 
-  // If a user is found on the system already, keep the password configured on
-  // the system rather than disabling it.
-  MATCH_USE_PASSWORD = 1<<4,
-  MATCH_SET_PASSWORD = 1<<5,
+	// If a user is found on the system already, keep the password configured on
+	// the system rather than disabling it.
+	MATCH_USE_PASSWORD = 1 << 4,
+	MATCH_SET_PASSWORD = 1 << 5,
 } match_flag_e;
 
 typedef struct autouser_config_s autouser_config_t;
 
 typedef struct {
-  const char* argv;
-  const char* suffix;
+	const char *argv;
+	const char *suffix;
 
-  const char* shell;
-  const char* home;
-  const char* gecos;
+	const char *shell;
+	const char *home;
+	const char *gecos;
 
-  uid_t min_uid;
-  uid_t max_uid;
-  gid_t gid;
+	uid_t min_uid;
+	uid_t max_uid;
+	gid_t gid;
 
-  uint32_t flags;
+	uint32_t flags;
 } autouser_match_t;
 
 struct autouser_config_s {
-  const char* seed;
-  const char* debug;
+	const char *seed;
+	const char *debug;
 
-  autouser_match_t *match;
-  size_t matchn;
+	autouser_match_t *match;
+	size_t matchn;
 };
 
 #endif

--- a/proxy/nss/nss-autouser_test.cc
+++ b/proxy/nss/nss-autouser_test.cc
@@ -1,0 +1,306 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <nss.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <fstream>
+
+extern "C" {
+#include "nss-autouser.h"
+
+extern uid_t compute_uid(const char* pseed, const char* name, uid_t min, uid_t max, int attempts);
+extern int suffix_index(const char* input, const char* suffix);
+extern int config_parse(const char* path, autouser_config_t* config);
+extern void config_free(autouser_config_t* config);
+extern int config_apply(const autouser_config_t* config, const char* process, const char* name, autouser_match_t *result);
+extern int store_result(const char* original, const char* name, uid_t uid, autouser_match_t* match, const char* password, char* buffer, size_t buflen, struct passwd* pwd, uint32_t flags);
+extern enum nss_status _nss_autouser_getpwnam_r(
+    const char *name, struct passwd *pwd, char *buffer, size_t buflen, int *errnop);
+}
+
+
+TEST(SuffixIndex, Basic) {
+  EXPECT_EQ(-1, suffix_index("foo", "bar"));
+  EXPECT_EQ(0, suffix_index("foo", "foo"));
+  EXPECT_EQ(1, suffix_index("foo", "oo"));
+  EXPECT_EQ(2, suffix_index("foo", "o"));
+  EXPECT_EQ(3, suffix_index("foo", ""));
+  EXPECT_EQ(0, suffix_index("", ""));
+  EXPECT_EQ(-1, suffix_index("", "baz"));
+  EXPECT_EQ(-1, suffix_index("foobazz", "baz"));
+  EXPECT_EQ(3, suffix_index("foobaz", "baz"));
+}
+
+TEST(ComputeUid, Basic) {
+  auto uid1 = compute_uid("test-seed", "test", 1, 100000, 10);
+  EXPECT_LE(1, uid1);
+  EXPECT_GE(100000, uid1);
+
+  auto uid2 = compute_uid("test-seed", "test", 1, 100000, 10);
+  EXPECT_EQ(uid1, uid2) << "same user, same seed, same uid expcted";
+
+  auto uid3 = compute_uid("tost-seed", "test", 1, 100000, 10);
+  EXPECT_NE(uid1, uid3) << "same user, different seed, different uid";
+}
+
+TEST(ComputeUid, Distribution) {
+  int distribution[10] = {0};
+  for (int i = 0; i < 1000; ++i) {
+    const auto& user = "fake-user-" + std::to_string(i);
+    const auto uid = compute_uid("seed", user.c_str(), 100000, 100009, 10);
+    EXPECT_LE(100000, uid);
+    EXPECT_GE(100009, uid);
+    ++distribution[uid - 100000];
+  }
+
+  for (const auto& dist : distribution) {
+    std::cerr << "VALUE " << dist << std::endl;
+  }
+
+  auto [min, max] = std::minmax_element(distribution, distribution + 10);
+  EXPECT_GE(15, *max - *min);
+  EXPECT_LE(90, *min);
+  EXPECT_GE(110, *max);
+}
+
+TEST(Config, ParseApplyFree) {
+  autouser_config_t config = {};
+
+  int status = config_parse("proxy/nss/testdata/empty.conf", &config);
+  EXPECT_EQ(0, status);
+  EXPECT_EQ(0, config.matchn);
+  EXPECT_EQ(NULL, config.match);
+  EXPECT_EQ(NULL, config.seed);
+  config_free(&config);
+
+  status = config_parse("proxy/nss/testdata/simple.conf", &config);
+  EXPECT_EQ(0, status);
+  EXPECT_STREQ("fuffa", config.seed);
+  ASSERT_EQ(1, config.matchn);
+  EXPECT_EQ(NULL, config.match[0].argv);
+  EXPECT_EQ(NULL, config.match[0].suffix);
+  EXPECT_EQ(NULL, config.match[0].shell);
+  EXPECT_EQ(NULL, config.match[0].home);
+  EXPECT_EQ(NULL, config.match[0].gecos);
+  EXPECT_EQ(70000, config.match[0].min_uid);
+  EXPECT_EQ(0xfffffff0, config.match[0].max_uid);
+  EXPECT_EQ(0, config.match[0].gid);
+  EXPECT_EQ(0x22, config.match[0].flags);
+
+  autouser_match_t result = {};
+  int offset = config_apply(&config, "ssh", "zarathustra", &result);
+  EXPECT_GT(0, offset);
+
+  EXPECT_EQ(NULL, result.argv);
+  EXPECT_EQ(NULL, result.suffix);
+  EXPECT_EQ(NULL, result.shell);
+  EXPECT_EQ(NULL, result.home);
+  EXPECT_EQ(NULL, result.gecos);
+  EXPECT_EQ(70000, result.min_uid);
+  EXPECT_EQ(0xfffffff0, result.max_uid);
+  EXPECT_EQ(0, result.gid);
+  EXPECT_EQ(0x22, result.flags);
+  config_free(&config);
+
+  status = config_parse("proxy/nss/testdata/advanced.conf", &config);
+  EXPECT_EQ(0, status);
+  EXPECT_STREQ("fuffa", config.seed);
+  ASSERT_EQ(6, config.matchn);
+
+  EXPECT_STREQ(NULL, config.match[0].argv);
+  EXPECT_STREQ(NULL, config.match[0].suffix);
+  EXPECT_STREQ(NULL, config.match[0].shell);
+  EXPECT_STREQ(NULL, config.match[0].home);
+  EXPECT_STREQ(NULL, config.match[0].gecos);
+  EXPECT_EQ(70000, config.match[0].min_uid);
+  EXPECT_EQ(0xfffffff0, config.match[0].max_uid);
+  EXPECT_EQ(1000, config.match[0].gid);
+  EXPECT_EQ(0x22, config.match[0].flags);
+
+  EXPECT_STREQ("sshd*", config.match[1].argv);
+  EXPECT_STREQ(NULL, config.match[1].suffix);
+  EXPECT_STREQ("/bin/docker-login", config.match[1].shell);
+  EXPECT_STREQ(NULL, config.match[1].home);
+  EXPECT_STREQ(NULL, config.match[1].gecos);
+  EXPECT_EQ(70000, config.match[1].min_uid);
+  EXPECT_EQ(0xfffffff1, config.match[1].max_uid);
+  EXPECT_EQ(0, config.match[1].gid);
+  EXPECT_EQ(0, config.match[1].flags);
+
+  EXPECT_STREQ("sshd*", config.match[2].argv);
+  EXPECT_STREQ(":system", config.match[2].suffix);
+  EXPECT_STREQ("/bin/bash", config.match[2].shell);
+  EXPECT_STREQ(NULL, config.match[2].home);
+  EXPECT_STREQ(NULL, config.match[2].gecos);
+  EXPECT_EQ(0, config.match[2].min_uid);
+  EXPECT_EQ(0, config.match[2].max_uid);
+  EXPECT_EQ(0, config.match[2].gid);
+  EXPECT_EQ(0, config.match[2].flags);
+
+  EXPECT_STREQ("sshd*", config.match[3].argv);
+  EXPECT_STREQ(":debug", config.match[3].suffix);
+
+  EXPECT_STREQ("login", config.match[4].argv);
+  EXPECT_STREQ(":system", config.match[4].suffix);
+
+  EXPECT_STREQ("login", config.match[5].argv);
+  EXPECT_STREQ(":debug", config.match[5].suffix);
+
+  result = autouser_match_t{};
+  offset = config_apply(&config, "sshdrive", "zarathustra", &result);
+  EXPECT_GT(0, offset);
+
+  EXPECT_STREQ("sshd*", result.argv);
+  EXPECT_STREQ(NULL, result.suffix);
+  EXPECT_STREQ("/bin/docker-login", result.shell);
+  EXPECT_STREQ(NULL, result.home);
+  EXPECT_STREQ(NULL, result.gecos);
+  EXPECT_EQ(70000, result.min_uid);
+  EXPECT_EQ(0xfffffff1, result.max_uid);
+  EXPECT_EQ(1000, result.gid);
+  EXPECT_EQ(0x22, result.flags);
+
+  result = autouser_match_t{};
+  offset = config_apply(&config, "sshdrive", "zara:system", &result);
+  EXPECT_EQ(4, offset);
+
+  EXPECT_STREQ("sshd*", result.argv);
+  EXPECT_STREQ(":system", result.suffix);
+  EXPECT_STREQ("/bin/bash", result.shell);
+  EXPECT_STREQ(NULL, result.home);
+  EXPECT_STREQ(NULL, result.gecos);
+  EXPECT_EQ(70000, result.min_uid);
+  EXPECT_EQ(0xfffffff1, result.max_uid);
+  EXPECT_EQ(1000, result.gid);
+  EXPECT_EQ(0x22, result.flags);
+
+  result = autouser_match_t{};
+  offset = config_apply(&config, "login", "zara:debug", &result);
+
+  EXPECT_STREQ("login", result.argv);
+  EXPECT_STREQ(":debug", result.suffix);
+  EXPECT_STREQ("/bin/tcpdump", result.shell);
+  EXPECT_STREQ(NULL, result.home);
+  EXPECT_STREQ(NULL, result.gecos);
+  EXPECT_EQ(70000, result.min_uid);
+  EXPECT_EQ(0xfffffff0, result.max_uid);
+  EXPECT_EQ(1000, result.gid);
+  EXPECT_EQ(0x22, result.flags);
+
+  config_free(&config);
+}
+
+TEST(Config, StoreResult) {
+  autouser_match_t match = {};
+  char buffer[1024];
+  struct passwd pwd = {};
+
+  // Purposedly short buffer, storing will fail.
+  EXPECT_GT(0, store_result("fooz", "foo", 1200, &match, NULL, buffer, 7, &pwd, 0));
+  EXPECT_STREQ(NULL, getenv("AUTOUSER_NAME"));
+  EXPECT_STREQ(NULL, getenv("AUTOUSER_SHELL"));
+  EXPECT_STREQ(NULL, getenv("AUTOUSER_HOME"));
+  EXPECT_STREQ(NULL, getenv("AUTOUSER_UID"));
+  EXPECT_STREQ(NULL, getenv("AUTOUSER_GID"));
+
+  // An empty match structure, will result in all defaults being used.
+  EXPECT_EQ(0, store_result("fooz", "foo", 1200, &match, NULL, buffer, 1024, &pwd, 0));
+  EXPECT_STREQ("fooz", getenv("AUTOUSER_ORIGINAL"));
+  EXPECT_STREQ("foo", getenv("AUTOUSER_NAME"));
+  EXPECT_STREQ("/bin/bash", getenv("AUTOUSER_SHELL"));
+  EXPECT_STREQ("/home/foo", getenv("AUTOUSER_HOME"));
+  EXPECT_STREQ("1200", getenv("AUTOUSER_UID"));
+  EXPECT_STREQ("1200", getenv("AUTOUSER_GID"));
+
+  EXPECT_STREQ("foo", pwd.pw_name);
+  EXPECT_STREQ("/bin/bash", pwd.pw_shell);
+  EXPECT_STREQ("/home/foo", pwd.pw_dir);
+  EXPECT_EQ(1200, pwd.pw_uid);
+  EXPECT_EQ(1200, pwd.pw_gid);
+  EXPECT_STREQ("*", pwd.pw_passwd);
+
+  // A match with some arbitrary values.
+  match = autouser_match_t{
+    .shell = "/bin/unabashed",
+    .home = "/tmp/goaway",
+    .gecos = "foo bar",
+    .gid = 42,
+  };
+  EXPECT_EQ(0, store_result("fooz", "foxy", 67, &match, NULL, buffer, 1024, &pwd, 0));
+  EXPECT_STREQ("foxy", getenv("AUTOUSER_NAME"));
+  EXPECT_STREQ("/bin/unabashed", getenv("AUTOUSER_SHELL"));
+  EXPECT_STREQ("/tmp/goaway/foxy", getenv("AUTOUSER_HOME"));
+  EXPECT_STREQ("67", getenv("AUTOUSER_UID"));
+  EXPECT_STREQ("42", getenv("AUTOUSER_GID"));
+
+  EXPECT_STREQ("foxy", pwd.pw_name);
+  EXPECT_STREQ("/bin/unabashed", pwd.pw_shell);
+  EXPECT_STREQ("/tmp/goaway/foxy", pwd.pw_dir);
+  EXPECT_EQ(67, pwd.pw_uid);
+  EXPECT_EQ(42, pwd.pw_gid);
+  EXPECT_STREQ("*", pwd.pw_passwd);
+
+  // Set password and full dir, annoyingly.
+  EXPECT_EQ(0, store_result("fooz", "foxy", 67, &match, "goo", buffer, 1024, &pwd, 1));
+  EXPECT_STREQ("goo", pwd.pw_passwd);
+  EXPECT_STREQ("/tmp/goaway", getenv("AUTOUSER_HOME"));
+  EXPECT_STREQ("/tmp/goaway", pwd.pw_dir);
+}
+
+TEST(Config, GetpwnamR) {
+  const auto config = R"""(
+Seed test
+
+MinUid 7000
+MaxUid 8000
+
+Suffix :system
+  Shell /bin/bash
+
+Suffix :ducker
+  Shell /bin/docker-login
+
+Suffix :docker
+  MinUid 1
+  MaxUid 1000
+  Shell /bin/docker-login
+)""";
+  
+  struct passwd pwd = {};
+  char buffer[1024] = {};
+  int err = 0;
+  auto status = _nss_autouser_getpwnam_r("bin", &pwd, buffer, 1024, &err);
+  EXPECT_EQ(NSS_STATUS_UNAVAIL, status);
+  EXPECT_EQ(ENOENT, err);
+
+  std::ofstream file("./nss-autouser.conf");
+  file << config;
+  file.close();
+
+  status = _nss_autouser_getpwnam_r("bin:ducker", &pwd, buffer, 1024, &err);
+  EXPECT_EQ(NSS_STATUS_NOTFOUND, status);
+  EXPECT_EQ(EINVAL, err);
+
+  status = _nss_autouser_getpwnam_r("bin:docker", &pwd, buffer, 1024, &err);
+  EXPECT_EQ(NSS_STATUS_SUCCESS, status);
+  EXPECT_EQ(0, err);
+
+  EXPECT_STREQ("bin", pwd.pw_name);
+  EXPECT_STREQ("/bin/docker-login", pwd.pw_shell);
+  EXPECT_STREQ("/bin", pwd.pw_dir);
+  EXPECT_EQ(2, pwd.pw_uid);
+  EXPECT_EQ(2, pwd.pw_gid);
+  EXPECT_STREQ("*", pwd.pw_passwd);
+
+  status = _nss_autouser_getpwnam_r("fueller", &pwd, buffer, 1024, &err);
+  EXPECT_EQ(NSS_STATUS_SUCCESS, status);
+  EXPECT_EQ(0, err);
+
+  EXPECT_STREQ("fueller", pwd.pw_name);
+  EXPECT_STREQ("/bin/bash", pwd.pw_shell);
+  EXPECT_STREQ("/home/fueller", pwd.pw_dir);
+  EXPECT_EQ(7776, pwd.pw_uid);
+  EXPECT_EQ(7776, pwd.pw_gid);
+  EXPECT_STREQ("*", pwd.pw_passwd);
+}

--- a/proxy/nss/testdata/advanced.conf
+++ b/proxy/nss/testdata/advanced.conf
@@ -1,0 +1,30 @@
+# Just a single default configuration for all
+# users and processes.
+
+Seed fuffa
+
+MinUid 70000
+MaxUid 0xfffffff0
+Gid 1000
+
+FullHomePath false
+PropagatePassword false
+
+Match sshd*
+  MinUid 70000
+  MaxUid 0xfffffff1
+  Shell /bin/docker-login
+  
+  Suffix :system
+    Shell /bin/bash
+
+  Suffix :debug
+    Shell /bin/tcpdump
+
+Match login
+  Suffix :system
+    Shell /bin/bash
+
+  Suffix :debug
+    Shell /bin/tcpdump
+

--- a/proxy/nss/testdata/simple.conf
+++ b/proxy/nss/testdata/simple.conf
@@ -1,0 +1,10 @@
+# Just a single default configuration for all
+# users and processes.
+
+Seed fuffa
+
+MinUid 70000
+MaxUid 0xfffffff0
+
+FullHomePath false
+PropagatePassword false


### PR DESCRIPTION
This PR introduces:

- libnss-autouser, an nsswitch.conf module to allow automated
  creation of users at login with ssh certificates.

- confparse, a small library for parsing ssh like configuration
  files in C.