### PR TITLE
lib/khttp/kassets: allow indexes in subdirectories.

### DIFF
--- a/lib/khttp/kassets/assets.go
+++ b/lib/khttp/kassets/assets.go
@@ -3,7 +3,6 @@ package kassets
 import (
 	"bytes"
 	"compress/gzip"
-	"log"
 	"mime"
 	"net/http"
 	"path"
@@ -71,9 +70,9 @@ func BasicMapper(mapper AssetMapper) AssetMapper {
 		if ext == ".html" {
 			name = strings.TrimSuffix(name, ext)
 			res := mapper(original, name, handler)
-			if name == "/index" {
-				log.Printf("    registering as /")
-				res = append(res, mapper(original, "/", handler)...)
+			if strings.HasSuffix(name, "/index") {
+				target := strings.TrimSuffix(name, "index")
+				res = append(res, mapper(original, target, handler)...)
 			}
 			return res
 		}


### PR DESCRIPTION
Background:
Static assets are served differently depending on the file name.

For example: the .html extension is normally stripped, so foo/bar.html
is served as foo/bar.

Before this change:
/index.html was served as both /index and as /, but a foo/bar/index.html
was only served as foo/bar/index.

After this change:
foo/bar/index.html is also served as foo/bar/. Arguably, this PR fixes
an existing bug in the code, as the intended behavior was for any
index.html file to serve as the directory index.