### PR TITLE
lib/config: add ability to delete key.

### DIFF
--- a/lib/config/BUILD.bazel
+++ b/lib/config/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/enfabrica/enkit/lib/config",
     visibility = ["//visibility:public"],
-    deps = ["//lib/config/marshal:go_default_library"],
+    deps = [
+        "//lib/config/marshal:go_default_library",
+        "//lib/multierror:go_default_library",
+    ],
 )
 
 go_test(

--- a/lib/config/directory/homedir_test.go
+++ b/lib/config/directory/homedir_test.go
@@ -38,6 +38,9 @@ func TestOpenDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 	assert.Equal(t, 0, len(data))
 
+	err = hd.Delete("test")
+	assert.True(t, os.IsNotExist(err))
+
 	quote := []byte("the burden of proof has to be placed on authority, and that it should be dismantled if that burden cannot be met")
 	err = hd.Write("test", quote)
 	assert.Nil(t, err)
@@ -49,4 +52,11 @@ func TestOpenDir(t *testing.T) {
 	confs, err = hd.List()
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"test"}, confs)
+
+	err = hd.Delete("test")
+	assert.Nil(t, err)
+
+	confs, err = hd.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, confs)
 }

--- a/lib/config/multi_test.go
+++ b/lib/config/multi_test.go
@@ -44,6 +44,11 @@ func TestMulti(t *testing.T) {
 	_, err = m.Unmarshal("quote", &read)
 	assert.True(t, os.IsNotExist(err))
 
+	err = m.Delete("quote")
+	assert.True(t, os.IsNotExist(err), "%v", err)
+	err = m.Delete("quote.toml")
+	assert.True(t, os.IsNotExist(err))
+
 	err = m.Marshal("quote", data)
 	assert.Nil(t, err)
 
@@ -81,7 +86,29 @@ func TestMulti(t *testing.T) {
 	err = m.Marshal(desc, data)
 	assert.Nil(t, err)
 
+	// Now we add a 3rd format, just so we can delete a file later.
+	err = m.Marshal("quote.yaml", data2)
+	assert.Nil(t, err)
+
 	found, err = m.List()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"quote.json", "quote.toml"}, found)
+	assert.Equal(t, []string{"quote.json", "quote.toml", "quote.yaml"}, found)
+
+	// Let's delete a specific file.
+	err = m.Delete(desc)
+	assert.Nil(t, err)
+
+	// Check that only one file was deleted.
+	found, err = m.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"quote.toml", "quote.yaml"}, found)
+
+	// Let's delete the whole key.
+	err = m.Delete("quote")
+	assert.Nil(t, err)
+
+	// No quote anymore.
+	found, err = m.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, found)
 }

--- a/lib/config/simple.go
+++ b/lib/config/simple.go
@@ -40,3 +40,11 @@ func (ss *SimpleStore) Unmarshal(name string, value interface{}) (Descriptor, er
 	}
 	return name, ss.marshaller.Unmarshal(data, value)
 }
+
+func (ss *SimpleStore) Delete(desc Descriptor) error {
+	name, ok := desc.(string)
+	if !ok {
+		return fmt.Errorf("API Usage Error - SimpleStore.Delete must be passed a string as descriptor")
+	}
+	return ss.loader.Delete(name)
+}

--- a/lib/config/store.go
+++ b/lib/config/store.go
@@ -1,16 +1,16 @@
-// Simple abstractions to read and write configuration parameters.
+// Simple abstractions to read and write configuration parameters by name.
 //
 // At the heart of the config module there is the `Store` interface, which allows to
-// load (Unmarshal) a configuration by name, or store it (Marshal).
+// load (Unmarshal) or store (Marshal) a configuration through a unique name.
 //
-// For example, once you have a Store object, all you have to do to load or store
-// a configuration is:
+// For example, once you have a Store object, you can store or load a configuration
+// with:
 //
 //     config := Config{
 //         Server: "127.0.0.1",
 //         Port: 53,
 //     }
-//   
+//
 //     if err := store.Marshal("server-config", config); err != nil {
 //        ...
 //     }
@@ -20,25 +20,22 @@
 //     if _, err := store.Unmarshal("server-config", &config); err != nil {
 //        ...
 //     }
-// 
+//
 // The "server-config" string is ... just a string. A key by which the configuration
 // is known by. Different Store implementations will use it differently: they may
 // turn it into a file name, into the key of a database, ...
 //
 // Internally, a `Store` does two things:
-//   1) It converts your config object into some binary blob.
+//   1) It converts your config object into some binary blob (marshal, unmarshal).
 //   2) It reads and writes this blob somewhere.
 //
 // Some databases and config stores use their own marshalling mechanism, while
 // others have no built in marshalling, and rely on a standard mechanism like
 // a json, yaml, or gob encoder.
 //
-// One layer below `Store` we have the `Loader` interface. The loader interface
-// allows to define a store that can only Read, Write, and List binary blobs
-// stored in the database.
-//
-// If you implement or use an object implementing the Loader interface, you can
-// use the NewSimple() or NewMulti() methods to create a `Store`.
+// If you need to store configs on a file system or database that does not have
+// a native marshalling/unmarshalling scheme, you can implement the `Loader`
+// interface, and then use NewSimple() or NewMulti() to turn a Loader into a Store.
 //
 // NewSimple and NewMulti wrap a store around an object capable of using one
 // of the standard encoders/decoders provided by go.
@@ -46,6 +43,7 @@
 package config
 
 // Represents a file that was Unmarshalled.
+//
 // Use descriptors to guarantee that a file is saved in the same location it was read from.
 type Descriptor interface{}
 
@@ -59,8 +57,14 @@ type Store interface {
 	// List the object names available for unmarshalling.
 	List() ([]string, error)
 
-	// descriptor is either a string, indicating a file name, or an object returned by Unmarshal.
-	// This allows to save data in exactly the same location or same way it was retrieved.
+	// Marshal saves an object, specified by value, under the name specified in descriptor.
+	//
+	// descriptor is either a string, indicating the desired unique name to store the
+	// object as, or an object returned by Unmarshal.
+	//
+	// Using a descriptor returned by Unmarshal guarantees that the object is written
+	// in exactly the same location where it was retrieved. This is useful for object
+	// stores that allow writing in multiple locations at once.
 	Marshal(descriptor Descriptor, value interface{}) error
 
 	// Unmarshal will read an object from the config store, and parse it into the value supplied,
@@ -70,6 +74,17 @@ type Store interface {
 	//
 	// In case the config file cannot be found, os.IsNotExist(error) will return true.
 	Unmarshal(name string, value interface{}) (Descriptor, error)
+
+	// Deletes an object.
+	//
+	// descriptor is either a string, indicating the desired unique name of the object
+	// to delete, or an object returned by Unmarshal.
+	//
+	// When specifying a string, Delete guarantees that all copies of the object known
+	// by that string are deleted.
+	//
+	// When specifying a Descriptor, Delete will only delete that one instance of the object.
+	Delete(descriptor Descriptor) error
 }
 
 // Implement the Loader interface to prvoide mechanisms to read and write configuration files.
@@ -80,4 +95,5 @@ type Loader interface {
 	List() ([]string, error)
 	Read(name string) ([]byte, error)
 	Write(name string, data []byte) error
+	Delete(name string) error
 }


### PR DESCRIPTION
Background:
So far, the config library allowed to store a config by key, and
retrieve it.

In this PR:
- add ability to delete a key.
- improve comments and documentation.
- add corresponding tests.

Additionally:
- Write() function in the homedir store has been improved to guarantee
  atomicity on POSIX filesystems.