### PR TITLE
lib/config: add a datastore config manager.

### DIFF
--- a/lib/config/BUILD.bazel
+++ b/lib/config/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/enfabrica/enkit/lib/config",
     visibility = ["//visibility:public"],
-    deps = ["//lib/config/marshal:go_default_library"],
+    deps = [
+        "//lib/config/marshal:go_default_library",
+        "//lib/multierror:go_default_library",
+    ],
 )
 
 go_test(

--- a/lib/config/datastore/BUILD.bazel
+++ b/lib/config/datastore/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["datastore.go"],
+    importpath = "github.com/enfabrica/enkit/lib/config/datastore",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/config:go_default_library",
+        "@com_github_davecgh_go_spew//spew:go_default_library",
+        "@com_google_cloud_go_datastore//:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
+    ],
+)

--- a/lib/config/datastore/datastore.go
+++ b/lib/config/datastore/datastore.go
@@ -1,0 +1,261 @@
+// Package datastore provides a Store capable of storing configs on datastore.
+//
+// The entry point is the New function, that allows you to create a Datastore
+// object.
+//
+// The Datastore object can then be used to open as many config stores as
+// necessary via the Open function, that can be used anywhere a store.Opener
+// is accepted.
+//
+// The Open function returns a proper Store, implementing the Marshal, Unmarshal,
+// and Delete methods.
+//
+// For example:
+//
+//   ds, err := datastore.New()
+//   if err != nil {
+//     ...
+//   }
+//
+//   ids, err := ds.Open("myapp1", "identities")
+//   if err != nil { ...
+//
+//   err, _ := ids.Marshal("carlo@enfabrica.net", credentials)
+//   if err != nil { ...
+//
+//   err, _ := ids.Marshal("default", credentials)
+//   if err != nil { ...
+//
+//   epts, err := ds.Open("myapp1", "endpoints")
+//   if err != nil { ...
+//
+//   err, _ := epts.Marshal("server1", parameters)
+//   err, _ := epts.Marshal("server2", parameters)
+//
+//
+// There are two main optional parameters that can be passed to datastore.New:
+// a ContextGenerator, and a KeyInitializer.
+//
+// A ContextGenerator returns a new context.Context every time it is invoked.
+// It can be used to set timeouts for operations, implement cancellations, or simply
+// change the context used at run time.
+//
+// A KeyInitializer generates a datastore.Key based on the parameters passed
+// to Open and Marshal. It can be used to map Marshal and Unmarshal operations
+// to arbitrary objects in the datastore tree.
+//
+//
+// To pass google options, a KeyInitializer, or ContextGenerator, you can use
+// one of the functional setters with datastore.New(). For example:
+//
+//  ds, err := datastore.New(WithGoogleOptions(opts), WithKeyInitializer(myfunc), WithContextGenerator(mybar))
+//
+package datastore
+
+import (
+	"cloud.google.com/go/datastore"
+	"context"
+	"fmt"
+	"github.com/enfabrica/enkit/lib/config"
+	"google.golang.org/api/option"
+	"os"
+	"reflect"
+)
+
+// ContextGenerator is a function capable of initializing or generating a context.
+type ContextGenerator func() context.Context
+
+// KeyGenerator is a function capable of generating a datastore key from a Marshal key.
+type KeyGenerator func(key string) (*datastore.Key, error)
+
+// KeyInitializer is a function capable of creating a KeyGenerator from Opener parameters.
+type KeyInitializer func(app string, namespaces ...string) (KeyGenerator, error)
+
+type Datastore struct {
+	Client          *datastore.Client
+	InitializeKey   KeyInitializer
+	GenerateContext ContextGenerator
+}
+
+var KindApp = "app"
+var KindNs = "ns"
+var KindEl = "el"
+
+// DefaultKeyGenerator generates a key by appending "el=key" to the specified root.
+var DefaultKeyGenerator = func(root *datastore.Key) KeyGenerator {
+	return func(element string) (*datastore.Key, error) {
+		return datastore.NameKey(KindEl, element, root), nil
+	}
+}
+
+// DefaultKeyInitializer returns a KeyGenerator using "app=myapp,ns=namespace,ns=namespace,..."
+// as root based on Open() parameters.
+var DefaultKeyInitializer KeyInitializer = func(app string, namespaces ...string) (KeyGenerator, error) {
+	root := datastore.NameKey(KindApp, app, nil)
+	for _, ns := range namespaces {
+		root = datastore.NameKey(KindNs, ns, root)
+	}
+	return DefaultKeyGenerator(root), nil
+}
+
+type options struct {
+	project   string
+	dsoptions []option.ClientOption
+
+	initializer KeyInitializer
+	cgenerator  ContextGenerator
+}
+
+type Modifier func(opt *options) error
+type Modifiers []Modifier
+
+// WithProject specifies the datastore project name.
+func WithProject(project string) Modifier {
+	return func(opt *options) error {
+		opt.project = project
+		return nil
+	}
+}
+
+func WithKeyInitializer(ki KeyInitializer) Modifier {
+	return func(opt *options) error {
+		opt.initializer = ki
+		return nil
+	}
+}
+
+func WithGoogleOptions(option ...option.ClientOption) Modifier {
+	return func(opt *options) error {
+		opt.dsoptions = append(opt.dsoptions, option...)
+		return nil
+	}
+}
+
+func WithContextGenerator(cgenerator ContextGenerator) Modifier {
+	return func(opt *options) error {
+		opt.cgenerator = cgenerator
+		return nil
+	}
+}
+
+func (mods Modifiers) Apply(opt *options) error {
+	for _, m := range mods {
+		if err := m(opt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DefaultContextGenerator returns a context with no deadline and no cancellation.
+var DefaultContextGenerator ContextGenerator = func() context.Context {
+	return context.Background()
+}
+
+func New(mods ...Modifier) (*Datastore, error) {
+	opts := options{initializer: DefaultKeyInitializer, cgenerator: DefaultContextGenerator, project: datastore.DetectProjectID}
+	if err := Modifiers(mods).Apply(&opts); err != nil {
+		return nil, err
+	}
+
+	client, err := datastore.NewClient(opts.cgenerator(), opts.project, opts.dsoptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Datastore{
+		Client:          client,
+		InitializeKey:   opts.initializer,
+		GenerateContext: opts.cgenerator,
+	}, nil
+}
+
+func (ds *Datastore) Open(app string, namespaces ...string) (config.Store, error) {
+	generator, err := ds.InitializeKey(app, namespaces...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Storer{Parent: ds, GenerateKey: generator, GenerateContext: ds.GenerateContext}, nil
+}
+
+type Storer struct {
+	Parent          *Datastore
+	GenerateKey     KeyGenerator
+	GenerateContext ContextGenerator
+}
+
+func (s *Storer) List() ([]string, error) {
+	key, err := s.GenerateKey("")
+	if err != nil {
+		return nil, err
+	}
+
+	q := datastore.NewQuery(key.Kind).Ancestor(key.Parent).KeysOnly()
+	keys, err := s.Parent.Client.GetAll(s.GenerateContext(), q, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []string{}
+	for _, key := range keys {
+		result = append(result, key.Name)
+	}
+	return result, nil
+}
+
+func (s *Storer) Marshal(descriptor config.Descriptor, value interface{}) error {
+	if reflect.ValueOf(value).Kind() != reflect.Ptr {
+		vp := reflect.New(reflect.TypeOf(value))
+		vp.Elem().Set(reflect.ValueOf(value))
+		value = vp.Interface()
+	}
+
+	name, converted := descriptor.(string)
+	if !converted {
+		return fmt.Errorf("invalid key: %#v - expected string", descriptor)
+	}
+
+	key, err := s.GenerateKey(name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.Parent.Client.Put(s.GenerateContext(), key, value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Storer) Unmarshal(name string, value interface{}) (config.Descriptor, error) {
+	key, err := s.GenerateKey(name)
+	if err != nil {
+		return "", err
+	}
+
+	if err := s.Parent.Client.Get(s.GenerateContext(), key, value); err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return "", os.ErrNotExist
+		}
+		return "", err
+	}
+	return name, nil
+}
+
+func (s *Storer) Delete(descriptor config.Descriptor) error {
+	name, converted := descriptor.(string)
+	if !converted {
+		return fmt.Errorf("invalid key: %#v - expected string", descriptor)
+	}
+
+	key, err := s.GenerateKey(name)
+	if err != nil {
+		return err
+	}
+
+	if err := s.Parent.Client.Delete(s.GenerateContext(), key); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/config/directory/homedir_test.go
+++ b/lib/config/directory/homedir_test.go
@@ -38,6 +38,9 @@ func TestOpenDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 	assert.Equal(t, 0, len(data))
 
+	err = hd.Delete("test")
+	assert.True(t, os.IsNotExist(err))
+
 	quote := []byte("the burden of proof has to be placed on authority, and that it should be dismantled if that burden cannot be met")
 	err = hd.Write("test", quote)
 	assert.Nil(t, err)
@@ -49,4 +52,11 @@ func TestOpenDir(t *testing.T) {
 	confs, err = hd.List()
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"test"}, confs)
+
+	err = hd.Delete("test")
+	assert.Nil(t, err)
+
+	confs, err = hd.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, confs)
 }

--- a/lib/config/multi_test.go
+++ b/lib/config/multi_test.go
@@ -44,6 +44,11 @@ func TestMulti(t *testing.T) {
 	_, err = m.Unmarshal("quote", &read)
 	assert.True(t, os.IsNotExist(err))
 
+	err = m.Delete("quote")
+	assert.True(t, os.IsNotExist(err), "%v", err)
+	err = m.Delete("quote.toml")
+	assert.True(t, os.IsNotExist(err))
+
 	err = m.Marshal("quote", data)
 	assert.Nil(t, err)
 
@@ -81,7 +86,29 @@ func TestMulti(t *testing.T) {
 	err = m.Marshal(desc, data)
 	assert.Nil(t, err)
 
+	// Now we add a 3rd format, just so we can delete a file later.
+	err = m.Marshal("quote.yaml", data2)
+	assert.Nil(t, err)
+
 	found, err = m.List()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"quote.json", "quote.toml"}, found)
+	assert.Equal(t, []string{"quote.json", "quote.toml", "quote.yaml"}, found)
+
+	// Let's delete a specific file.
+	err = m.Delete(desc)
+	assert.Nil(t, err)
+
+	// Check that only one file was deleted.
+	found, err = m.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"quote.toml", "quote.yaml"}, found)
+
+	// Let's delete the whole key.
+	err = m.Delete("quote")
+	assert.Nil(t, err)
+
+	// No quote anymore.
+	found, err = m.List()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, found)
 }

