### PR TITLE
Fix SSHD Weirdness on HostKeys

### DIFF
--- a/lib/kcerts/BUILD.bazel
+++ b/lib/kcerts/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//lib/cache:go_default_library",
         "//lib/config/marshal:go_default_library",
+        "//lib/kcerts/ked25519:go_default_library",
         "//lib/logger:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
         "@org_golang_x_crypto//ssh:go_default_library",

--- a/lib/kcerts/ked25519/BUILD.bazel
+++ b/lib/kcerts/ked25519/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cert.go"],
+    importpath = "github.com/enfabrica/enkit/lib/kcerts/ked25519",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_crypto//ed25519:go_default_library",
+        "@org_golang_x_crypto//ssh:go_default_library",
+    ],
+)

--- a/lib/kcerts/ked25519/LICENSE
+++ b/lib/kcerts/ked25519/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Michael Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/kcerts/ked25519/cert.go
+++ b/lib/kcerts/ked25519/cert.go
@@ -46,7 +46,6 @@ func MarshalED25519PrivateKey(key ed25519.PrivateKey) []byte {
 	// Add the pubkey to the optionally-encrypted block
 	pk, ok := key.Public().(ed25519.PublicKey)
 	if !ok {
-		//fmt.Fprintln(os.Stderr, "ed25519.PublicKey type assertion failed on an ed25519 public key. This should never ever happen.")
 		return nil
 	}
 	pubKey := []byte(pk)

--- a/lib/kcerts/ked25519/cert.go
+++ b/lib/kcerts/ked25519/cert.go
@@ -1,0 +1,87 @@
+package ked25519ackage
+
+import (
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/ssh"
+	"math/rand"
+)
+// Copied from https://github.com/mikesmitty/edkey/blob/master/edkey.go
+/* Writes ed25519 private keys into the new OpenSSH private key format.
+I have no idea why this isn't implemented anywhere yet, you can do seemingly
+everything except write it to disk in the OpenSSH private key format. */
+func MarshalED25519PrivateKey(key ed25519.PrivateKey) []byte {
+	// Add our key header (followed by a null byte)
+	magic := append([]byte("openssh-key-v1"), 0)
+
+	var w struct {
+		CipherName   string
+		KdfName      string
+		KdfOpts      string
+		NumKeys      uint32
+		PubKey       []byte
+		PrivKeyBlock []byte
+	}
+
+	// Fill out the private key fields
+	pk1 := struct {
+		Check1  uint32
+		Check2  uint32
+		Keytype string
+		Pub     []byte
+		Priv    []byte
+		Comment string
+		Pad     []byte `ssh:"rest"`
+	}{}
+
+	// Set our check ints
+	ci := rand.Uint32()
+	pk1.Check1 = ci
+	pk1.Check2 = ci
+
+	// Set our key type
+	pk1.Keytype = ssh.KeyAlgoED25519
+
+	// Add the pubkey to the optionally-encrypted block
+	pk, ok := key.Public().(ed25519.PublicKey)
+	if !ok {
+		//fmt.Fprintln(os.Stderr, "ed25519.PublicKey type assertion failed on an ed25519 public key. This should never ever happen.")
+		return nil
+	}
+	pubKey := []byte(pk)
+	pk1.Pub = pubKey
+
+	// Add our private key
+	pk1.Priv = []byte(key)
+
+	// Might be useful to put something in here at some point
+	pk1.Comment = ""
+
+	// Add some padding to match the encryption block size within PrivKeyBlock (without Pad field)
+	// 8 doesn't match the documentation, but that's what ssh-keygen uses for unencrypted keys. *shrug*
+	bs := 8
+	blockLen := len(ssh.Marshal(pk1))
+	padLen := (bs - (blockLen % bs)) % bs
+	pk1.Pad = make([]byte, padLen)
+
+	// Padding is a sequence of bytes like: 1, 2, 3...
+	for i := 0; i < padLen; i++ {
+		pk1.Pad[i] = byte(i + 1)
+	}
+
+	// Generate the pubkey prefix "\0\0\0\nssh-ed25519\0\0\0 "
+	prefix := []byte{0x0, 0x0, 0x0, 0x0b}
+	prefix = append(prefix, []byte(ssh.KeyAlgoED25519)...)
+	prefix = append(prefix, []byte{0x0, 0x0, 0x0, 0x20}...)
+
+	// Only going to support unencrypted keys for now
+	w.CipherName = "none"
+	w.KdfName = "none"
+	w.KdfOpts = ""
+	w.NumKeys = 1
+	w.PubKey = append(prefix, pubKey...)
+	w.PrivKeyBlock = ssh.Marshal(pk1)
+
+	magic = append(magic, ssh.Marshal(w)...)
+
+	return magic
+}

--- a/lib/kcerts/ked25519/cert.go
+++ b/lib/kcerts/ked25519/cert.go
@@ -9,6 +9,8 @@ import (
 /* Writes ed25519 private keys into the new OpenSSH private key format.
 I have no idea why this isn't implemented anywhere yet, you can do seemingly
 everything except write it to disk in the OpenSSH private key format. */
+
+// MarshalED25519PrivateKey writes ed25519 private keys into the new OpenSSH private key format.
 func MarshalED25519PrivateKey(key ed25519.PrivateKey) []byte {
 	// Add our key header (followed by a null byte)
 	magic := append([]byte("openssh-key-v1"), 0)

--- a/lib/kcerts/keys.go
+++ b/lib/kcerts/keys.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"github.com/enfabrica/enkit/lib/kcerts/ked25519"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -32,11 +33,7 @@ func (e ed25519Provider) Signer() crypto.Signer {
 }
 
 func (e ed25519Provider) SSHPemEncode() ([]byte, error) {
-	res, err := x509.MarshalPKCS8PrivateKey(e.rawKey)
-	if err != nil {
-		return nil, err
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: res}), nil
+	return pem.EncodeToMemory(&pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: ked25519ackage.MarshalED25519PrivateKey(e.rawKey)}), nil
 }
 
 func (e ed25519Provider) Raw() interface{} {

--- a/lib/knetwork/BUILD.bazel
+++ b/lib/knetwork/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["ports.go", "shutdown.go"],
+    srcs = [
+        "ports.go",
+        "shutdown.go",
+    ],
     importpath = "github.com/enfabrica/enkit/lib/knetwork",
     visibility = ["//visibility:public"],
 )

--- a/lib/knetwork/BUILD.bazel
+++ b/lib/knetwork/BUILD.bazel
@@ -2,10 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "ports.go",
-        "shutdown.go",
-    ],
+    srcs = ["ports.go", "shutdown.go"],
     importpath = "github.com/enfabrica/enkit/lib/knetwork",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Right Now, if you ssh encode a ed25519 private key, it is invalid in sshd, but not ssh for some reason. 

Needs investigation, but this works with sshd. 