### PR TITLE
proxy/ptunnel/tunnel: add support for backgrounding.

### DIFF
--- a/proxy/ptunnel/commands/tunnel.go
+++ b/proxy/ptunnel/commands/tunnel.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"github.com/enfabrica/enkit/lib/client"
 	"github.com/enfabrica/enkit/lib/goroutine"
@@ -19,9 +20,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 )
 
 type Tunnel struct {
@@ -33,6 +36,8 @@ type Tunnel struct {
 
 	TunnelFlags *ptunnel.Flags
 	Listen      string
+	Background  bool
+	CheckAccess bool
 }
 
 func (r *Tunnel) Username() string {
@@ -43,7 +48,27 @@ func (r *Tunnel) Username() string {
 	return user.Username
 }
 
-func (r *Tunnel) Run(cmd *cobra.Command, args []string) error {
+func (r *Tunnel) Run(cmd *cobra.Command, args []string) (err error) {
+	id := ""
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		// Ensure all errors are logged. This is especially important when backgrounding.
+		if id != "" {
+			id += " "
+		}
+		r.Log.Infof("%sterminated with status %v", id, err)
+
+		// Return a specific exit status when address is already in use.
+		// This is a common error, that scripts may want to handle directly.
+		var serr *os.SyscallError
+		if errors.As(err, &serr) && serr.Err == syscall.EADDRINUSE {
+			err = kflags.NewStatusErrorf(10, "cannot open socket - %w", err)
+		}
+	}()
+
 	// Treat credentials as optional, move forward in any case.
 	_, cookie, _ := r.IdentityCookie()
 
@@ -75,7 +100,7 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) error {
 	case len(args) == 2:
 		lport, err := strconv.ParseUint(args[1], 10, 16)
 		if err != nil || lport <= 0 || lport > 65535 {
-			return kflags.NewUsageErrorf("Come on! A lport number is an integer between 1 and 65535 - %s leads to %w", args[1], err)
+			return kflags.NewUsageErrorf("Come on! A port number is an integer between 1 and 65535 - %s leads to %w", args[1], err)
 		}
 		port = uint16(lport)
 		fallthrough
@@ -96,10 +121,10 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) error {
 			rhost = ""
 		}
 
-		return r.RunListener(purl, host, port, cookie, net.JoinHostPort(rhost, rport))
+		return r.OpenAndListen(purl, id, host, port, cookie, net.JoinHostPort(rhost, rport))
 	}
 
-	id := fmt.Sprintf("tunnel by %s on <stdin/stdout> with %s:%d through %s", r.Username(), host, port, proxy)
+	id = fmt.Sprintf("tunnel by %s on <stdin/stdout> with %s:%d through %s", r.Username(), host, port, proxy)
 	r.Log.Infof("%s - establishing connection", id)
 
 	err = r.RunTunnel(purl, id, host, port, cookie, os.Stdin, os.Stdout)
@@ -109,40 +134,98 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func (r *Tunnel) RunListener(proxy *url.URL, host string, port uint16, cookie *http.Cookie, hostport string) error {
-	addr, err := net.ResolveTCPAddr("tcp", hostport)
-	if err != nil {
-		return err
-	}
-
-	listener, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return err
-	}
+func (r *Tunnel) RunListener(listener net.Listener, proxy *url.URL, host string, port uint16, cookie *http.Cookie, hostport string) error {
 	defer listener.Close()
 	for {
-		conn, err := listener.AcceptTCP()
+		generic, err := listener.Accept()
 		if err != nil {
 			return err
 		}
 
+		conn := generic.(*net.TCPConn)
 		id := fmt.Sprintf("tunnel by %s on %s with %s:%d via %s from %s", r.Username(), hostport, host, port, proxy, conn.RemoteAddr())
 		r.Log.Infof("%s - accepted connection", id)
 		go func() {
 			defer conn.Close()
-			r.RunTunnel(proxy, id, host, port, cookie, knetwork.ReadOnlyClose(conn), knetwork.WriteOnlyClose(conn))
+			err := r.RunTunnel(proxy, id, host, port, cookie, knetwork.ReadOnlyClose(conn), knetwork.WriteOnlyClose(conn))
+			if err != nil {
+				r.Log.Infof("%s - terminated with %v", id, err)
+			}
 		}()
 	}
 }
 
-func (r *Tunnel) RunTunnel(proxy *url.URL, id, host string, port uint16, cookie *http.Cookie, reader io.ReadCloser, writer io.WriteCloser) error {
-	pool := nasshp.NewBufferPool(r.BufferSize)
-	tunnel, err := ptunnel.NewTunnel(pool, ptunnel.WithLogger(r.Log), ptunnel.FromFlags(r.TunnelFlags))
+var magicEnvVariable = "__ENKIT_TUNNEL_BACKGROUND__"
+
+// IsBackgroundFork returns true if this code is running in the background fork of enkit.
+func IsBackgroundFork() bool {
+	_, present := os.LookupEnv(magicEnvVariable)
+	return present
+}
+
+// OpenAndListen will start listening with whatever mechanism has been configured via flags.
+//
+// If background is disabled, it will simply open a listening socket, and wait for connections.
+//
+// If background is enabled, it will:
+// 0) Check if OpenAndListen is being called as a result of the fork()/exec() in step 2) below.
+//
+// If it is, re-use the already opened file descriptor, and finally start listening.
+// If it is not...
+//
+// 1) Open a listening socket - which guarantees that when the parent process exits, the port is open.
+// 2) Fork and exec enkit again - with exactly the same flags and parameters, passing the listening socket
+//    as file descriptor number 3 (this is part of the ExtraFiles API in cmd.Exec).
+//    This hopefully will get us back in this function. A simple fork() would have been significantly
+//    simpler, but the behavior with threads is undefined and evil.
+func (r *Tunnel) OpenAndListen(proxy *url.URL, id, host string, port uint16, cookie *http.Cookie, hostport string) error {
+	var listener net.Listener
+	if r.Background && IsBackgroundFork() {
+		var err error
+		listener, err = net.FileListener(os.NewFile(3, "listener"))
+		if err != nil {
+			return err
+		}
+	} else {
+		err := r.CanConnect(proxy, id, host, port, cookie)
+		if err != nil {
+			return err
+		}
+
+		addr, err := net.ResolveTCPAddr("tcp", hostport)
+		if err != nil {
+			return err
+		}
+
+		tlisten, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return err
+		}
+		if r.Background {
+			err := r.RunBackground(tlisten)
+			tlisten.Close()
+			return err
+		}
+
+		listener = tlisten
+	}
+
+	return r.RunListener(listener, proxy, host, port, cookie, hostport)
+}
+
+func (r *Tunnel) RunBackground(listener *net.TCPListener) error {
+	file, err := listener.File()
 	if err != nil {
 		return err
 	}
-	defer tunnel.Close()
 
+	cmd := exec.Command(os.Args[0], os.Args[1:]...)
+	cmd.Env = append(os.Environ(), magicEnvVariable+"=true")
+	cmd.ExtraFiles = []*os.File{file}
+	return cmd.Start()
+}
+
+func (r *Tunnel) NewTunnelOptions(id string, cookie *http.Cookie) []ptunnel.GetModifier {
 	mods := []ptunnel.GetModifier{
 		ptunnel.WithRetryOptions(retry.WithDescription(id)),
 	}
@@ -177,6 +260,27 @@ func (r *Tunnel) RunTunnel(proxy *url.URL, id, host string, port uint16, cookie 
 		mods = append(mods, loader)
 	}
 
+	return mods
+}
+
+func (r *Tunnel) CanConnect(proxy *url.URL, id, host string, port uint16, cookie *http.Cookie) error {
+	if !r.CheckAccess {
+		return nil
+	}
+
+	_, err := ptunnel.GetSID(proxy, host, port, r.NewTunnelOptions(id, cookie)...)
+	return err
+}
+
+func (r *Tunnel) RunTunnel(proxy *url.URL, id, host string, port uint16, cookie *http.Cookie, reader io.ReadCloser, writer io.WriteCloser) error {
+	pool := nasshp.NewBufferPool(r.BufferSize)
+	tunnel, err := ptunnel.NewTunnel(pool, ptunnel.WithLogger(r.Log), ptunnel.FromFlags(r.TunnelFlags))
+	if err != nil {
+		return err
+	}
+	defer tunnel.Close()
+
+	mods := r.NewTunnelOptions(id, cookie)
 	err = goroutine.WaitFirstError(
 		func() error {
 			return tunnel.KeepConnected(proxy, host, port, mods...)
@@ -191,7 +295,6 @@ func (r *Tunnel) RunTunnel(proxy *url.URL, id, host string, port uint16, cookie 
 		},
 	)
 
-	r.Log.Infof("%s - terminated (%v)", id, err)
 	return err
 }
 
@@ -224,6 +327,13 @@ func NewTunnel(base *client.BaseFlags) *Tunnel {
 	Open the local port 1234 on INADDR_ANY (dangerous! anyone will be able to connect) and
 	forward every connection to 10.10.0.12 port 80.
 
+  $ tunnel --background -L 1234 10.10.0.12 80
+	Same as the first listening tunnel, but background the process as soon
+        as it's believed doing so won't result in any error.
+	IMPORTANT: prefer --background over using & in your shell. & will
+	introduce a race condition - where you might use the port before it is open -
+	and it may fail without any easy way to handle it.
+
 To use in ssh_config, you can have a block like:
 
     # Use the proxy for any host in the 'internal.enfabrica.net' domain.
@@ -242,8 +352,9 @@ was installed in your system, it may require running 'enkit tunnel ...' instead.
 	root.Command.Flags().IntVar(&root.BufferSize, "buffer-size", 1024*16, "Default read and write buffer size for window management")
 	root.Command.Flags().StringVarP(&root.Proxy, "proxy", "p", "", "Full url of the proxy to connect to, must be specified")
 	root.Command.Flags().StringVarP(&root.Listen, "listen", "L", "", "Local address or port to listen on")
+	root.Command.Flags().BoolVarP(&root.Background, "background", "b", false, "When listening with -L - run the tunnel in the background")
+	root.Command.Flags().BoolVarP(&root.CheckAccess, "check-access", "c", true, "When listening with -L - check credentials before opening the socket")
 
 	root.TunnelFlags = ptunnel.DefaultFlags().Register(&kcobra.FlagSet{FlagSet: root.Command.Flags()}, "")
-
 	return root
 }


### PR DESCRIPTION
Before this change:
1) The only way to background a tunnel was to use & in shell.
   This caused two issues: a) race condition, there is no way
   to know that the tunnel handshake has completed and it is
   ready to listen for connections when it is first used, and
   b) there is no way to handle errors properly. Eg, wait for
   it to finish? can't do, if all goes well, it'll never finish.
2) There was no error checking before the first connection attempt.
   This caused a tunnel creation to succeed, but then fail the
   first time it was actually used.

In this PR:
- introduce a --background option. This will open the listening
  socket and check for errors *before* backgrounding, so it is
  dead easy and reliable for shell scripts to background a tunnel.
- introduce error checking before opening the listening socket.
  This will ask the proxy for permission to connect before the
  first socket is ever opened. This is of course advisory only:
  there is no guarantee that the cookie won't be revoked later,
  or that ACLs won't change. But at least it catches the most
  common problems in a user friendly way.