--- a/lib/config/simple.go
+++ b/lib/config/simple.go
@@ -40,3 +40,11 @@ func (ss *SimpleStore) Unmarshal(name string, value interface{}) (Descriptor, er
 	}
 	return name, ss.marshaller.Unmarshal(data, value)
 }
+
+func (ss *SimpleStore) Delete(desc Descriptor) error {
+	name, ok := desc.(string)
+	if !ok {
+		return fmt.Errorf("API Usage Error - SimpleStore.Delete must be passed a string as descriptor")
+	}
+	return ss.loader.Delete(name)
+}

--- a/lib/config/store.go
+++ b/lib/config/store.go
@@ -1,16 +1,16 @@
-// Simple abstractions to read and write configuration parameters.
+// Simple abstractions to read and write configuration parameters by name.
 //
 // At the heart of the config module there is the `Store` interface, which allows to
-// load (Unmarshal) a configuration by name, or store it (Marshal).
+// load (Unmarshal) or store (Marshal) a configuration through a unique name.
 //
-// For example, once you have a Store object, all you have to do to load or store
-// a configuration is:
+// For example, once you have a Store object, you can store or load a configuration
+// with:
 //
 //     config := Config{
 //         Server: "127.0.0.1",
 //         Port: 53,
 //     }
-//   
+//
 //     if err := store.Marshal("server-config", config); err != nil {
 //        ...
 //     }
