### PR TITLE
Vendor jq and Update tests

### DIFF
--- a/bazel/init.bzl
+++ b/bazel/init.bzl
@@ -5,6 +5,7 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 load("@com_github_atlassian_bazel_tools//multirun:deps.bzl", "multirun_dependencies")
+load("//bazel/ui:deps.bzl", "install_ui_deps")
 
 def enkit_init_go():
     go_rules_dependencies()
@@ -32,3 +33,4 @@ def enkit_init():
     enkit_init_proto()
     enkit_init_ts()
     enkit_init_tools()
+    install_ui_deps()

--- a/bazel/ui/BUILD.bazel
+++ b/bazel/ui/BUILD.bazel
@@ -1,4 +1,16 @@
+load("//bazel/utils:binary.bzl", "declare_binary")
+
 exports_files([
     "react.bzl",
     "merge-package.sh",
 ])
+
+declare_binary(
+    name = "jq",
+    binary = select({
+        "@platforms//os:linux": "@jq_linux_amd64//:jq",
+        "@platforms//os:osx": "@jq_macos_amd64//:jq",
+    }),
+    binary_name = "jq",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/ui/deps.bzl
+++ b/bazel/ui/deps.bzl
@@ -1,0 +1,13 @@
+load("//bazel/utils:binary.bzl", "download_binary")
+
+def install_ui_deps():
+    download_binary(
+        name = "jq_linux_amd64",
+        binary_name = "jq",
+        uri = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64",
+    )
+    download_binary(
+        name = "jq_macos_amd64",
+        binary_name = "jq",
+        uri = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
+    )

--- a/bazel/ui/merge-package.sh
+++ b/bazel/ui/merge-package.sh
@@ -2,6 +2,8 @@
 args=("$@")
 counter=0
 ss=""
+jq_path=$1
+shift
 while [ "$1" != "" ]; do
   if [ -z "$ss" ]; then
     ss=".[0]"
@@ -11,4 +13,4 @@ while [ "$1" != "" ]; do
   counter=$((counter+1))
   shift
 done
-echo "$(jq -s "$ss" "${args[@]}")"
+$jq_path -s "$ss" "${args[@]:1}"

--- a/bazel/ui/react.bzl
+++ b/bazel/ui/react.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//bazel/utils:files.bzl", "rebase_and_copy_files")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//bazel/utils:binary.bzl", "declare_binary")
 
 """Creates a react project after running create-react-app.
 
@@ -29,8 +30,8 @@ def react_project(name, srcs, package_jsons, yarn_locks, publics, tsconfig, patc
     native.genrule(
         name = merge_json_name,
         outs = [paths.join(runner_dir_name, "package.json")],
-        tools = ["//bazel/ui:merge-package.sh"],
-        cmd = "$(location //bazel/ui:merge-package.sh) $(SRCS) > $@",
+        tools = ["//bazel/ui:merge-package.sh", "//bazel/ui:jq"],
+        cmd = "$(location //bazel/ui:merge-package.sh) $(location //bazel/ui:jq) $(SRCS) > $@",
         srcs = package_jsons,
         **kwargs
     )

--- a/bazel/utils/binary.bzl
+++ b/bazel/utils/binary.bzl
@@ -1,15 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def _download_binary(ctx):
-    """Downloads a single binary that is not tarballed.
-
-    Example:
-          download_binary(
-                name = "jq_macos_amd64",
-                binary_name = "jq",
-                uri = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
-            )
-    """
     ctx.download(
         url = [
             ctx.attr.uri,
@@ -24,6 +15,15 @@ def _download_binary(ctx):
 
 download_binary = repository_rule(
     _download_binary,
+    doc = """Downloads a single binary that is not tarballed.
+
+               Example:
+                     download_binary(
+                           name = "jq_macos_amd64",
+                           binary_name = "jq",
+                           uri = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
+                       )
+               """,
     attrs = {
         "binary_name": attr.string(
             mandatory = True,
@@ -35,20 +35,6 @@ download_binary = repository_rule(
 )
 
 def _declare_binary(ctx):
-    """Declares a single binary, used as a wrapper around a select() statement
-
-    Example:
-        declare_binary(
-            name = "jq",
-            binary = select({
-                "@platforms//os:linux": "@jq_linux_amd64//:jq",
-                "@platforms//os:osx": "@jq_macos_amd64//:jq",
-            }),
-            binary_name = "jq",
-            visibility = ["//visibility:public"],
-        )
-
-    """
     out = ctx.actions.declare_file(ctx.attr.binary_name)
     ctx.actions.symlink(
         output = out,
@@ -58,6 +44,20 @@ def _declare_binary(ctx):
 
 declare_binary = rule(
     _declare_binary,
+    doc = """Declares a single binary, used as a wrapper around a select() statement
+
+              Example:
+                  declare_binary(
+                      name = "jq",
+                      binary = select({
+                          "@platforms//os:linux": "@jq_linux_amd64//:jq",
+                          "@platforms//os:osx": "@jq_macos_amd64//:jq",
+                      }),
+                      binary_name = "jq",
+                      visibility = ["//visibility:public"],
+                  )
+
+              """,
     attrs = {
         "binary_name": attr.string(
             mandatory = True,

--- a/bazel/utils/binary.bzl
+++ b/bazel/utils/binary.bzl
@@ -1,0 +1,72 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def _download_binary(ctx):
+    """Downloads a single binary that is not tarballed.
+
+    Example:
+          download_binary(
+                name = "jq_macos_amd64",
+                binary_name = "jq",
+                uri = "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64",
+            )
+    """
+    ctx.download(
+        url = [
+            ctx.attr.uri,
+        ],
+        output = ctx.attr.binary_name,
+        executable = True,
+    )
+    ctx.file(
+        "BUILD.bazel",
+        content = 'exports_files(glob(["*"]))',
+    )
+
+download_binary = repository_rule(
+    _download_binary,
+    attrs = {
+        "binary_name": attr.string(
+            mandatory = True,
+        ),
+        "uri": attr.string(
+            mandatory = True,
+        ),
+    },
+)
+
+def _declare_binary(ctx):
+    """Declares a single binary, used as a wrapper around a select() statement
+
+    Example:
+        declare_binary(
+            name = "jq",
+            binary = select({
+                "@platforms//os:linux": "@jq_linux_amd64//:jq",
+                "@platforms//os:osx": "@jq_macos_amd64//:jq",
+            }),
+            binary_name = "jq",
+            visibility = ["//visibility:public"],
+        )
+
+    """
+    out = ctx.actions.declare_file(ctx.attr.binary_name)
+    ctx.actions.symlink(
+        output = out,
+        target_file = ctx.files.binary[0],
+    )
+    return DefaultInfo(executable = out)
+
+declare_binary = rule(
+    _declare_binary,
+    attrs = {
+        "binary_name": attr.string(
+            mandatory = True,
+        ),
+        "binary": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+        ),
+    },
+)


### PR DESCRIPTION
- Adds in the download_binary and declare_binary rules, which are simple wrappers
- Uses the wrapper to download binaries and executes them inside the ui tests.