### PR TITLE
Revert org_golang_google_grpc to v1.32.0

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -2151,8 +2151,8 @@ def go_repositories():
     go_repository(
         name = "org_golang_google_grpc",
         importpath = "google.golang.org/grpc",
-        sum = "h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=",
-        version = "v1.36.0",
+        sum = "h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=",
+        version = "v1.32.0",
     )
 
     go_repository(


### PR DESCRIPTION
Upgrading the go_repo to v1.36.0 as part of the introduction of the license manager caused a regression that broke the container_image bazel rule as seen here https://github.com/enfabrica/enkit/commit/f78c01ce3cedb6247d2d90a0e73d7a698148faee. If I remember correctly, running `bazel run //:gazelle` updated a bunch of go repos automatically.