### PR TITLE
gee: apt update before apt install

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1054,7 +1054,7 @@ function _install_tools() {
 
   if [ ! -x "${JQ}" ]; then
     _info "Installing missing tool: jq"
-    sudo /usr/bin/apt install jq
+    sudo /usr/bin/apt update && sudo /usr/bin/apt install jq
     if [ ! -x "${JQ}" ]; then
       _fatal "Could not install jq."
     fi


### PR DESCRIPTION
A user encountered an issue where jq couldn't be installed without running
"apt update" in the dev container first.  In this change, we play it safe
by always running apt update before apt install.
