### PR TITLE
kbuild: update custom archive script for use with enf kernel builds

### DIFF
--- a/kbuild/utils/generate_custom_archive.sh
+++ b/kbuild/utils/generate_custom_archive.sh
@@ -6,18 +6,39 @@
 
 usage()
 {
-        cat <<EOF
-Generate a kbuild compliant .tar.gz starting from a compiled custom linux source tree.
-usage: ${0##*/} OPTS
-    -k KDIR      Directory containing the compiled custom linux source tree
-    -t OUTDIR    Root directory for containing the generated kernel package
-    -v KVER      Kernel version (used to name the package)
-This will generate a KVER.tar.gz file inside OUTDIR, built from the pre-compiled kernel in KDIR.
-The pre-compiled kernel is expected to have been obtained by:
+	cat <<EOF
+Generate a kbuild compliant .tar.gz starting from a compiled custom Linux source tree.
+
+USAGE:
+    ${0##*/} -k KDIR -t OUTDIR [-v KVER] [-c KCONFIG]
+
+OPTIONS:
+    -k KDIR
+	Build directory containing the compiled Linux tree.
+
+    -t OUTDIR
+	Root directory for containing the generated kernel package.
+
+    -v KVER
+	Optional. Kernel version (used to name the package).  The
+	default is to use the kernel version found in the compiled
+	kernel build directory.
+
+    -c KCONFIG
+	Optional. Kernel config file, relative to kernel build
+	directory.  The default is to use ".config".
+
+DESCRIPTION:
+
+This command will generate a tar archive inside OUTDIR, built from the
+pre-compiled kernel in KDIR.  The pre-compiled kernel is expected to
+have been obtained by:
+
 1. Downloading kernel source code from somewhere into KDIR
 2. export ARCH=x
 3. cd KDIR && make defconfig && make menuconfig # Enable/disable stuff.
 4. make
+
 EOF
 }
 
@@ -53,42 +74,58 @@ exit 1
 EOF
 }
 
-while getopts ":k:t:v:h" o
+KCONFIG=".config"
+
+while getopts ":k:t:v:c:h" o
 do
         case $o in
                 k) SRCDIR="$OPTARG";;
                 t) INSTALLDIR="$OPTARG";;
                 v) KERNELVERSION="$OPTARG";;
+                c) KCONFIG="$OPTARG";;
                 h) usage; exit 0;;
-                *) usage; exit 1;;
+                *) echo "Error: Unknown argument."; usage; exit 1;;
         esac
 done
 
-if ! [[ -v SRCDIR ]] || ! [[ -v INSTALLDIR ]] || ! [[ -v KERNELVERSION ]];
+if ! [[ -v SRCDIR ]] || ! [[ -v INSTALLDIR ]];
 then
 	usage
 	exit 1
 fi
 
+set -e
+
 SRCDIR=$(realpath -s "$SRCDIR")
+
+if ! [[ -v KERNELVERSION ]];
+then
+	KERNELVERSION=$(cat "${SRCDIR}/include/config/kernel.release")
+fi
+
+RT_KCONFIG="${SRCDIR}/$KCONFIG"
+if ! [[ -r $RT_KCONFIG ]];
+then
+	echo "Error: Unable to find kernel config '$KCONFIG' in kernel build directory."
+	usage
+	exit 1
+fi
+
 INSTALLDIR=$(realpath -s "$INSTALLDIR")
 TARGETDIR="${INSTALLDIR}/usr/src/linux-headers-${KERNELVERSION}"
 SCRIPTNAME="install-${KERNELVERSION}.sh"
 
-set -e
-mkdir -p "${TARGETDIR}/arch"
-mkdir -p "${TARGETDIR}/include"
-mkdir -p "${TARGETDIR}/scripts"
-mkdir -p "${TARGETDIR}/tools"
+rm -rf "$INSTALLDIR"
+mkdir -p "${TARGETDIR}"
 mkdir -p "${INSTALLDIR}/lib/modules/${KERNELVERSION}/build"
 
 generate_install_script "${INSTALLDIR}/${SCRIPTNAME}"
-chmod 755 ${INSTALLDIR}/${SCRIPTNAME}
-cp -r $SRCDIR/scripts/* $TARGETDIR/scripts/
-cp -r $SRCDIR/tools/* $TARGETDIR/tools/
-cp -r $SRCDIR/arch/* $TARGETDIR/arch/
-cp -r $SRCDIR/include/* $TARGETDIR/include/
-cp -r $SRCDIR/Makefile $SRCDIR/.config $SRCDIR/Module.symvers $TARGETDIR/
+chmod 755 "${INSTALLDIR}/${SCRIPTNAME}"
+for d in scripts tools arch include ; do
+	cp -a "$SRCDIR/${d}" "$TARGETDIR/"
+done
+cp -a "$SRCDIR/Makefile" "$SRCDIR/Module.symvers" "$TARGETDIR/"
+cp -a "$RT_KCONFIG" "$TARGETDIR/.config"
 (
 	cd "$INSTALLDIR"
 	tar -czvf "${KERNELVERSION}.tar.gz" "${SCRIPTNAME}" "usr" "lib"


### PR DESCRIPTION
The Enfabrica kernel build separates the kernel config from the kernel
build output directory.  Previously, the archive script assumed the
kernel config had a specific path.  Thus the archive script and
Enfabrica kernel build layout were incompatible.

The change here is to add an option to the archive script to specify
the path of the kernel config.  The default maintains the previous
behaviour, assuming ".config" in the kernel build directory.

Also the kernel version parameter is now optional.  If not specified
the kernel version is taken from the kernel build directory, from
${SRCDIR}/include/config/kernel.release.

Signed-off-by: Curt Brune <curt@enfabrica.net>