### PR TITLE
[bugfix]: pam_script_acct should exit 0 if autouser is not involved.

### DIFF
--- a/proxy/nss/configs/pam_script_acct
+++ b/proxy/nss/configs/pam_script_acct
@@ -15,6 +15,10 @@ function error() {
 # Failure exit will cause PAM to fail login.
 set -e
 
+test "$AUTOUSER_AUTOGEN" == "true" || {
+  exit 0 # nothing to do.
+}
+
 test -n "$PAM_USER" -a -n "$AUTOUSER_ORIGINAL" -a -n "$AUTOUSER_AUTOGEN" || {
   error "User creation script invoked without all the environment variables."
 }
@@ -25,10 +29,6 @@ test "$PAM_USER" == "$AUTOUSER_ORIGINAL" || {
 
 test "$PAM_SERVICE" == "sshd" || {
   error "User creation script invoked for non-ssh login"
-}
-
-test "$AUTOUSER_AUTOGEN" == "true" || {
-  exit 0 # nothing to do.
 }
 
 # If there is a one GID per user policy, implement it.


### PR DESCRIPTION
Before this change: if AUTOUSER NSS was not involved with the login
of a user, the pam script would fail. This would cause existing users
in the normal passwd file to not be able to log in.

After this change: if AUTOUSER NSS was not involved with the login,
exit 0, to let pam continue with whatever it is doing, rather than
kicking the user out.