### PR TITLE
gee__init: add --no-single-branch to git clone

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1717,7 +1717,11 @@ function gee__init() {
   if ! "${GH}" repo list | grep "^${GHUSER}/${REPO}" > /dev/null; then
     _gh repo fork --clone=false "${UPSTREAM}/${REPO}"
   fi
-  _git clone --depth "${CLONE_DEPTH}" "${URL}" "${REPO_DIR}/${MAIN}"
+  _git clone \
+    --depth "${CLONE_DEPTH}" \
+    --no-single-branch \
+    "${URL}" \
+    "${REPO_DIR}/${MAIN}"
   cd "${REPO_DIR}/${MAIN}"
   _git remote add upstream "${UPSTREAM_URL}"
   _git fetch upstream


### PR DESCRIPTION
This fixes a bug that was introduced in
https://github.com/enfabrica/enkit/pull/162.

It turns out that adding "--depth" option to "git clone" also implies the
"--single-branch" option, which causes git to only pull down the refs for the
main branch.

That is, the .git/config file for origin contained:

```
[remote "origin"]
  url = org-64667743@github.com:jonathan-enf/internal.git
  fetch = +refs/heads/master:refs/remotes/origin/master
```

It should be:

```
[remote "origin"]
  url = org-64667743@github.com:jonathan-enf/internal.git
  fetch = +refs/heads/*:refs/remotes/origin/*
```

This will cause git to error out as if origin/feature1 didn't exist, because
git was configured not to fetch it.

Since we always want all branch heads to be pulled down from origin, I had to
add the "--no-single-branch" option to undo the hidden side-effect.
