### PR TITLE
Simple machinist fixes

### DIFF
--- a/machinist/machine/commands.go
+++ b/machinist/machine/commands.go
@@ -37,7 +37,7 @@ func NewEnrollCommand(conf *config.Node) *cobra.Command {
 
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			n, err := New()
+			n, err := New(WithConfig(conf))
 			if err != nil {
 				return err
 			}

--- a/machinist/machine/commands.go
+++ b/machinist/machine/commands.go
@@ -33,9 +33,6 @@ func NewNodeCommand(common *config.Common) *cobra.Command {
 func NewEnrollCommand(conf *config.Node) *cobra.Command {
 	c := &cobra.Command{
 		Use:  "enroll [Name] [OPTIONS]",
-		Args: cobra.ExactArgs(1),
-
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			n, err := New(WithConfig(conf))
 			if err != nil {


### PR DESCRIPTION
- passes in config to enroll command so that some base flags don't have to be set.
- using cobra Args commands breaks kcobra, so I removed it.