### PR TITLE
Hotfix Change Multiplier on Cert TTL

### DIFF
--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -239,8 +239,8 @@ func SignPublicKey(p PrivateKey, certType uint32, principals []string, ttl time.
 		}
 	}
 
-	from := time.Now().UTC()
-	to := time.Now().UTC().Add(ttl * time.Hour)
+	from := time.Now()
+	to := time.Now().Add(ttl)
 	cert := &ssh.Certificate{
 		CertType:        certType,
 		Key:             pub,


### PR DESCRIPTION
I think this was a legacy piece of code that got checked in