@@ -20,25 +20,22 @@
 //     if _, err := store.Unmarshal("server-config", &config); err != nil {
 //        ...
 //     }
-// 
+//
 // The "server-config" string is ... just a string. A key by which the configuration
 // is known by. Different Store implementations will use it differently: they may
 // turn it into a file name, into the key of a database, ...
 //
 // Internally, a `Store` does two things:
-//   1) It converts your config object into some binary blob.
+//   1) It converts your config object into some binary blob (marshal, unmarshal).
 //   2) It reads and writes this blob somewhere.
 //
 // Some databases and config stores use their own marshalling mechanism, while
 // others have no built in marshalling, and rely on a standard mechanism like
 // a json, yaml, or gob encoder.
 //
-// One layer below `Store` we have the `Loader` interface. The loader interface
-// allows to define a store that can only Read, Write, and List binary blobs
-// stored in the database.
-//
-// If you implement or use an object implementing the Loader interface, you can
-// use the NewSimple() or NewMulti() methods to create a `Store`.
+// If you need to store configs on a file system or database that does not have
+// a native marshalling/unmarshalling scheme, you can implement the `Loader`
+// interface, and then use NewSimple() or NewMulti() to turn a Loader into a Store.
 //
 // NewSimple and NewMulti wrap a store around an object capable of using one
 // of the standard encoders/decoders provided by go.
