### PR TITLE
ip-manager: don't discard stdout and stderr.

### DIFF
--- a/manager/client/main.go
+++ b/manager/client/main.go
@@ -20,6 +20,9 @@ func run(timeout time.Duration, cmd string, args ...string) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	job := exec.CommandContext(ctx, cmd, args...)
+	job.Stdout = os.Stdout
+	job.Stderr = os.Stderr
+
 	err := job.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		log.Fatalf("Job failed to complete after %d seconds: %s %s \n", timeout, cmd, strings.Join(args, " "))


### PR DESCRIPTION
Background:
As per https://golang.org/pkg/os/exec/#Cmd, if Stdout or Stderr are
not set, stdout and stderr are sent to /dev/null.
This discards all of our precious logs.

In this change:
- do not discard stdout and stderr