### PR TITLE
lib/server: break out assets management function.

### DIFF
--- a/astore/server/BUILD.bazel
+++ b/astore/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//lib/kflags:go_default_library",
         "//lib/kflags/kcobra:go_default_library",
         "//lib/kflags/kconfig:go_default_library",
+        "//lib/khttp/kassets:go_default_library",
         "//lib/khttp/kcookie:go_default_library",
         "//lib/logger:go_default_library",
         "//lib/oauth:go_default_library",

--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/enfabrica/enkit/lib/oauth"
 	"github.com/enfabrica/enkit/lib/oauth/ogrpc"
 	"github.com/enfabrica/enkit/lib/server"
+	"github.com/enfabrica/enkit/lib/khttp/kassets"
 	"github.com/enfabrica/enkit/lib/srand"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -146,14 +147,14 @@ func Start(targetURL, cookieDomain, oAuthType string, astoreFlags *astore.Flags,
 	rpc_auth.RegisterAuthServer(grpcs, authServer)
 
 	mux := http.NewServeMux()
-	stats := server.AssetStats{}
+	stats := kassets.AssetStats{}
 
 	// Public configs, those are accessible to anyone on the internet.
 	mux.HandleFunc("/configs/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("%s On %s", kconfig.YodaSays, time.Now()), http.StatusNotFound)
 	})
-	server.RegisterAssets(&stats, assets.Data, "", server.BasicMapper(server.MuxMapper(mux)))
-	server.RegisterAssets(&stats, configs.Data, "", server.PrefixMapper("/configs", server.StripExtensionMapper(server.BasicMapper(server.MuxMapper(mux)))))
+	kassets.RegisterAssets(&stats, assets.Data, "", kassets.BasicMapper(kassets.MuxMapper(mux)))
+	kassets.RegisterAssets(&stats, configs.Data, "", kassets.PrefixMapper("/configs", kassets.StripExtensionMapper(kassets.BasicMapper(kassets.MuxMapper(mux)))))
 	stats.Log(log.Printf)
 
 	// Published artifacts, web page for human consumption, lists the options available for download.

--- a/lib/khttp/kassets/BUILD.bazel
+++ b/lib/khttp/kassets/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["assets.go"],
+    importpath = "github.com/enfabrica/enkit/lib/khttp/kassets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/khttp:go_default_library",
+        "//lib/logger:go_default_library",
+        "@com_github_dustin_go_humanize//:go_default_library",
+    ],
+)

--- a/lib/khttp/server.go
+++ b/lib/khttp/server.go
@@ -11,6 +11,8 @@ import (
 	"os"
 )
 