@@ -46,6 +43,7 @@
 package config
 
 // Represents a file that was Unmarshalled.
+//
 // Use descriptors to guarantee that a file is saved in the same location it was read from.
 type Descriptor interface{}
 
@@ -59,8 +57,14 @@ type Store interface {
 	// List the object names available for unmarshalling.
 	List() ([]string, error)
 
-	// descriptor is either a string, indicating a file name, or an object returned by Unmarshal.
-	// This allows to save data in exactly the same location or same way it was retrieved.
+	// Marshal saves an object, specified by value, under the name specified in descriptor.
+	//
+	// descriptor is either a string, indicating the desired unique name to store the
+	// object as, or an object returned by Unmarshal.
+	//
+	// Using a descriptor returned by Unmarshal guarantees that the object is written
+	// in exactly the same location where it was retrieved. This is useful for object
+	// stores that allow writing in multiple locations at once.
 	Marshal(descriptor Descriptor, value interface{}) error
 
 	// Unmarshal will read an object from the config store, and parse it into the value supplied,
@@ -70,6 +74,17 @@ type Store interface {
 	//
 	// In case the config file cannot be found, os.IsNotExist(error) will return true.
 	Unmarshal(name string, value interface{}) (Descriptor, error)
+
+	// Deletes an object.
+	//
+	// descriptor is either a string, indicating the desired unique name of the object
+	// to delete, or an object returned by Unmarshal.
+	//
+	// When specifying a string, Delete guarantees that all copies of the object known
+	// by that string are deleted.
+	//
+	// When specifying a Descriptor, Delete will only delete that one instance of the object.
+	Delete(descriptor Descriptor) error
 }
 
 // Implement the Loader interface to prvoide mechanisms to read and write configuration files.
@@ -80,4 +95,5 @@ type Loader interface {
 	List() ([]string, error)
 	Read(name string) ([]byte, error)
 	Write(name string, data []byte) error
+	Delete(name string) error
 }


### PR DESCRIPTION
Background:
So far, configs could only be stored in a directory, or in the
home directory of the user.

This PR introduces a new config.Store implementation, capable
of storing objects and configs in datastore.