### PR TITLE
gee: added unit test

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@//bazel/astore:defs.bzl", "astore_upload")
-load("@//bazel:bats.bzl", "bats_test")
+load("@//bazel:shellutils.bzl", "bats_test")
 
 sh_library(
     name = "gee-lib",

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,4 +1,16 @@
 load("@//bazel/astore:defs.bzl", "astore_upload")
+load("@//bazel:bats.bzl", "bats_test")
+
+sh_library(
+    name = "gee-lib",
+    srcs = [ "gee" ],
+)
+
+bats_test(
+    name = "gee-bats",
+    srcs = ["gee.bats"],
+    deps = [":gee-lib"],
+)
 
 filegroup(
     name = "gee-script",

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-read -r -d '' USAGE <<'EOT'
+if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___ 
  / _` |/ _ \/ _ \  git
 | (_| |  __/  __/  enabled
@@ -77,6 +77,7 @@ review.
      gee rupdate
 
 EOT
+then :; fi
 # Philosophy:
 #
 #    If I have to look it up on stack overflow, it should get encoded in gee.
@@ -3253,4 +3254,6 @@ function main() {
   fi
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/gee.bats
+++ b/scripts/gee.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load "external/bats_support/load.bash"
+load "external/bats_assert/load.bash"
+
+# for tputs
+export TERM=screen-256color
+
+setup() {
+  source ./scripts/gee
+}
+
+@test "_contains_element" {
+  local -a A=(1 2 3 4 5 6)
+  run _contains_element 4 "${A[@]}"
+  assert_success
+  run _contains_element 9 "${A[@]}"
+  assert_failure
+}
+
+@test "_parse_options" {
+  declare -A FLAGS=()
+  declare -a ARGS_POSITIONAL=()
+
+  _parse_options "abcdef:g" -b -c -f foo bar -g -a bum
+
+  # typeset -p FLAGS >&3
+  assert_equal 1    "${FLAGS[b]}"
+  assert_equal 1    "${FLAGS[c]}"
+  assert_equal foo  "${FLAGS[f]}"
+  assert_equal 1    "${FLAGS[g]}"
+  assert_equal 1    "${FLAGS[a]}"
+  assert_equal 2    "${#ARGS_POSITIONAL[@]}"
+  assert_equal bar  "${ARGS_POSITIONAL[0]}"
+  assert_equal bum  "${ARGS_POSITIONAL[1]}"
+}
+
+@test "_parse_options success" {
+  declare -A FLAGS=()
+  declare -a ARGS_POSITIONAL=()
+  run _parse_options "abcdef:g" -b -c -f foo bar -g -a bum
+  assert_success
+}
+
+@test "_parse_options failure" {
+  declare -A FLAGS=()
+  declare -a ARGS_POSITIONAL=()
+  run _parse_options "abcdef:g" -b -c -f foo bar -g -a -z bum
+  assert_failure
+}


### PR DESCRIPTION
This built atop PR #167.

Adds gee.bats, a unit test for testing gee internal functions.
Adds _parse_options, a gee internal function that needed testing.