+type FuncHandler func(w http.ResponseWriter, r *http.Request)
+
 type Flags struct {
 	HttpPort    int
 	HttpAddress string

--- a/lib/oauth/BUILD.bazel
+++ b/lib/oauth/BUILD.bazel
@@ -11,9 +11,9 @@ go_library(
     deps = [
         "//lib/kflags:go_default_library",
         "//lib/khttp:go_default_library",
+        "//lib/khttp/kassets:go_default_library",
         "//lib/khttp/kcookie:go_default_library",
         "//lib/oauth/cookie:go_default_library",
-        "//lib/server:go_default_library",
         "//lib/token:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],

--- a/lib/oauth/oauth.go
+++ b/lib/oauth/oauth.go
@@ -61,7 +61,7 @@ import (
 	"github.com/enfabrica/enkit/lib/khttp"
 	"github.com/enfabrica/enkit/lib/khttp/kcookie"
 	"github.com/enfabrica/enkit/lib/oauth/cookie"
-	"github.com/enfabrica/enkit/lib/server"
+	"github.com/enfabrica/enkit/lib/khttp/kassets"
 	"github.com/enfabrica/enkit/lib/token"
 )
 
@@ -195,8 +195,8 @@ func (a *Authenticator) LoginURL(target string, state interface{}) (string, []by
 
 // Mapper configures all the URLs to redirect to / unless an authentication cookie is provided by the browser.
 // Further, it configures / to redirect and perform oauth authentication.
-func (auth *Authenticator) Mapper(mapper server.AssetMapper, lm ...LoginModifier) server.AssetMapper {
-	return func(original, name string, handler server.HttpHandler) []string {
+func (auth *Authenticator) Mapper(mapper kassets.AssetMapper, lm ...LoginModifier) kassets.AssetMapper {
+	return func(original, name string, handler khttp.FuncHandler) []string {
 		ext := filepath.Ext(original)
 		switch {
 		case name == "/favicon.ico":
@@ -316,7 +316,7 @@ func (a *Extractor) GetCredentialsFromRequest(r *http.Request) (*CredentialsCook
 //
 // Normally, you should use WithCredentialsOrRedirect(). Use this function only if you
 // expect your handler to be invoked with or without credentials.
-func (a *Extractor) WithCredentials(handler server.HttpHandler) server.HttpHandler {
+func (a *Extractor) WithCredentials(handler khttp.FuncHandler) khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		creds, err := a.GetCredentialsFromRequest(r)
 		if creds != nil && err == nil {
@@ -330,7 +330,7 @@ func (a *Extractor) WithCredentials(handler server.HttpHandler) server.HttpHandl
 //
 // Same as WithCredentials, except that invalid credentials result in a redirect to the specified target.
 // GetCredentials() invoked from the handler is guaranteed to return a non null result.
-func (a *Authenticator) WithCredentialsOrRedirect(handler server.HttpHandler, target string) server.HttpHandler {
+func (a *Authenticator) WithCredentialsOrRedirect(handler khttp.FuncHandler, target string) khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		creds, err := a.GetCredentialsFromRequest(r)
 		if creds == nil || err != nil {
@@ -343,7 +343,7 @@ func (a *Authenticator) WithCredentialsOrRedirect(handler server.HttpHandler, ta
 }
 
 // WithCredentialsOrError invokes the handler if credentials are available, errors out if not.
-func (a *Authenticator) WithCredentialsOrError(handler server.HttpHandler) server.HttpHandler {
+func (a *Authenticator) WithCredentialsOrError(handler khttp.FuncHandler) khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		creds, err := a.GetCredentialsFromRequest(r)
 		if creds == nil || err != nil {
@@ -375,7 +375,7 @@ func (a *Authenticator) WithCredentialsOrError(handler server.HttpHandler) serve
 // with your own code, ensuring it is an absolute URL.
 //
 // Note that login handlers need to be registered with your oauth provider.
-func (a *Authenticator) MakeLoginHandler(handler server.HttpHandler, lm ...LoginModifier) server.HttpHandler {
+func (a *Authenticator) MakeLoginHandler(handler khttp.FuncHandler, lm ...LoginModifier) khttp.FuncHandler {
 	loginHandler := a.LoginHandler(lm...)
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -422,7 +422,7 @@ func (a *Authenticator) MakeLoginHandler(handler server.HttpHandler, lm ...Login
 // Note that this call does not allow you to carry any additional state.
 // Use session cookies for that part instead, or get parameters.
 //
-func (a *Authenticator) LoginHandler(lm ...LoginModifier) server.HttpHandler {
+func (a *Authenticator) LoginHandler(lm ...LoginModifier) khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := a.PerformLogin(w, r, lm...)
 		if err != nil {
@@ -447,7 +447,7 @@ func (a *Authenticator) LoginHandler(lm ...LoginModifier) server.HttpHandler {
 //
 // Note that auth handlers need to be registered with your oauth provider.
 //
-func (a *Authenticator) MakeAuthHandler(handler server.HttpHandler) server.HttpHandler {
+func (a *Authenticator) MakeAuthHandler(handler khttp.FuncHandler) khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data, handled, err := a.PerformAuth(w, r)
 		if err == nil && data.Creds != nil {
@@ -476,7 +476,7 @@ func (a *Authenticator) MakeAuthHandler(handler server.HttpHandler) server.HttpH
 // In case of error, an ugly error message is displayed.
 //
 // Use MakeAuthHandler to customize the behavior.
-func (a *Authenticator) AuthHandler() server.HttpHandler {
+func (a *Authenticator) AuthHandler() khttp.FuncHandler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, handled, err := a.PerformAuth(w, r)
 		if err != nil {

--- a/lib/server/BUILD.bazel
+++ b/lib/server/BUILD.bazel
@@ -2,12 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = ["run.go"],
     importpath = "github.com/enfabrica/enkit/lib/server",
     visibility = ["//visibility:public"],
     deps = [
-        "//lib/logger:go_default_library",
-        "@com_github_dustin_go_humanize//:go_default_library",
         "@com_github_improbable_eng_grpc_web//go/grpcweb:go_default_library",
         "@com_github_soheilhy_cmux//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/lib/server/run.go
+++ b/lib/server/run.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"github.com/soheilhy/cmux"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+func Run(mux *http.ServeMux, grpcs *grpc.Server) {
+	reflection.Register(grpcs)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "6433"
+	}
+
+	log.Printf("Opening port %s - will be available at http://127.0.0.1:%s/", port, port)
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("failed to listen: %s", err)
+	}
+
+	// Create all listeners.
+	cml := cmux.New(listener)
+	grpcl := cml.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	httpl := cml.Match(cmux.Any())
+
+	grpcw := grpcweb.WrapServer(grpcs, grpcweb.WithAllowNonRootResource(true), grpcweb.WithWebsockets(true), grpcweb.WithOriginFunc(func(string) bool { return true }))
+
+	https := &http.Server{Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if grpcw.IsGrpcWebRequest(req) {
+			grpcw.ServeHTTP(resp, req)
+		} else {
+			mux.ServeHTTP(resp, req)
+		}
+	})}
+	go grpcs.Serve(grpcl)
+	go https.Serve(httpl)
+
+	if err := cml.Serve(); err != nil {
+		log.Fatalf("Serve failed with error: %s", err)
+	}
+}


### PR DESCRIPTION
This is a minor cleanup: right now, server.go includes a Run()
with heavy dependencies on grpc, and a bunch of helper functions
to deal with asset files.

The functions for asset file managmenet are generically useful
and self contained. But by being in the server library, they
cannot be used without bringing in the entire grpc ecosystem.

Also, it does not make sense for those functions to be in lib/server.

In this PR:
- move asset management functions as they are in lib/khttp/kassets.
- update code using those functions/libraries as necessary.
- rename lib/server/main.go in lib/server/run.go as there is no main
  there.

This PR is otherwise a noop: no code change has been performed.