### PR TITLE
add in correct parse public key, not using wire format

### DIFF
--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -43,7 +43,7 @@ func (s *Server) HostCertificate(ctx context.Context, request *auth.HostCertific
 	if b == nil {
 		return nil, errors.New("the public key was empty, or was an invlaid block")
 	}
-	pubKey, err := ssh.ParsePublicKey(b.Bytes)
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(b.Bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 			}, nil
 		}
 		// If the ca signer was present, continuing with public keys.
-		savedPubKey, err := ssh.ParsePublicKey(b.Bytes)
+		savedPubKey, _, _, _, err := ssh.ParseAuthorizedKey(b.Bytes)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Corrects mistake where the public key was being deserialized using the wrong method. 