### PR TITLE
astore/server/auth/auth_test.go: make it work again.

### DIFF
--- a/astore/server/auth/BUILD.bazel
+++ b/astore/server/auth/BUILD.bazel
@@ -29,6 +29,9 @@ go_test(
     deps = [
         "//astore/common:go_default_library",
         "//astore/rpc:auth-go",
+        "//lib/cache:go_default_library",
+        "//lib/kcerts:go_default_library",
+        "//lib/logger:go_default_library",
         "//lib/oauth:go_default_library",
         "//lib/srand:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -124,24 +124,24 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 		if _, err := io.ReadFull(s.rng, nonce[:]); err != nil {
 			return nil, status.Errorf(codes.Internal, "could not generate nonce - %s", err)
 		}
-		b, _ := pem.Decode(req.Publickey)
+
 		// If the ca signer is nil that means the CA was never passed in flags, if the request never sent a public key
 		// then so ssh certs will be sent back.
-		if s.caSigner == nil || b == nil {
+		if s.caSigner == nil || len(req.Publickey) <= 0 {
 			return &auth.TokenResponse{
 				Nonce: nonce[:],
 				Token: box.Seal(nil, []byte(authData.Cookie), &nonce, (*[32]byte)(clientPub), (*[32]byte)(s.serverPriv)),
 			}, nil
 		}
 		// If the ca signer was present, continuing with public keys.
-		savedPubKey, _, _, _, err := ssh.ParseAuthorizedKey(b.Bytes)
+		savedPubKey, _, _, _, err := ssh.ParseAuthorizedKey(req.Publickey)
 		if err != nil {
-			return nil, err
+			return nil, status.Errorf(codes.InvalidArgument, "PublicKey cannot be parsed as an ssh authorized key - %s", err)
 		}
 		effectivePrincipals := append(s.principals, authData.Creds.Identity.Username)
 		userCert, err := kcerts.SignPublicKey(s.caSigner, ssh.UserCert, effectivePrincipals, s.userCertTTL, savedPubKey)
 		if err != nil {
-			return nil, fmt.Errorf("error generating certificates: %w", err)
+			return nil, status.Errorf(codes.Internal, "error signing key - %s", err)
 		}
 		return &auth.TokenResponse{
 			Nonce:       nonce[:],

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -3,6 +3,7 @@ package kcerts
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/ed25519"
 	"fmt"
 	"github.com/enfabrica/enkit/lib/cache"
 	"github.com/enfabrica/enkit/lib/logger"
@@ -100,7 +101,11 @@ func (a SSHAgent) Valid() bool {
 	return err == nil
 }
 
-func (a SSHAgent) AddCertificates(privateKey *rsa.PrivateKey, publicKey ssh.PublicKey, ttl uint32) error {
+// AddCertificates loads an ssh certificate into the agent.
+// privateKey must be a key type accepted by the golang.org/x/ssh/agent AddedKey struct.
+// At time of writing, this can be: *rsa.PrivateKey, *dsa.PrivateKey, ed25519.PrivateKey or *ecdsa.PrivateKey.
+// Note that ed25519.PrivateKey should be passed by value.
+func (a SSHAgent) AddCertificates(privateKey interface{}, publicKey ssh.PublicKey, ttl uint32) error {
 	conn, err := net.Dial("unix", a.Socket)
 	if err != nil {
 		return err
@@ -186,39 +191,68 @@ func CreateNewSSHAgent() (*SSHAgent, error) {
 	return s, nil
 }
 
-// GenerateUserSSHCert will sign and return credentials based on the CA signer and given parameters
-// to generate a user cert, certType must be 1, and host certs ust have certType 2
-func GenerateUserSSHCert(ca ssh.Signer, certType uint32, principals []string, ttl time.Duration) (*rsa.PrivateKey, *ssh.Certificate, error) {
-	priv, pub, err := MakeKeys()
+// KeyGenerator is A function capable of generating a key pair.
+//
+// The function is expected to return a Public Key, a Private Key,
+// and an error.
+//
+// Only keys supported by x/crypto/ssh.NewPublicKey are supported.
+type KeyGenerator func() (interface{}, interface{}, error)
+
+// MakeKeys uses the speficied key generator to create a pair of ssh keys.
+//
+// The first return value is a marshalled version of the public key,
+// a binary blob suitable for transmission.
+// The second return value is the private key in the original format.
+// This is generally directly usable with functions like agent.Add.
+func MakeKeys(generator KeyGenerator) ([]byte, interface{}, error) {
+	public, private, err := generator()
 	if err != nil {
-		return priv, nil, err
-	}
-	from := time.Now().UTC()
-	to := time.Now().UTC().Add(ttl * time.Hour)
-	cert := &ssh.Certificate{
-		CertType:        certType,
-		Key:             pub,
-		ValidAfter:      uint64(from.Unix()),
-		ValidBefore:     uint64(to.Unix()),
-		ValidPrincipals: principals,
-		Permissions:     ssh.Permissions{},
-	}
-	if err := cert.SignCert(rand.Reader, ca); err != nil {
 		return nil, nil, err
 	}
-	return priv, cert, nil
+
+	encoded, err := EncodePublicKey(public)
+	if err != nil {
+		return nil, nil, err
+	}
+	return encoded, private, nil
 }
 
-func MakeKeys() (*rsa.PrivateKey, ssh.PublicKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+func EncodePublicKey(key interface{}) ([]byte, error) {
+	pubKey, err := ssh.NewPublicKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return ssh.MarshalAuthorizedKey(pubKey), nil
+}
+
+func GenerateRSA() (interface{}, interface{}, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, nil, err
 	}
-	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
-	if err != nil {
-		return nil, nil, err
+	return &privateKey.PublicKey, privateKey, err
+}
+
+func GenerateED25519() (interface{}, interface{}, error) {
+	return ed25519.GenerateKey(rand.Reader)
+}
+
+var GenerateDefault = GenerateED25519;
+
+// SelectGenerator returns a different generator based on the specified string.
+//
+// Currently it accepts "rsa", or "ed25519".
+func SelectGenerator(name string) KeyGenerator {
+	name = strings.ToLower(name)
+	if name == "rsa" {
+		return GenerateRSA
 	}
-	return privateKey, publicKey, err
+	if name == "ed25519" {
+		return GenerateED25519
+	}
+	return nil
 }
 
 // SignPublicKey will sign and return credentials based on the CA signer and given parameters


### PR DESCRIPTION
With recent changes to generate keys client side, and have them
signed by the server only, auth_test.go broke.

The new interface supported RSA keys only, while the test
verified ed25519 as well. I had two choices, either:
1) drop ed25519 support
2) do the minimal amount of work to have ed25519 supported.

I went for the latter route. This means:
- don't PEM encode the key in the client <-> server communication.
  The ssh library is already marshalling them. This simplifies
  the code, as there is no PEM encoding supported by ssh
  for ed25519 keys at this point (eg, ssh-keygen -e -m PEM -f ed-key
  will fail with an error like 'unsupported key format').

- change the interfaces so that some generics are passed
  around. This is more error prone, as the golang compiler
  can no longer warn us about a few errors, but it's in
  par with what the ssh library does internally.

- additionally, increased the default RSA key length.

A separate PR will allow to pick the default for the key
used, and likely change it to ed25519.