### PR TITLE
kflags/kconfig: export enkit_path to running packages.

### DIFF
--- a/lib/kflags/kconfig/namespace.go
+++ b/lib/kflags/kconfig/namespace.go
@@ -173,6 +173,8 @@ func CreateExecuteAction(packagedir string, commanddir string, argv []string, va
 		subs := BuildMap(vars, flagarg)
 		subs["package_dir"] = packagedir
 		subs["command_dir"] = commanddir
+		enkit, _ := os.Executable()
+		subs["enkit_path"] = enkit
 
 		// The argv configured in the manifest is subject to template variable substitution...
 		argv, err := ExpandArgs(argv, subs)


### PR DESCRIPTION
Background:
When a package is downloaded from our internal repository and run,
a few variables are passed via the environment and can also be use
for command line flag substitution.

In this PR:
Add the 'enkit_path' variable, replaced as '{enkit_path}' on the
cli, or exported as KCONFIG_ENKIT_PATH on the environment.