### PR TITLE
Fix compat issue with future auth-server release

### DIFF
--- a/lib/kauth/login.go
+++ b/lib/kauth/login.go
@@ -2,7 +2,6 @@ package kauth
 
 import (
 	"context"
-	"encoding/pem"
 	"fmt"
 	"github.com/enfabrica/enkit/astore/common"
 	"github.com/enfabrica/enkit/astore/rpc/auth"
@@ -71,7 +70,7 @@ func PerformLogin(authClient auth.AuthClient, l logger.Logger, repeater *retry.O
 	}
 	treq := &auth.TokenRequest{
 		Url:       ares.Url,
-		Publickey: pem.EncodeToMemory(&pem.Block{Type: "EC PUBLIC KEY", Bytes: ssh.MarshalAuthorizedKey(sshPub)}),
+		Publickey: ssh.MarshalAuthorizedKey(sshPub),
 	}
 	var tres *auth.TokenResponse
 	if err := repeater.Run(func() error {


### PR DESCRIPTION
So since this got change to not be pem encoded:
https://github.com/enfabrica/enkit/blob/master/astore/server/auth/auth.go#L137 

This change is needed in order to be compatible. The code without this fix works with the current version of auth. Not sure if we want this to be cross compatible or not (e.g. retry with pem encoded).  