### PR TITLE
lib/kflags: add ability to provide command line flags from a map.

### DIFF
--- a/lib/kflags/BUILD.bazel
+++ b/lib/kflags/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "defaults.go",
         "env.go",
         "flags.go",
+        "map.go",
     ],
     importpath = "github.com/enfabrica/enkit/lib/kflags",
     visibility = ["//visibility:public"],
@@ -19,7 +20,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["flags_test.go"],
+    srcs = [
+        "env_test.go",
+        "flags_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/lib/kflags/defaults.go
+++ b/lib/kflags/defaults.go
@@ -153,7 +153,7 @@ func SetContent(fl flag.Value, name string, value []byte) (string, error) {
 	return newv, fl.Set(newv)
 }
 
-// Populator is a function that given a set of resolvers, it is capable of invoking
+// Populator is a function that given a set of Augmenters, it is capable of invoking
 // them to assign default flag values.
 type Populator func(resolvers ...Augmenter) error
 

--- a/lib/kflags/env_test.go
+++ b/lib/kflags/env_test.go
@@ -1,0 +1,13 @@
+package kflags
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCamelRewrite(t *testing.T) {
+	assert.Equal(t, "", CamelRewrite(""))
+	assert.Equal(t, "Foo", CamelRewrite("foo"))
+	assert.Equal(t, "FooBar", CamelRewrite("foo-bar"))
+	assert.Equal(t, "FooBarBaz", CamelRewrite("foo_bar----baz--"))
+}

--- a/lib/kflags/flags.go
+++ b/lib/kflags/flags.go
@@ -43,6 +43,12 @@ type ContentValue interface {
 	SetContent(origin string, content []byte) error
 }
 
+// Consumer is any object that can take flags, and provides a common method
+// to register flags.
+type Consumer interface {
+	Register(fs FlagSet, prefix string)
+}
+
 // Wrap errors in a StatusError to indicate a different exit value to be
 // returned if the error causes the program to exit.
 type StatusError struct {

--- a/lib/kflags/kconfig/config.go
+++ b/lib/kflags/kconfig/config.go
@@ -125,7 +125,7 @@ type options struct {
 	log logger.Logger
 
 	// Generates the name of environment variables.
-	mangler kflags.EnvMangler
+	mangler kflags.VarMangler
 
 	paramfactory   ParamFactory
 	commandfactory CommandFactory
@@ -140,7 +140,7 @@ func DefaultOptions() *options {
 	return &options{
 		log:            logger.Nil,
 		recursionLimit: 10,
-		mangler:        kflags.PrefixRemap(kflags.DefaultRemap, "KCONFIG"),
+		mangler:        kflags.PrefixRemap(kflags.DefaultEnvRemap, "KCONFIG"),
 	}
 }
 
@@ -216,7 +216,7 @@ func WithBaseURL(url string) Modifier {
 	}
 }
 
-func WithMangler(mangler kflags.EnvMangler) Modifier {
+func WithMangler(mangler kflags.VarMangler) Modifier {
 	return func(o *options) error {
 		o.mangler = mangler
 		return nil

--- a/lib/kflags/kconfig/namespace.go
+++ b/lib/kflags/kconfig/namespace.go
@@ -59,7 +59,7 @@ type NamespaceAugmenter struct {
 	cf    CommandFactory
 
 	log     logger.Logger
-	mangler kflags.EnvMangler
+	mangler kflags.VarMangler
 
 	wg    sync.WaitGroup
 	elock sync.RWMutex // Protects errs below, but also access to visited flags (which may not support concurrent access).
@@ -74,7 +74,7 @@ type ParamFactory func(base *url.URL, param *Parameter) (Retriever, error)
 // CommandFactory is a function capable of retrieving a command implementation.
 type CommandFactory func(url, hash string) (string, *Manifest, error)
 
-func NewNamespaceAugmenter(base *url.URL, namespaces []Namespace, log logger.Logger, mangler kflags.EnvMangler, cf CommandFactory, pf ParamFactory) (*NamespaceAugmenter, error) {
+func NewNamespaceAugmenter(base *url.URL, namespaces []Namespace, log logger.Logger, mangler kflags.VarMangler, cf CommandFactory, pf ParamFactory) (*NamespaceAugmenter, error) {
 	ci := &NamespaceAugmenter{base: base, index: map[string]*namespaceData{}, cf: cf, log: log, mangler: mangler}
 	errs := []error{}
 	for _, ns := range namespaces {
@@ -146,7 +146,7 @@ func ExpandArgs(argv []string, subs map[string]interface{}) ([]string, error) {
 }
 
 // ExpandArg takes a key:value map, and creates environment variables containging the key and value.
-func PrepareEnv(subs map[string]interface{}, mangler kflags.EnvMangler) []string {
+func PrepareEnv(subs map[string]interface{}, mangler kflags.VarMangler) []string {
 	env := os.Environ()
 	for k, v := range subs {
 		str, ok := v.(string)
@@ -164,7 +164,7 @@ func PrepareEnv(subs map[string]interface{}, mangler kflags.EnvMangler) []string
 	return env
 }
 
-func CreateExecuteAction(packagedir string, commanddir string, argv []string, vars []Var, mangler kflags.EnvMangler, printer logger.Printer) (kflags.CommandAction, error) {
+func CreateExecuteAction(packagedir string, commanddir string, argv []string, vars []Var, mangler kflags.VarMangler, printer logger.Printer) (kflags.CommandAction, error) {
 	if len(argv) < 1 {
 		return nil, fmt.Errorf("argv must have at least the command name - it is empty")
 	}

--- a/lib/kflags/map.go
+++ b/lib/kflags/map.go
@@ -1,0 +1,73 @@
+package kflags
+
+type MapAugmenter struct {
+	args map[string]string
+	manglers []VarMangler
+}
+
+type MapModifier func(e *MapAugmenter)
+
+type MapModifiers []MapModifier
+
+func (ems MapModifiers) Apply(e *MapAugmenter) {
+	for _, em := range ems {
+		em(e)
+	}
+}
+
+// WithMapMangler sets the list of manglers to use to lookup the parameters in the map.
+func WithMapMangler(m ...VarMangler) MapModifier {
+	return func(e *MapAugmenter) {
+		e.manglers = m
+	}
+}
+
+// By default, the map augmenter looks up the literal flag name and a camel case version of it.
+//
+// For example, if the 'retry-number' flag is to be filled, 'retry-number' and 'RetryNumber'
+// are both looked up in the supplied map.
+var DefaultVarMangler = []VarMangler{SkipNamespaceRemap(JoinRemap("")), SkipNamespaceRemap(JoinRemap("", CamelRewrite))}
+
+// NewMapAugmenter returns an augmenter capable of looking up flags in a map.
+//
+// For example, supply a map like map["retry-number"] = "3", and the flag
+// "retry-number" will be set to the value of 3 depending on the VarMangler
+// configured.
+func NewMapAugmenter(args map[string]string, mods ...MapModifier) *MapAugmenter {
+	augmenter := &MapAugmenter{
+		args: args,
+		manglers: DefaultVarMangler,
+	}
+
+	MapModifiers(mods).Apply(augmenter)
+	return augmenter
+}
+
+// VisitCommand implements the VisitCommand interface of Augmenter. In AssetAugmenter, it is a noop.
+func (ma *MapAugmenter) VisitCommand(ns string, command Command) (bool, error) {
+	return false, nil
+}
+
+// VisitFlag implements the VisitFlag interface of Augmenter.
+func (ma *MapAugmenter) VisitFlag(reqns string, fl Flag) (bool, error) {
+	tomangle := []string{fl.Name()}
+
+	for _, mangler := range ma.manglers {
+		name := mangler(tomangle...)
+		if name == "" {
+			continue
+		}
+
+		result, found := ma.args[name]
+		if found {
+			return true, fl.Set(result)
+		}
+	}
+
+	return false, nil
+}
+
+// Done implements the Done interface of Augmenter.
+func (ar *MapAugmenter) Done() error {
+	return nil
+}

--- a/lib/kflags/map.go
+++ b/lib/kflags/map.go
@@ -5,6 +5,8 @@ type MapAugmenter struct {
 	manglers []VarMangler
 }
 
+var _ Augmenter = &MapAugmenter{}
+
 type MapModifier func(e *MapAugmenter)
 
 type MapModifiers []MapModifier


### PR DESCRIPTION
This change introduces a new Augmenter, the MapAugmenter, which allows
to provide flag defaults from a simple map, provided at the agumenter
creation time.

The MapAgumenter can be configured to use one or more EnvManglers
(now renamed VarMangler) to allow to compute a different key from
a flag name. For example, by using a Camel mangler, for a flag named
"network-timeout", the key "NetworkTimeout" is looked up in the flag.

Additionally, this PR restructures manglers to be more genereically
useful, and introduces a couple new ones.

No functional change to the codebase, this just adds new library
functions that will be used in an upcoming PR.