### PR TITLE
lib/token: allow to extract the issued time.

### DIFF
--- a/lib/oauth/cli/BUILD.bazel
+++ b/lib/oauth/cli/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/lib/oauth/cli",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib/kflags:go_default_library",
+        "//lib/kflags/kcobra:go_default_library",
+        "//lib/oauth:go_default_library",
+        "//lib/srand:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "enauth",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/lib/oauth/cli/main.go
+++ b/lib/oauth/cli/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"github.com/enfabrica/enkit/lib/kflags"
+	"github.com/enfabrica/enkit/lib/kflags/kcobra"
+	"github.com/enfabrica/enkit/lib/oauth"
+	"github.com/enfabrica/enkit/lib/srand"
+	"github.com/spf13/cobra"
+	"math/rand"
+	"os"
+	"time"
+)
+
+func Verify(rng *rand.Rand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verifies an authentication cookie for validity",
+		Args:  cobra.ExactArgs(1),
+	}
+
+	options := struct {
+		*oauth.ExtractorFlags
+	}{}
+
+	options.ExtractorFlags = oauth.DefaultExtractorFlags().Register(&kcobra.FlagSet{cmd.Flags()}, "")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(options.TokenVerifyingKey) <= 0 {
+			return kflags.NewUsageErrorf("must specify a --token-verifying-key")
+		}
+
+		ext, err := oauth.NewExtractor(oauth.WithExtractorFlags(options.ExtractorFlags))
+		if err != nil {
+			return err
+		}
+
+		meta, creds, err := ext.ParseCredentialsCookie(args[0])
+
+		fmt.Printf("version: %d\n", meta.Version())
+		fmt.Printf("id: %s\n", creds.Identity.Id)
+		fmt.Printf("username: %s\n", creds.Identity.Username)
+		fmt.Printf("org: %s\n", creds.Identity.Organization)
+		fmt.Printf("issued: %s\n", meta.Issued())
+		now := time.Now()
+		if !meta.Expires().IsZero() {
+			fmt.Printf("expires: %s (duration:%s, in:%s)\n", meta.Expires(), meta.Expires().Sub(meta.Issued()), meta.Expires().Sub(now))
+		}
+		if !meta.Max().IsZero() {
+			fmt.Printf("max: %s (duration:%s, in:%s)\n", meta.Max(), meta.Max().Sub(meta.Issued()), meta.Max().Sub(now))
+		}
+
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+			os.Exit(1)
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+func Generate(rng *rand.Rand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generates a signing and verifying key pair",
+		Args:  cobra.NoArgs,
+	}
+
+	options := struct {
+		*oauth.SigningExtractorFlags
+		Id           string
+		Username     string
+		Organization string
+	}{}
+
+	options.SigningExtractorFlags = oauth.DefaultSigningExtractorFlags().Register(&kcobra.FlagSet{cmd.Flags()}, "")
+	cmd.Flags().StringVar(&options.Id, "id", "", "Unique ID of the user to hard code in the token")
+	cmd.Flags().StringVar(&options.Username, "username", "", "Username to hard code in the token")
+	cmd.Flags().StringVar(&options.Organization, "organization", "", "Organization to hard code in the token")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if options.Username == "" {
+			return kflags.NewUsageErrorf("an username must be provided with --username")
+		}
+		if len(options.TokenSigningKey) <= 0 {
+			return kflags.NewUsageErrorf("must specify a --token-signing-key")
+		}
+
+		ext, err := oauth.NewExtractor(oauth.WithRng(rng), oauth.WithSigningExtractorFlags(options.SigningExtractorFlags))
+		if err != nil {
+			return err
+		}
+
+		cookie, err := ext.EncodeCredentials(oauth.CredentialsCookie{Identity: oauth.Identity{
+			Id:           options.Id,
+			Username:     options.Username,
+			Organization: options.Organization,
+		}})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("COOKIE: %s\n", cookie)
+		return err
+	}
+
+	return cmd
+}
+
+func main() {
+	rng := rand.New(srand.Source)
+	root := &cobra.Command{
+		Use:   "enauth",
+		Short: "Tool to help dealing with oauth tokens",
+	}
+
+	root.AddCommand(Generate(rng))
+	root.AddCommand(Verify(rng))
+	cobra.EnablePrefixMatching = true
+	kcobra.Run(root)
+}

