### PR TITLE
bazel/linux/defs.bzl: speed up kernel builds.

### DIFF
--- a/bazel/linux/kernel_tree.BUILD.bzl
+++ b/bazel/linux/kernel_tree.BUILD.bzl
@@ -1,6 +1,6 @@
 filegroup(
     name = "{name}-tree",
-    srcs = glob(["**/*"]),
+    srcs = glob(["*"], allow_empty=False, exclude_directories=0),
     visibility = [
         "//visibility:public",
     ],


### PR DESCRIPTION
Background:
When bazel analyzes a target, it has to determine which input files
are necessary, if they changed, and maintain a tree in memory.
To do so, it has to load the list of files, compute hashes, ...

For kernel trees, this is really slow: there's 100,000s files
in there.

In this PR:
- change the glob expression from (**/* excluding directories [the default])
  to a simple * including directories.
- from empirical evidence, this seems to make the build visibly faster.

Looking at the bazel output on the screen, with this simple change
bazel went from: 325K targets configured, to just 26!

The only side effect is that it seems like the directories scanned
are made available in read only mode, which is actually desireable.

Although the amount of work to determine which files changed is
probably the same, work on the tree is probably much faster as
there are fewer nodes.

INFO: Analyzed target //{driver name} (3 packages loaded, 26 targets configured).

INFO: Analyzed target //{driver name} (3 packages loaded, 325430 targets configured).