### PR TITLE
Fixes HostCert Invalid

### DIFF
--- a/astore/server/auth/factory.go
+++ b/astore/server/auth/factory.go
@@ -117,7 +117,9 @@ func WithCA(fileContent []byte) Modifier {
 func WithPrincipals(raw string) Modifier {
 	return func(server *Server) error {
 		splitString := strings.Split(raw, ",")
-		server.principals = splitString
+		if len(splitString) >= 1 && splitString[0] != "" {
+			server.principals = splitString
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
If no principals were specified, it would add []string{""} to principals instead of an empty string. This would lead to the certificate containing "", and the valid username. 

While this didn't affect functionality (since its invalid) just removes some dirty output from sshd since it causes some wonky errors. 