--- a/lib/oauth/factory.go
+++ b/lib/oauth/factory.go
@@ -15,19 +15,28 @@ import (
 )
 
 type ExtractorFlags struct {
+	// Version of the cookie format.
+	Version int
+
 	BaseCookie string
 
 	SymmetricKey      []byte
 	TokenVerifyingKey []byte
 
-	// How long are the generated credentials valid for.
-	// Limit how long user credentials will be accepted for.
+	// When generating credentials, how long should the token be valid for?
 	LoginTime time.Duration
+	// When checking credentials, tokens older than MaxLoginTime will be
+	// rejected no matter what.
+	MaxLoginTime time.Duration
 }
 
 func (f *ExtractorFlags) Register(set kflags.FlagSet, prefix string) *ExtractorFlags {
+	set.IntVar(&f.Version, prefix+"token-version", f.Version,
+		"Which kind of token to generate. 0 indicates version 0, 1 indicates version 1")
 	set.DurationVar(&f.LoginTime, prefix+"login-time", f.LoginTime,
 		"How long should the generated authentication tokens be valid for.")
+	set.DurationVar(&f.MaxLoginTime, prefix+"max-login-time", f.MaxLoginTime,
+		"When verifying a cookie, reject cookies older than this long no matter what.")
 	set.StringVar(&f.BaseCookie, prefix+"base-cookie", "",
 		"Prefix to append to the cookies used for authentication")
 	set.ByteFileVar(&f.SymmetricKey, prefix+"token-encryption-key", "",
@@ -42,7 +51,30 @@ func (f *ExtractorFlags) Register(set kflags.FlagSet, prefix string) *ExtractorF
 func DefaultExtractorFlags() *ExtractorFlags {
 	o := DefaultOptions(nil)
 	return &ExtractorFlags{
-		LoginTime: o.loginTime,
+		LoginTime:    o.loginTime,
+		MaxLoginTime: o.maxLoginTime,
+	}
+}
+
+type SigningExtractorFlags struct {
+	*ExtractorFlags
+
+	// Keys used to generate signed tokens.
+	TokenSigningKey []byte
+}
+
+func (f *SigningExtractorFlags) Register(set kflags.FlagSet, prefix string) *SigningExtractorFlags {
+	set.ByteFileVar(&f.TokenSigningKey, prefix+"token-signing-key", "",
+		"Path of the file containing the private key to use to sign the returned client tokens. "+
+			"If both token-encryption-key and token-signing-key are not specified, a key is generated")
+
+	f.ExtractorFlags.Register(set, prefix)
+	return f
+}
+
+func DefaultSigningExtractorFlags() *SigningExtractorFlags {
+	return &SigningExtractorFlags{
+		ExtractorFlags: DefaultExtractorFlags(),
 	}
 }
 
@@ -64,7 +96,7 @@ func (rf *RedirectorFlags) Register(set kflags.FlagSet, prefix string) *Redirect
 }
 
 type Flags struct {
-	*ExtractorFlags
+	*SigningExtractorFlags
 
 	// The URL at the end of the oauth authentication process.
 	TargetURL string
@@ -72,9 +104,6 @@ type Flags struct {
 	// A buffer containing a JSON file with the Credentials struct (below).
 	// This is passed to WithFileSecrets().
 	OauthSecretJSON []byte
-
-	// Keys used to generate signed tokens.
-	TokenSigningKey []byte
 
 	// Alternative to OauthSecretJSON, OauthSecretID and OauthSecretKey can be used.
 	OauthSecretID  string
@@ -88,8 +117,8 @@ type Flags struct {
 func DefaultFlags() *Flags {
 	o := DefaultOptions(nil)
 	return &Flags{
-		ExtractorFlags: DefaultExtractorFlags(),
-		AuthTime:       o.authTime,
+		SigningExtractorFlags: DefaultSigningExtractorFlags(),
+		AuthTime:              o.authTime,
 	}
 }
 
@@ -103,11 +132,7 @@ func (f *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
 	set.DurationVar(&f.AuthTime, prefix+"auth-time", f.AuthTime,
 		"How long should the token forwarded to the remote oauth server be valid for. This bounds how long the oauth authentication process can take at most")
 
-	set.ByteFileVar(&f.TokenSigningKey, prefix+"token-signing-key", "",
-		"Path of the file containing the private key to use to sign the returned client tokens. "+
-			"If both token-encryption-key and token-signing-key are not specified, a key is generated")
-
-	f.ExtractorFlags.Register(set, prefix)
+	f.SigningExtractorFlags.Register(set, prefix)
 	return f
 }
 
@@ -249,6 +274,23 @@ func WithLoginTime(lt time.Duration) Modifier {
 	}
 }
 
+func WithVersion(version int) Modifier {
+	return func(opt *Options) error {
+		if version != 0 && version != 1 {
+			return fmt.Errorf("invalid version number %d - only 0 or 1 are valid", version)
+		}
+		opt.version = version
+		return nil
+	}
+}
+
+func WithMaxLoginTime(lt time.Duration) Modifier {
+	return func(opt *Options) error {
+		opt.maxLoginTime = lt
+		return nil
+	}
+}
+
 func WithRedirectorFlags(fl *RedirectorFlags) Modifier {
 	return func(o *Options) error {
 		authURL := fl.AuthURL
@@ -268,7 +310,13 @@ func WithRedirectorFlags(fl *RedirectorFlags) Modifier {
 		WithAuthURL(u)(o)
 		return WithExtractorFlags(fl.ExtractorFlags)(o)
 	}
+}
 
+func WithRng(rng *rand.Rand) Modifier {
+	return func(o *Options) error {
+		o.rng = rng
+		return nil
+	}
 }
 
 func WithExtractorFlags(fl *ExtractorFlags) Modifier {
@@ -282,7 +330,22 @@ func WithExtractorFlags(fl *ExtractorFlags) Modifier {
 			mods = append(mods, WithSigningOptions(token.UseVerifyingKey(key)))
 		}
 
-		mods = append(mods, WithSymmetricOptions(token.UseSymmetricKey(fl.SymmetricKey)), WithLoginTime(fl.LoginTime))
+		mods = append(mods, WithSymmetricOptions(token.UseSymmetricKey(fl.SymmetricKey)), WithLoginTime(fl.LoginTime), WithMaxLoginTime(fl.MaxLoginTime), WithVersion(fl.Version))
+		return Modifiers(mods).Apply(o)
+	}
+}
+
+func WithSigningExtractorFlags(fl *SigningExtractorFlags) Modifier {
+	return func(o *Options) error {
+		mods := []Modifier{}
+		if len(fl.TokenSigningKey) != 0 {
+			key, err := token.SigningKeyFromSlice(fl.TokenSigningKey)
+			if err != nil {
+				return fmt.Errorf("invalid key specified with --token-signing-key - %s", err)
+			}
+			mods = append(mods, WithSigningOptions(token.UseSigningKey(key)))
+		}
+		mods = append(mods, WithExtractorFlags(fl.ExtractorFlags))
 		return Modifiers(mods).Apply(o)
 	}
 }
@@ -326,30 +389,18 @@ func WithFlags(fl *Flags) Modifier {
 			fl.TokenVerifyingKey = (*verify.ToBytes())[:]
 		}
 
-		if len(fl.TokenSigningKey) != 0 {
-			key, err := token.SigningKeyFromSlice(fl.TokenSigningKey)
-			if err != nil {
-				return fmt.Errorf("invalid key specified with --token-signing-key - %s", err)
-			}
-			mods = append(mods, WithSigningOptions(token.UseSigningKey(key)))
-		}
-		if len(fl.TokenVerifyingKey) != 0 {
-			key, err := token.VerifyingKeyFromSlice(fl.TokenVerifyingKey)
-			if err != nil {
-				return fmt.Errorf("invalid key specified with --token-verifying-key - %s", err)
-			}
-			mods = append(mods, WithSigningOptions(token.UseVerifyingKey(key)))
-		}
-
-		mods = append(mods, WithSymmetricOptions(token.UseSymmetricKey(fl.SymmetricKey)), WithAuthTime(fl.AuthTime), WithLoginTime(fl.LoginTime), WithSecrets(fl.OauthSecretID, fl.OauthSecretKey))
+		mods = append(mods, WithAuthTime(fl.AuthTime), WithSecrets(fl.OauthSecretID, fl.OauthSecretKey), WithSigningExtractorFlags(fl.SigningExtractorFlags))
 		return Modifiers(mods).Apply(o)
 	}
 }
 
 type Options struct {
-	rng        *rand.Rand
-	authTime   time.Duration // How long the user has to complete authentication.
-	loginTime  time.Duration // How long the token is valid for after successful authentication.
+	rng          *rand.Rand
+	authTime     time.Duration // How long the user has to complete authentication.
+	loginTime    time.Duration // How long the token is valid for after successful authentication.
+	maxLoginTime time.Duration // Tokens issued more than maxLoginTime ago will always be rejected.
+
+	version    int
 	conf       *oauth2.Config
 	verifier   Verifier
 	baseCookie string
@@ -361,33 +412,31 @@ type Options struct {
 
 func DefaultOptions(rng *rand.Rand) Options {
 	return Options{
-		rng:       rng,
-		authTime:  time.Minute * 30,
-		loginTime: time.Hour * 24,
-		conf:      &oauth2.Config{},
+		rng:          rng,
+		authTime:     time.Minute * 30,
+		loginTime:    time.Hour * 24,
+		maxLoginTime: time.Hour * 24 * 365,
+		conf:         &oauth2.Config{},
 	}
 }
 
 func (opt *Options) NewAuthenticator() (*Authenticator, error) {
+	extractor, err := opt.NewExtractor()
+	if err != nil {
+		return nil, err
+	}
+
 	be, err := token.NewSymmetricEncoder(opt.rng, opt.symmetricSetters...)
 	if err != nil {
-		return nil, fmt.Errorf("error setting up symmetric encryption: %w", err)
+		return nil, fmt.Errorf("error setting up authenticating cipher: %w", err)
 	}
 
-	se, err := token.NewSigningEncoder(opt.rng, opt.signingSetters...)
-	if err != nil {
-		return nil, fmt.Errorf("error setting up signing encryption: %w", err)
-	}
-
-	ue := token.NewBase64UrlEncoder()
 	authenticator := &Authenticator{
-		Extractor: Extractor{
-			loginEncoder: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.loginTime), be, se, ue)),
-		},
+		Extractor: *extractor,
 
 		rng: opt.rng,
 
-		authEncoder: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.authTime), be, ue)),
+		authEncoder: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.authTime), be, token.NewBase64UrlEncoder())),
 
 		conf:     opt.conf,
 		verifier: opt.verifier,
