### PR TITLE
linux/defs.bzl: remove ugly newline.

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -151,7 +151,7 @@ def _kernel_modules(ctx):
     message = ""
     copy_command = ""
     for m in modules:
-        message += "kernel building: compiling module %s for %s\n" % (m, ki.package)
+        message += "kernel building: compiling module %s for %s" % (m, ki.package)
         rename = m
         if ctx.attr.rename:
             rename = ctx.attr.rename + m


### PR DESCRIPTION
I was just testing the kernel builds, and noticed that the bazel
output has an unexpected newline. Eg:

    kernel building: compiling module enf.ko for enf-5.11.16-1+enf-1621888669-gd552cf86321e
; 318s remote
    kernel building: compiling module enf.ko for custom_distro-zctap-backported-5.10
; 303s remote
    kernel building: compiling module enf.ko for enfvm-5.11.16-1+enf-1621893941-gd552cf86321e
; 288s remote
    kernel building: compiling module enf_queues_test.ko for custom-5.9.0-um
; 275s remote

This PR removes it.