### PR TITLE
Adds the ability to support hostnames in the proxy

### DIFF
--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "blocking.go",
         "browser.go",
         "nassh.go",
+        "types.go",
         "window.go",
     ],
     importpath = "github.com/enfabrica/enkit/proxy/nasshp",

--- a/proxy/nasshp/types.go
+++ b/proxy/nasshp/types.go
@@ -1,0 +1,51 @@
+package nasshp
+
+import (
+	"net"
+	"strings"
+)
+
+type HostIp string
+
+func (hi HostIp) IsUrl() bool {
+	res := strings.Split(string(hi), ":")
+	if len(res) != 2 {
+		return false
+	}
+	return net.ParseIP(res[0]) == nil
+}
+
+func (hi HostIp) Resolve() []string {
+	res := strings.Split(string(hi), ":")
+	if len(res) != 2 {
+		return []string{}
+	}
+	p := res[1]
+	ips, err := net.LookupHost(res[0])
+	if err != nil {
+		return []string{}
+	}
+	var toReturn []string
+	for _, ip := range ips {
+		toReturn = append(toReturn, strings.Join([]string{ip, ":", p}, ""))
+	}
+	return toReturn
+}
+
+type Verdict int
+
+const (
+	// Can't decide either way. This is useful for chaning filters.
+	VerdictUnknown Verdict = iota
+	// Let the request in.
+	VerdictAllow
+	// Block the request.
+	VerdictDrop
+)
+
+func (v Verdict) MergePreferAllow(vv Verdict) Verdict {
+	if v == VerdictAllow || vv == VerdictAllow {
+		return VerdictAllow
+	}
+	return VerdictDrop
+}

--- a/proxy/ptunnel/BUILD.bazel
+++ b/proxy/ptunnel/BUILD.bazel
@@ -24,10 +24,12 @@ go_test(
     deps = [
         "//lib/khttp:go_default_library",
         "//lib/khttp/ktest:go_default_library",
+        "//lib/khttp/protocol:go_default_library",
         "//lib/logger:go_default_library",
         "//lib/srand:go_default_library",
         "//lib/token:go_default_library",
         "//proxy/nasshp:go_default_library",
+        "//proxy/utils:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/proxy/utils/whitelist.go
+++ b/proxy/utils/whitelist.go
@@ -36,8 +36,9 @@ func NewPatternList(allowed []string) (PatternList, error) {
 
 // Allow is a nasshp.Filter function that returns nasshp.VerdictAllow if the proto and hostport
 // string specified match any pattern in the list created with NewPatternList.
-func (pl PatternList) Allow(proto string, hostport string, creds *oauth.CredentialsCookie) nasshp.Verdict {
-	key := proto + "|" + hostport
+// proto is one word.
+func (pl PatternList) Allow(proto string, ipport string, creds *oauth.CredentialsCookie) nasshp.Verdict {
+	key := proto + "|" + ipport
 	for _, pattern := range pl {
 		match, err := filepath.Match(pattern, key)
 		if err == nil && match {


### PR DESCRIPTION
Right now in /proxy, the host query parameter can only support ips. This adds the ability to use hostnames. 

Also establishes a way to test with httptest package. 