@@ -412,21 +461,30 @@ func (opt *Options) NewAuthenticator() (*Authenticator, error) {
 	return authenticator, nil
 }
 
+// NewExtractor creates either a simple Extractor, or a SigningExtractor.
+//
+// An Extractor is an object able to parse and extract data from a signed and
+// encrypted cookie.
+//
+// A SigningExtractor is just like an extractor, except it is also capable
+// of generating new signing cookies.
 func (opt *Options) NewExtractor() (*Extractor, error) {
-	be, err := token.NewSymmetricEncoder(nil, opt.symmetricSetters...)
+	be, err := token.NewSymmetricEncoder(opt.rng, opt.symmetricSetters...)
 	if err != nil {
-		return nil, fmt.Errorf("error setting up symmetric decryption: %w", err)
+		return nil, fmt.Errorf("error setting up symmetric cipher: %w", err)
 	}
 
-	se, err := token.NewSigningEncoder(nil, opt.signingSetters...)
+	se, err := token.NewSigningEncoder(opt.rng, opt.signingSetters...)
 	if err != nil {
-		return nil, fmt.Errorf("error setting up signature verification: %w", err)
+		return nil, fmt.Errorf("error setting up signing cipher: %w", err)
 	}
 
 	ue := token.NewBase64UrlEncoder()
 	return &Extractor{
-		baseCookie:   opt.baseCookie,
-		loginEncoder: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.loginTime), be, se, ue)),
+		version:       opt.version,
+		baseCookie:    opt.baseCookie,
+		loginEncoder0: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.loginTime), be, se, ue)),
+		loginEncoder1: token.NewTypeEncoder(token.NewChainedEncoder(token.NewTimeEncoder(nil, opt.maxLoginTime), token.NewExpireEncoder(nil, opt.loginTime), be, se, ue)),
 	}, nil
 }
 

