### PR TITLE
add gee-shellcheck_test

### DIFF
--- a/bazel/shellutils.bzl
+++ b/bazel/shellutils.bzl
@@ -58,3 +58,50 @@ bats_test = rule(
     test = True,
     implementation = _exec_test_impl,
 )
+
+def _external_exec_test_impl(ctx):
+  # Generic test that runs an external executable.  Right now, this is only
+  # used for shellcheck_test (shellcheck requires cabal to build, and so bazel
+  # integration is non-trivial).
+  runfiles = ctx.runfiles(
+      files = ctx.files.srcs + ctx.files.deps,
+      collect_data = True,
+  )
+  srcs = [f.short_path for f in ctx.files.srcs]
+  script = EXEC_TEST_TEMPLATE.format(
+          command = ctx.attr._command,
+          args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
+          srcs = " ".join([shell.quote(x) for x in srcs]),
+  )
+  ctx.actions.write(
+      output = ctx.outputs.executable,
+      is_executable = True,
+      content = script,
+  )
+  return DefaultInfo(
+      runfiles = runfiles,
+  )
+
+shellcheck_test = rule(
+    doc = """
+      Runs shellcheck on a shell script.
+    """,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc="Shell scripts to check."
+        ),
+        "extra_args": attr.string_list(
+            doc="Extra arguments to pass to shellcheck.",
+        ),
+        "deps": attr.label_list(
+            doc="Extra dependencies to make available when shellcheck runs.",
+        ),
+        "_command": attr.string(
+            default = "/usr/bin/shellcheck",  # available in dev container.
+            doc="Path to external shellcheck command.",
+        ),
+    },
+    test = True,
+    implementation = _external_exec_test_impl,
+)

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@//bazel/astore:defs.bzl", "astore_upload")
-load("@//bazel:shellutils.bzl", "bats_test")
+load("@//bazel:shellutils.bzl", "bats_test", "shellcheck_test")
 
 sh_library(
     name = "gee-lib",
@@ -10,6 +10,11 @@ bats_test(
     name = "gee-bats",
     srcs = ["gee.bats"],
     deps = [":gee-lib"],
+)
+
+shellcheck_test(
+    name = "gee-shellcheck_test",
+    srcs = ["gee"],
 )
 
 filegroup(


### PR DESCRIPTION
gee: use shelltest as a regression test for gee.

This should help me avoid embarrassing mistakes in the future, though this tool really needs to be rewritten in a real language.