### PR TITLE
bugfix: allow the generated certs to allocate a pty.

### DIFF
--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -192,6 +192,19 @@ func CreateNewSSHAgent() (*SSHAgent, error) {
 // SignPublicKey will sign and return credentials based on the CA signer and given parameters
 // to generate a user cert, certType must be 1, and host certs ust have certType 2
 func SignPublicKey(p PrivateKey, certType uint32, principals []string, ttl time.Duration, pub ssh.PublicKey) (*ssh.Certificate, error) {
+	// OpenSSH controls what the key allows through extensions.
+	// See https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys
+	var extensions map[string]string
+	if certType == 1 {
+		extensions = map[string]string{
+			"permit-agent-forwarding": "",
+			"permit-x11-forwarding":   "",
+			"permit-port-forwarding":  "",
+			"permit-pty":              "",
+			"permit-user-rc":          "",
+		}
+	}
+
 	from := time.Now().UTC()
 	to := time.Now().UTC().Add(ttl * time.Hour)
 	cert := &ssh.Certificate{
@@ -200,7 +213,9 @@ func SignPublicKey(p PrivateKey, certType uint32, principals []string, ttl time.
 		ValidAfter:      uint64(from.Unix()),
 		ValidBefore:     uint64(to.Unix()),
 		ValidPrincipals: principals,
-		Permissions:     ssh.Permissions{},
+		Permissions: ssh.Permissions{
+			Extensions: extensions,
+		},
 	}
 	s, err := NewSigner(p)
 	if err != nil {


### PR DESCRIPTION
Background:
OpenSSH server (and this is an OpenSSH feature - other servers
don't necessarily implement it) allows the certificate to specify
what the user can and cannot do on the remote host.
Eg, can agent forwarding be used? can a pty be allocated?

This PR enables all extensions in ssh.