### PR TITLE
gee whatsout: diff against parent, not master

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2286,16 +2286,15 @@ _register_help "whatsout" \
   "List locally changed files in this branch." <<'EOT'
 Usage: gee whatsout
 
-Reports which files differ from main.
+Reports which files in this branch differ from parent branch.
 EOT
 
 function gee__whatsout() {
   _check_cwd
-  local BRANCH MERGEBASE
+  local BRANCH PARENT
   BRANCH="$(_get_current_branch)"
-  _set_main
-  MERGEBASE="$(git merge-base "origin/${MAIN}" "${BRANCH}")"
-  _git diff --name-only "${MERGEBASE}" 
+  PARENT="$(_get_parent_branch "${BRANCH}")"
+  _git diff --name-only "${PARENT}...${BRANCH}"
   if git diff --quiet ; then
     _info "Note: This branch contains uncommitted changes."
   fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -2293,6 +2293,7 @@ function gee__whatsout() {
   _check_cwd
   local BRANCH PARENT
   BRANCH="$(_get_current_branch)"
+  _read_parents_file
   PARENT="$(_get_parent_branch "${BRANCH}")"
   _git diff --name-only "${PARENT}...${BRANCH}"
   if git diff --quiet ; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -1105,6 +1105,16 @@ function _count_diffs() {
   "${GIT}" diff --name-only "${BRANCH_A}..${BRANCH_B}" | wc -l
 }
 
+function _branch_has_unstaged_changes() {
+  if "${GIT}" diff --quiet; then
+    # RC=0 means no differences, so return false
+    return 1
+  else
+    # RC=1 means differences were found, so return true
+    return 0
+  fi
+}
+
 function _branch_ahead_behind() {
   # Report how many commits this branch is ahead/behind another branch.
   local branch; branch="$1"
@@ -1905,7 +1915,7 @@ function gee__diff() {
   else
     _git_can_fail diff "${PARENT_BRANCH}"
   fi
-  if git diff --quiet ; then
+  if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."
   fi
 }
@@ -1932,7 +1942,7 @@ function gee__pack() {
   _parse_options "o:" "$@"
   local CURRENT_BRANCH
   CURRENT_BRANCH="$(_get_current_branch)"
-  if git diff --quiet ; then
+  if _branch_has_unstaged_changes; then
     _warn "You have uncommitted work in this branch that won't be packed."
     _confirm_or_exit "Do you want to proceed anyway? (y/N)  "
   fi
@@ -2296,7 +2306,7 @@ function gee__whatsout() {
   _read_parents_file
   PARENT="$(_get_parent_branch "${BRANCH}")"
   _git diff --name-only "${PARENT}...${BRANCH}"
-  if git diff --quiet ; then
+  if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."
   fi
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -2770,7 +2770,7 @@ function gee__pr_debug() {
   local -a PRS=()
   mapfile -t PRS < <( _list_open_pr_numbers )
   _info "Open pull requests: ${PRS[*]}"
-  mapfile -t PRS < <( _list_merged_pr_numbers )
+  mapfile -t PRS < <( _list_merged_pr_numbers "")
   _info "Merged pull requests: ${PRS[*]}"
 }
 


### PR DESCRIPTION
Decided that having "gee whatsout" show differents from parent, rather than
differences from main (same as "gee diff") was more intuitive.

Along the way, noticed that "git diff --quiet" has the opposite polarity of
exit code than I expected, so fixed.
