### PR TITLE
linux/defs.bzl: Declare Module.symvers for each package

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -162,6 +162,12 @@ def _kernel_modules(ctx):
             module = m,
             output_long = output.path,
         )
+        output = ctx.actions.declare_file(ctx.attr.rename + "Module.symvers")
+        outputs += [output]
+        copy_command += "cp {src_dir}/Module.symvers {output_long} && ".format(
+            src_dir = srcdir,
+            output_long = output.path,
+        )
     copy_command += "true"
 
     extra = ""


### PR DESCRIPTION
The Module.symvers file will be necessary to build external modules that
consume exported symbols from a given module that it takes a dependency
on. Declaring it as a build artifact makes it easily available to other
builds.

Signed-off-by: Raghu Raja <raghu@enfabrica.net>