### PR TITLE
[bugfix] lib/kcerts/certs.go: relax validity checks on TTL computation.

### DIFF
--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -152,7 +152,7 @@ func (a SSHAgent) AddCertificates(privateKey PrivateKey, publicKey ssh.PublicKey
 	agentClient := agent.NewClient(conn)
 	ttl := SSHCertRemainingTTL(cert)
 	if ttl == InValidCertTimeDuration {
-		return fmt.Errorf("ssh: certificate is already expired or invalid, not adding")
+		return fmt.Errorf("certificate is already expired or invalid, not adding")
 	}
 	return agentClient.Add(agent.AddedKey{
 		PrivateKey:   privateKey.Raw(),


### PR DESCRIPTION
Problem:
The authentication server clock may not be perfectly in sync with that
of the client. A few seconds of skew are possible.

When a certificate is loaded in the agent, how long is left for the
certificate has to be computed (so the agent discards the certificate
once no longer used).

Before this change:
- As part of computing how much time was left, the code also checked
  if the certificate was within the window of validity, down to the
  second.
- A 1 second skew between server and client (with server in the future
  by 1 second) could cause the certificate to be rejected.

In this change:
- compute the time left solely based on when the certificate expires.
  Generally, this is measured in hours, so a few seconds of skew do
  not affect the total result.
- don't check that the certificate is within the window of validity.
  Leave that to ssh-agent and the remote server to figure out and
  accept.