### PR TITLE
bazel/init.bzl: initialize golang sdk in one place only.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,11 +9,6 @@ load("//bazel:deps.bzl", "enkit_deps")
 
 enkit_deps()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_register_toolchains(version = "1.15.14")
-
 load("//bazel:init.bzl", "enkit_init")
 
 enkit_init()

--- a/bazel/init.bzl
+++ b/bazel/init.bzl
@@ -8,7 +8,7 @@ load("@com_github_atlassian_bazel_tools//multirun:deps.bzl", "multirun_dependenc
 
 def enkit_init_go():
     go_rules_dependencies()
-    go_register_toolchains()
+    go_register_toolchains(version = "1.15.14")
     go_embed_data_dependencies()
     gazelle_dependencies()
 


### PR DESCRIPTION
Before this change:
- WORKSPACE initializes the go toolchain
- bazel/init.bzl initializes the go toolchain
- the first initialization wins (WORKSPACE), so all works in enkit/

- another repository (internal) uses @enkit/baze/init.bzl
- there is no WORKSPACE initialization

---> CRASH, as the initialization in bazel/init.bzl is invalid with
the newer versions of the toolchain.

In this PR:
- initialize the golang toolchain from one place only,
  bazel/init.bzl, with the correct version.