--- a/lib/oauth/ogrpc/ogrpc.go
+++ b/lib/oauth/ogrpc/ogrpc.go
@@ -104,7 +104,7 @@ func ProcessMetdata(auth *oauth.Authenticator, ctx context.Context) (context.Con
 	if cookie == nil {
 		return ctx, status.Errorf(codes.Unauthenticated, "no credentials cookie")
 	}
-	creds, err := auth.ParseCredentialsCookie(*cookie)
+	_, creds, err := auth.ParseCredentialsCookie(*cookie)
 	if err != nil {
 		return ctx, status.Errorf(codes.Unauthenticated, "invalid credentials - %s", err)
 	}

--- a/lib/token/token.go
+++ b/lib/token/token.go
@@ -11,15 +11,19 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"time"
+	"context"
 
 	"golang.org/x/crypto/nacl/sign"
 )
+
+// Use internally to define keys exported via context.
+type contextKey string
 
 // BinaryEncoders convert an array of bytes into another by applying binary transformations.
 // For example: encryption, signature, ...
 type BinaryEncoder interface {
 	Encode([]byte) ([]byte, error)
-	Decode([]byte) ([]byte, error)
+	Decode(context.Context, []byte) (context.Context, []byte, error)
 }
 
 type ChainedEncoder []BinaryEncoder
