### PR TITLE
gee: use SSHKEYFILE if it exists

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -615,31 +615,41 @@ function _startup_checks() {
   fi
 
   # check ssh agent
-  if ! ssh-add -l > /dev/null; then
-    local RC=$?
-    if (( RC == 2 )); then
-      _warn "Could not connect to ssh-agent."
-      _info "Consider adding \"eval \`enkit agent print\`\" to your .bashrc"
-      local RESP
-      read -r -p \
-        "Would you like gee to append this line to your .bashrc file now? (y/N)  "\
-        RESP
-      case "${RESP}" in
-        [Yy]*)
-          printf "eval \`enkit agent print\`\n" >> ~/.bashrc
-          ;;
-      esac
-      eval "$(enkit agent print)"
+  local RC
+  set +e
+  ssh-add -l >/dev/null
+  RC=$?
+  set -e
+  if (( RC == 0 )); then
+    return 0
+  elif (( RC == 1 )); then
+    if [[ -f "${SSHKEYFILE}" ]]; then
+      _cmd ssh-add "${SSHKEYFILE}"
     fi
+  elif (( RC == 2 )); then
+    _warn "Could not connect to ssh-agent."
+    _info "Consider adding \"eval \`enkit agent print\`\" to your .bashrc"
+    local RESP
+    read -r -p \
+      "Would you like gee to append this line to your .bashrc file now? (y/N)  "\
+      RESP
+    case "${RESP}" in
+      [Yy]*)
+        printf "eval \`enkit agent print\`\n" >> ~/.bashrc
+        ;;
+    esac
+    eval "$(enkit agent print)"
   fi
-  if ! ssh-add -l > /dev/null; then
-    local RC=$?
-    if (( RC == 1 )); then
-      _fatal "ssh-agent doesn't report any keys.  Please \"enkit login\" and try again."
-    fi
-    if (( RC == 2 )); then
-      _fatal "Persistent failure connecting to ssh-agent."
-    fi
+  
+  set +e
+  ssh-add -l >/dev/null
+  RC=$?
+  set -e
+  if (( RC == 1 )); then
+    _fatal "ssh-agent doesn't report any keys.  Please \"enkit login\" and try again."
+  elif (( RC == 2 )); then
+    _fatal "Persistent failure connecting to ssh-agent."
+  elif (( RC != 0 )); then
     _fatal "Unknown error from ssh-add command: RC=${RC}"
   fi
 }


### PR DESCRIPTION
This is adding back some functionality that I deleted when we were trying to
switch to enkit certs instead of ssh keys.
