### PR TITLE
lib/client: differentiate credential errors.

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"github.com/enfabrica/enkit/lib/cache"
 	"github.com/enfabrica/enkit/lib/client/ccontext"
 	"github.com/enfabrica/enkit/lib/config"
@@ -109,7 +108,8 @@ func (bf *BaseFlags) IdentityErrorHandler(message string) kflags.ErrorHandler {
 				identity = "youruser@yourdomain.com"
 			}
 		}
-		return fmt.Errorf("Attempting to use your credentials failed with:\n%w\n\nThis probably means that you just need to log in again with:\n\t%s %s",
+		return kflags.NewStatusErrorf(100,
+                        "Attempting to use your credentials failed with:\n%w\n\nThis probably means that you just need to log in again with:\n\t%s %s",
 			logger.NewIndentedError(err, "    (for debug only) "), message, identity)
 	}
 }


### PR DESCRIPTION
Background:
Most errors in enkit today default to causing the binary to exit
with status 1. Shell scripts have no choice but to parse the output
to tell different errors apart.

In this PR:
- change the identity error handling to return status 100 when an
  identity error takes place.
- this allows scripts to tell the error apart, and behave accordingly.