### PR TITLE
monitor: dockerize the background pinger.

### DIFF
--- a/monitor/BUILD.bazel
+++ b/monitor/BUILD.bazel
@@ -18,6 +18,31 @@ go_library(
 
 go_binary(
     name = "monitor",
+    data = [":probes.toml"],
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+
+go_image(
+    name = "monitor-image",
+    base = "@golang_base//image",
+    binary = ":monitor",
+    data = [
+      ":probes.toml",
+    ],
+    args = ["$(location :probes.toml)"],
+    visibility = ["//visibility:public"],
+)
+
+container_push(
+    name = "upload-monitor-image",
+    format = "Docker",
+    image = ":monitor-image",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/monitor",
+    tag = "monitor-server",
     visibility = ["//visibility:public"],
 )

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,0 +1,8 @@
+# use docker-compose up -d to start the server with the correct settings.
+version: "3.3"
+services:
+  monitor:
+    network_mode: "host"
+    image: "gcr.io/devops-284019/infra/monitor:monitor-server"
+    user: "nobody"
+    restart: "unless-stopped"


### PR DESCRIPTION
In this PR:
- add rules to create a docker container for our monitor.
- add docker-compose.yml as an alternative to our typical shell scripts
  to start the container locally.