### PR TITLE
feature/fix: disable TLS by default with backends.

### DIFF
--- a/proxy/httpp/build.go
+++ b/proxy/httpp/build.go
@@ -1,6 +1,7 @@
 package httpp
 
 import (
+	"crypto/tls"
 	"fmt"
 	"github.com/enfabrica/enkit/lib/khttp"
 	"github.com/enfabrica/enkit/lib/logger"
@@ -37,7 +38,11 @@ func NewProxy(fromurl, tourl string, transform *Transform) (*httputil.ReversePro
 		req.URL.RawPath = ""
 	}
 
-	return &httputil.ReverseProxy{Director: director}, nil
+	proxy := &httputil.ReverseProxy{Director: director}
+	proxy.Transport = &http.Transport{
+	        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return proxy, nil
 }
 
 type ProxyCreator func(m *Mapping) (http.Handler, error)


### PR DESCRIPTION
This is a temporary hack waiting the overhaul of the proxy
configuration file. Until then, let's disable certificate
verification when talking to internal backends.

This is a security risk. However, most of the interal backends
configured happen to be horrible ssl appliances with self signed
certificates, and no ability to configure a real certificate.
Practically speaking, this is the only option to get them to
work.

With the config overhaul, it will be possible to selectively
disable certificate validation, or pin certificates directly
in the configuration file.