### PR TITLE
proxy/ptunnel: fix race condition in showing error messages.

### DIFF
--- a/lib/knetwork/BUILD.bazel
+++ b/lib/knetwork/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "nopclose.go",
         "ports.go",
         "shutdown.go",
     ],

--- a/lib/knetwork/nopclose.go
+++ b/lib/knetwork/nopclose.go
@@ -1,0 +1,35 @@
+package knetwork
+
+import (
+	"io"
+)
+
+type nopReadCloser struct {
+	io.Reader
+}
+
+func (n *nopReadCloser) Close() error {
+	return nil
+}
+
+// NopReadCloser turns any io.Reader into a io.ReadCloser with a nop closer.
+//
+// This can also be used to ignore Close() events on another ReadCloser.
+func NopReadCloser(reader io.Reader) io.ReadCloser {
+	return &nopReadCloser{reader}
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (n *nopWriteCloser) Close() error {
+	return nil
+}
+
+// NopWriteCloser turns any io.Writer into a io.WriteCloser with a nop closer.
+//
+// This can also be used to ignore Close() events on another WriteCloser.
+func NopWriteCloser(writer io.Writer) io.WriteCloser {
+	return &nopWriteCloser{writer}
+}

--- a/lib/knetwork/shutdown.go
+++ b/lib/knetwork/shutdown.go
@@ -27,6 +27,7 @@ type WriteOnlyCloser interface {
 type readOnlyCloseAdapter struct {
 	ReadOnlyCloser
 }
+
 func (roca *readOnlyCloseAdapter) Close() error {
 	return roca.CloseRead()
 }
@@ -42,6 +43,7 @@ func ReadOnlyClose(woc ReadOnlyCloser) io.ReadCloser {
 type writeOnlyCloseAdapter struct {
 	WriteOnlyCloser
 }
+
 func (roca *writeOnlyCloseAdapter) Close() error {
 	return roca.CloseWrite()
 }

--- a/proxy/ptunnel/commands/tunnel.go
+++ b/proxy/ptunnel/commands/tunnel.go
@@ -127,7 +127,7 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) (err error) {
 	id = fmt.Sprintf("tunnel by %s on <stdin/stdout> with %s:%d through %s", r.Username(), host, port, proxy)
 	r.Log.Infof("%s - establishing connection", id)
 
-	err = r.RunTunnel(purl, id, host, port, cookie, os.Stdin, os.Stdout)
+	err = r.RunTunnel(purl, id, host, port, cookie, os.Stdin, knetwork.NopWriteCloser(os.Stdout))
 	if err == io.EOF {
 		return nil
 	}


### PR DESCRIPTION
Background:
With v17 of enkit tunnel, we noticed that the login error instructing
users to re-login in case of authentication error was not always showing.
Some times it was showing, some times it was not - for the same error.

We tracked it down to a race condition on shutdown, introduced in v17:
- v17 added code to properly shutdown the proxied connections.
  This is key for using tunnels in listening mode.
- as a result of that change, a normal tunnel used by ssh also started
  propagating connection closures correctly.

Now:
- when the ssh client uses a ProxyCommand, if the command closes
  the file descriptor, ssh will kill the command.
- this introduced the problem:
  1) Proxy closes connection.
  2) Tunnel command notices, immediately closes file descriptor for ssh.
  RACE CONDITION: ssh may kill the tunnel before or after it is able
  to print the error message. If ssh is fast, no error message is printed.
  If ssh is slow, then the error message is printed.

In this PR:
- Changed the code so when running in normal tunnel mode, we don't close
  the write descriptor if the proxy closes the connection. The error
  is still detected by the tunnel command, which will print the correct
  message and exit, but won't give reasons to ssh to kill the command
  before then.