@@ -40,25 +44,31 @@ func (ce *ChainedEncoder) Encode(data []byte) ([]byte, error) {
 	return data, nil
 }
 
-func (ce *ChainedEncoder) Decode(data []byte) ([]byte, error) {
+func (ce *ChainedEncoder) Decode(ctx context.Context, data []byte) (context.Context, []byte, error) {
 	encs := ([]BinaryEncoder)(*ce)
+	var first error
 	for ix := range encs {
 		enc := encs[len(encs)-ix-1]
 
 		var err error
-		data, err = enc.Decode(data)
+		ctx, data, err = enc.Decode(ctx, data)
 		if err != nil {
-			return nil, err
+			if first == nil {
+				first = err
+			}
+			if data == nil {
+				break
+			}
 		}
 	}
-	return data, nil
+	return ctx, data, first
 }
 
 // StringEncoders convert an array of bytes into a string safe for specific applications.
 // For example: mime64, url, ...
 type StringEncoder interface {
 	Encode([]byte) (string, error)
-	Decode(string) ([]byte, error)
+	Decode(context.Context, string) (context.Context, []byte, error)
 }
 
 type TimeSource func() time.Time
@@ -88,18 +98,21 @@ func (t *TimeEncoder) Encode(data []byte) ([]byte, error) {
 }
 
 var ExpiredError = fmt.Errorf("signature expired")
+var IssuedTimeKey = contextKey("issued")
 
-func (t *TimeEncoder) Decode(data []byte) ([]byte, error) {
+func (t *TimeEncoder) Decode(ctx context.Context, data []byte) (context.Context, []byte, error) {
 	issued, parsed := binary.Varint(data)
 	if parsed <= 0 {
-		return nil, fmt.Errorf("invalid timestamp in buffer")
+		return ctx, nil, fmt.Errorf("invalid timestamp in buffer")
 	}
 
-	if issued <= 0 || time.Unix(issued, 0).Add(t.validity).Before(t.now()) {
-		return nil, ExpiredError
-	}
+	itime := time.Unix(issued, 0)
+        ctx = context.WithValue(ctx, IssuedTimeKey, itime)
 
-	return data[parsed:], nil
+	if issued <= 0 || itime.Add(t.validity).Before(t.now()) {
+		return ctx, data[parsed:], ExpiredError
+	}
+	return ctx, data[parsed:], nil
 }
 
 type TypeEncoder struct {
@@ -121,17 +134,20 @@ func (t *TypeEncoder) Encode(data interface{}) ([]byte, error) {
 	return t.be.Encode(buffer.Bytes())
 }
 
-func (t *TypeEncoder) Decode(data []byte, output interface{}) error {
-	data, err := t.be.Decode(data)
-	if err != nil {
-		return err
+func (t *TypeEncoder) Decode(ctx context.Context, data []byte, output interface{}) (context.Context, error) {
+	ctx, data, derr := t.be.Decode(ctx, data)
+	if data == nil && derr != nil {
+		return ctx, derr
 	}
 
 	enc := gob.NewDecoder(bytes.NewReader(data))
-	if err := enc.Decode(output); err != nil {
-		return err
+	nerr := enc.Decode(output)
+
+	err := derr
+	if derr == nil {
+		err = nerr
 	}
-	return nil
+	return ctx, err
 }
 
 type SymmetricEncoder struct {
@@ -250,9 +266,9 @@ func (t *SymmetricEncoder) Encode(data []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
-func (t *SymmetricEncoder) Decode(ciphertext []byte) ([]byte, error) {
+func (t *SymmetricEncoder) Decode(ctx context.Context, ciphertext []byte) (context.Context, []byte, error) {
 	if len(ciphertext) < t.cipher.NonceSize() {
-		return nil, fmt.Errorf("ciphertext too short to contain nonce")
+		return ctx, nil, fmt.Errorf("ciphertext too short to contain nonce")
 	}
 
 	nonce := ciphertext[:t.cipher.NonceSize()]
@@ -260,9 +276,9 @@ func (t *SymmetricEncoder) Decode(ciphertext []byte) ([]byte, error) {
 
 	plaintext, err := t.cipher.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		return nil, err
+		return ctx, nil, err
 	}
-	return plaintext, nil
+	return ctx, plaintext, nil
 }
 
 type Base64Encoder struct {
@@ -280,13 +296,13 @@ func (e *Base64Encoder) Encode(data []byte) ([]byte, error) {
 	e.enc.Encode(dst, data)
 	return dst, nil
 }
-func (e *Base64Encoder) Decode(data []byte) ([]byte, error) {
+func (e *Base64Encoder) Decode(ctx context.Context, data []byte) (context.Context, []byte, error) {
 	dst := make([]byte, e.enc.DecodedLen(len(data)))
 	_, err := e.enc.Decode(dst, data)
 	if err != nil {
-		return nil, err
+		return ctx, nil, err
 	}
-	return dst, nil
+	return ctx, dst, nil
 }
 
 type VerifyingKey [32]byte
@@ -369,13 +385,13 @@ func (t *SigningEncoder) Encode(data []byte) ([]byte, error) {
 	return sign.Sign(nil, data, t.signing.ToBytes()), nil
 }
 
-func (t *SigningEncoder) Decode(value []byte) ([]byte, error) {
+func (t *SigningEncoder) Decode(ctx context.Context, value []byte) (context.Context, []byte, error) {
 	if t.verifying == nil {
-		return nil, fmt.Errorf("a verifying key must be supplied to decode data")
+		return ctx, nil, fmt.Errorf("a verifying key must be supplied to decode data")
 	}
 	data, ok := sign.Open(nil, value, t.verifying.ToBytes())
 	if !ok {
-		return nil, fmt.Errorf("signature did not match")
+		return ctx, nil, fmt.Errorf("signature did not match")
 	}
-	return data, nil
+	return ctx, data, nil
 }

--- a/lib/token/token_test.go
+++ b/lib/token/token_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+	"context"
 )
 
 func TestSimple(t *testing.T) {
@@ -23,7 +24,7 @@ func TestSimple(t *testing.T) {
 
 	data, err := be.Encode([]byte{1, 2, 3, 4})
 	assert.Nil(t, err)
-	original, err := be.Decode(data)
+	_, original, err := be.Decode(context.Background(), data)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{1, 2, 3, 4}, original)
 }
@@ -44,7 +45,7 @@ func TestTypeEncoder(t *testing.T) {
 	assert.NotEqual(t, data1, data2)
 
 	var result string
-	err = te.Decode(data1, &result)
+	_, err = te.Decode(context.Background(), data1, &result)
 	assert.Nil(t, err)
 	assert.Equal(t, "this is a string", result)
 }
@@ -66,13 +67,13 @@ func TestTimeEncoder(t *testing.T) {
 	assert.NotNil(t, data)
 
 	ts = ts.Add(time.Second * 2)
-	arr, err := te.Decode(data)
+	_, arr, err := te.Decode(context.Background(), data)
 	assert.Nil(t, err)
 	assert.NotNil(t, arr)
 	assert.Equal(t, []byte{0, 1, 2, 3, 4}, arr)
 
 	// Now the timer has expired.
 	ts = ts.Add(time.Second * 3)
-	arr, err = te.Decode(data)
+	_, arr, err = te.Decode(context.Background(), data)
 	assert.NotNil(t, err)
 }

--- a/proxy/nasshp/nassh.go
+++ b/proxy/nasshp/nassh.go
@@ -1,6 +1,7 @@
 package nasshp
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -356,7 +357,7 @@ func (np *NasshProxy) ServeConnect(w http.ResponseWriter, r *http.Request) {
 	ack := strings.TrimSpace(params.Get("ack"))
 	pos := strings.TrimSpace(params.Get("pos"))
 
-	hostportb, err := np.encoder.Decode([]byte(sid))
+	_, hostportb, err := np.encoder.Decode(context.Background(), []byte(sid))
 	if err != nil {
 		http.Error(w, "invalid sid provided", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Background:
Before this change, a token was either valid or invalid.
There was no way to determine why it was invalid (except for the
error status) or how much time was left in the token.

In this change:
- lib/token has been modified so:
  1) decoders can attach arbitrary metadata using the standard context.Context
     golang library. This breaks API compatibility.

  2) decoders keep moving forward even if there is an error. This
     allows to extract the validity of a token (and its content)
     even if expired.

  An error is still returned, of course, as the token is invalid.
  But the caller can still check the information decoded, and print
  it if necessary.

- updated oauth library so that:
  1) decoders are used with the new API.
  2) issued time is returned. This breaks API compatibility.

- updates through the repository to use the new API calls.