### PR TITLE
gee fix: fix clang-format

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3072,20 +3072,17 @@ function gee__fix() {
     fi
   done
   if (( "${#CLANG_FILES[@]}" )); then
-    if grep -q "name = \"cc_format\"" "${BDIR}/BUILD.bazel"; then
-      _cmd /usr/bin/bazelisk run \
-          --noshow_progress --noshow_loading_progress --logging=0 \
-          --ui_event_filters=-info,-debug \
-          //:cc_format \
-          -- \
-          "${CLANG_FILES[@]}"
-    elif [[ -x /usr/bin/clang-format-10 ]]; then
-      _info "clang-format-10: Fixing ${CLANG_FILES[*]}"
+    local CLANG_FORMAT=""
+    if [[ -x /usr/bin/clang-format-10 ]]; then
+      CLANG_FORMAT="/usr/bin/clang-format-10"
+    fi
+    if [[ -n "${CLANG_FORMAT}" ]]; then
+      _info "clang-format: Fixing ${CLANG_FILES[*]}"
       local STYLE="Google"
       if [[ -f "${BDIR}/cc.clang_format" ]]; then
         STYLE="${BDIR}/cc.clang_format"
       fi
-      _cmd /usr/bin/clang-format-10 --verbose --style="${STYLE}" -i "${CLANG_FILES[@]}"
+      _cmd "${CLANG_FORMAT}" --verbose --style="${STYLE}" -i "${CLANG_FILES[@]}"
     else
       _warn "No clang-format tool available."
     fi
@@ -3099,7 +3096,9 @@ function gee__fix() {
         PY_FILES+=("${FNAME}")
       fi
     done
-    _cmd "${BDIR}/pyformat.sh" "${PY_FILES[@]}"
+    if (( "${#PY_FILES[@]}" )); then
+      _cmd "${BDIR}/pyformat.sh" "${PY_FILES[@]}"
+    fi
   fi
 
   # TODO(jonathan): Add more formatters.


### PR DESCRIPTION
Even though the cc_format rule in enkit was updated to accept file names as
arguments, the enkit library was never released or updated in internal.  This
caused the default behavior (cc_format iterating over all files) to persist.

I think that ultimately, this felt like a fragile and unnecessary extra
dependency, so I went back to invoking clang-format-10 without depending on any
particular version of enkit being released.  The same formatting rules
(specified in cc.format) are employed.  Maybe at some point in the future
we can swap to building clang-format from source, if needed.

Ultimately, gee really should be a stand-alone tool that works in environments
other than enfabrica's.
