### PR TITLE
Add in additional Oauth2 methods

### DIFF
--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -138,7 +138,10 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "PublicKey cannot be parsed as an ssh authorized key - %s", err)
 		}
-		effectivePrincipals := append(s.principals, authData.Creds.Identity.Username)
+		effectivePrincipals := s.principals
+		for _, i := range authData.Identities {
+			effectivePrincipals = append(effectivePrincipals, i.Username)
+		}
 		userCert, err := kcerts.SignPublicKey(s.caPrivateKey, ssh.UserCert, effectivePrincipals, s.userCertTTL, savedPubKey)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error signing key - %s", err)

--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -138,9 +138,9 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "PublicKey cannot be parsed as an ssh authorized key - %s", err)
 		}
-		effectivePrincipals := s.principals
+		effectivePrincipals := append(s.principals, authData.PrimaryIdentity.Username)
 		for _, i := range authData.Identities {
-			effectivePrincipals = append(effectivePrincipals, i.Username)
+			effectivePrincipals = append(effectivePrincipals, i.GlobalName())
 		}
 		userCert, err := kcerts.SignPublicKey(s.caPrivateKey, ssh.UserCert, effectivePrincipals, s.userCertTTL, savedPubKey)
 		if err != nil {

--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -250,12 +250,13 @@ func Start(targetURL, cookieDomain, oAuthType string, astoreFlags *astore.Flags,
 		}
 
 		if key, ok := data.State.(common.Key); ok {
-			is, err := authWeb.Flow.Identities(&key)
+			primary, is, err := authWeb.Flow.Identities(&key)
 			if err != nil {
 				ShowResult(w, r, "angry", "Not Authorized", messageFail, http.StatusUnauthorized)
 			}
 			//TODO(adam): changes type of feedtoken to look cleaner
 			data.Identities = is
+			data.PrimaryIdentity = primary
 			authServer.FeedToken(key, data)
 		}
 		if !handled {

--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -234,7 +234,6 @@ func Start(targetURL, cookieDomain, oAuthType string, astoreFlags *astore.Flags,
 
 		data, handled, err := authWeb.PerformAuth(w, r, copts...)
 		if err != nil {
-			fmt.Println("FINALIZED")
 			ShowResult(w, r, "angry", "Not Authorized", messageFail, http.StatusUnauthorized)
 			log.Printf("ERROR - could not perform token exchange - %s", err)
 			return

--- a/lib/oauth/BUILD.bazel
+++ b/lib/oauth/BUILD.bazel
@@ -4,11 +4,13 @@ go_library(
     name = "go_default_library",
     srcs = [
         "factory.go",
+        "flow.go",
         "oauth.go",
     ],
     importpath = "github.com/enfabrica/enkit/lib/oauth",
     visibility = ["//visibility:public"],
     deps = [
+        "//astore/common:go_default_library",
         "//lib/kflags:go_default_library",
         "//lib/khttp:go_default_library",
         "//lib/khttp/kassets:go_default_library",
@@ -16,5 +18,6 @@ go_library(
         "//lib/oauth/cookie:go_default_library",
         "//lib/token:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
+        "@org_golang_x_oauth2//github:go_default_library",
     ],
 )

--- a/lib/oauth/BUILD.bazel
+++ b/lib/oauth/BUILD.bazel
@@ -19,5 +19,6 @@ go_library(
         "//lib/token:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
         "@org_golang_x_oauth2//github:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
     ],
 )

--- a/lib/oauth/factory.go
+++ b/lib/oauth/factory.go
@@ -2,8 +2,10 @@ package oauth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"golang.org/x/oauth2/github"
+	"golang.org/x/oauth2/google"
 	"io/ioutil"
 	"math/rand"
 	"net/url"
@@ -416,10 +418,18 @@ func WithAdditionalFlow(fileContent []byte) Modifier {
 		if err := json.Unmarshal(fileContent, &d); err != nil {
 			return err
 		}
+		var endpoint oauth2.Endpoint
+		if d.Type == "google" {
+			endpoint = google.Endpoint
+		}else if d.Type == "github" {
+			endpoint = github.Endpoint
+		}else{
+			return errors.New("oauth: additional flow type is not supported")
+		}
 		c := oauth2.Config{
 			ClientID:     d.ClientID,
 			ClientSecret: d.ClientSecret,
-			Endpoint:     github.Endpoint,
+			Endpoint:     endpoint,
 			Scopes:       []string{"email"},
 		}
 		opt.extraAuthConfig = &c

--- a/lib/oauth/flow.go
+++ b/lib/oauth/flow.go
@@ -1,0 +1,101 @@
+package oauth
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/enfabrica/enkit/astore/common"
+	"golang.org/x/oauth2"
+	"sync"
+)
+
+type FlowState struct {
+	OptionalUsed bool
+	RequiredUsed bool
+	Identities   []Identity
+}
+
+type FlowController struct {
+	currentFlows map[string]*FlowState
+	flowLock     sync.RWMutex
+	required     *oauth2.Config
+	optional     *oauth2.Config
+}
+
+func (fc *FlowController) getState(keyID *common.Key) (*FlowState, error) {
+	flowID := hex.EncodeToString(keyID[:])
+	fc.flowLock.RLock()
+	defer fc.flowLock.RUnlock()
+	state := fc.currentFlows[flowID]
+	if state == nil {
+		return nil, fmt.Errorf("flow %s id not exist", flowID)
+	}
+	return state, nil
+}
+
+func (fc *FlowController) saveState(keyID *common.Key, state *FlowState) {
+	fc.flowLock.Lock()
+	defer fc.flowLock.Unlock()
+	flowID := hex.EncodeToString(keyID[:])
+	fc.currentFlows[flowID] = state
+}
+
+// FirstOrCreateFlow
+func (fc *FlowController) FirstOrCreateFlow(keyID *common.Key) {
+	_, err := fc.getState(keyID)
+	if err != nil {
+		fc.saveState(keyID, &FlowState{})
+	}
+}
+
+func (fc *FlowController) FetchOauthConfig(keyID *common.Key) (*oauth2.Config, error) {
+	flowState, err := fc.getState(keyID)
+	if err != nil {
+		return nil, err
+	}
+	if flowState.OptionalUsed || fc.optional == nil {
+		return fc.required, nil
+	}
+	return fc.optional, nil
+}
+
+func (fc *FlowController) MarkAsDone(keyID *common.Key, conf *oauth2.Config) error {
+	flowState, err := fc.getState(keyID)
+	if err != nil {
+		return err
+	}
+	if conf == fc.optional {
+		flowState.OptionalUsed = true
+	}
+	if conf == fc.required {
+		flowState.RequiredUsed = true
+	}
+	fc.saveState(keyID, flowState)
+	return nil
+}
+
+func (fc *FlowController) ShouldRedirect(keyID *common.Key) bool {
+	flowID := hex.EncodeToString(keyID[:])
+	flowState := fc.currentFlows[flowID]
+	if flowState.OptionalUsed && flowState.RequiredUsed {
+		return false
+	}
+	return true
+}
+
+func (fc *FlowController) SaveIdentityForFlow(keyID *common.Key, iden Identity) error {
+	state, err := fc.getState(keyID)
+	if err != nil {
+		return err
+	}
+	state.Identities = append(state.Identities, iden)
+	fc.saveState(keyID, state)
+	return nil
+}
+
+func (fc *FlowController) Identities(keyID *common.Key) ([]Identity, error) {
+	flowState, err := fc.getState(keyID)
+	if err != nil {
+		return nil, err
+	}
+	return flowState.Identities, nil
+}

--- a/lib/oauth/flow.go
+++ b/lib/oauth/flow.go
@@ -40,14 +40,14 @@ func (fc *FlowController) saveState(keyID *common.Key, state *FlowState) {
 	fc.currentFlows[flowID] = state
 }
 
-// FirstOrCreateFlow
+// FirstOrCreateFlow initializes a state for the give common.Key
 func (fc *FlowController) FirstOrCreateFlow(keyID *common.Key) {
 	_, err := fc.getState(keyID)
 	if err != nil {
 		fc.saveState(keyID, &FlowState{})
 	}
 }
-
+// FetchOauthConfig returns the current oauth2.Config needed to be exchanged in the flow.
 func (fc *FlowController) FetchOauthConfig(keyID *common.Key) (*oauth2.Config, error) {
 	flowState, err := fc.getState(keyID)
 	if err != nil {
@@ -59,6 +59,8 @@ func (fc *FlowController) FetchOauthConfig(keyID *common.Key) (*oauth2.Config, e
 	return fc.optional, nil
 }
 
+// MarkAsDone will tell the flow that the oauth2.Config has been redeemed for this Identity. The next oauth2.Config
+// fetched from FetchOauthConfig will be different
 func (fc *FlowController) MarkAsDone(keyID *common.Key, conf *oauth2.Config, identity Identity) error {
 	flowState, err := fc.getState(keyID)
 	if err != nil {
@@ -91,6 +93,7 @@ func (fc *FlowController) ShouldRedirect(keyID *common.Key) bool {
 	return true
 }
 
+// Identities will return the primary identity and a list of the optional flow identities redeemed.
 func (fc *FlowController) Identities(keyID *common.Key) (Identity, []Identity, error) {
 	flowState, err := fc.getState(keyID)
 	if err != nil {

--- a/lib/oauth/flow.go
+++ b/lib/oauth/flow.go
@@ -74,8 +74,10 @@ func (fc *FlowController) MarkAsDone(keyID *common.Key, conf *oauth2.Config) err
 }
 
 func (fc *FlowController) ShouldRedirect(keyID *common.Key) bool {
-	flowID := hex.EncodeToString(keyID[:])
-	flowState := fc.currentFlows[flowID]
+	flowState, err := fc.getState(keyID)
+	if err != nil {
+		return false
+	}
 	if flowState.OptionalUsed && flowState.RequiredUsed {
 		return false
 	}

--- a/monitor/BUILD.bazel
+++ b/monitor/BUILD.bazel
@@ -28,12 +28,12 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_image(
     name = "monitor-image",
+    args = ["$(location :probes.toml)"],
     base = "@golang_base//image",
     binary = ":monitor",
     data = [
-      ":probes.toml",
+        ":probes.toml",
     ],
-    args = ["$(location :probes.toml)"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Adds in the ability to specify a single other oauth2 method (multiple are trivial to add) that must execute before the "required" flow occurs.

It accomplishes this by keeping track of which oauth2.Configs have been redeemed, and resets the flow until all have been finished. 

I still need to figure out a way to e2e test the auth server against real OIDC.
---
- add in the --add-oauth CLI flag, which enables additional oauth methods
- adds in a flow controller to the Authenticator struct in lib/oauth
 