### PR TITLE
license_manager: Add proto definition file

### DIFF
--- a/license_manager/proto/BUILD.bazel
+++ b/license_manager/proto/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "license_manager_proto",
+    srcs = ["license_manager.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "license_manager_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/enfabrica/enkit/license_manager/proto",
+    proto = ":license_manager_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":license_manager_go_proto"],
+    importpath = "github.com/enfabrica/enkit/license_manager/proto",
+    visibility = ["//visibility:public"],
+)

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -1,0 +1,175 @@
+syntax = "proto3";
+
+package license_manager.proto;
+
+import "google/protobuf/timestamp.proto";
+
+// Describes a vendor-agnostic frontend for allocating licenses to hardware tool
+// command invocations.
+// Terminology:
+//
+//   License: A tuple of (vendor, license_type) strings that identifies a
+//     resource that can only be used by one process at a time. These resources
+//     are ultimately fetched from and returned to a vendor-specific license
+//     server.
+//
+//     Licenses are "allocated" when the LicenseManager frontend associates it
+//     with an invocation.
+//
+//     Licenses are "in use" when the invocation actually uses a license from
+//     the underlying license server. Licenses should not be "in use" unless
+//     they are also "allocated", but "allocated" licenses are not always "in
+//     use".
+//
+//   Invocation: A single execution of a particular hardware toolchain binary.
+//     Invocations may use a license, and to do so they must be allocated one
+//     before the underlying hardware toolchain process is allowed to execute.
+
+service LicenseManager {
+  // Allocate attempts to allocate a specific license type for this invocation.
+  // If successful, invocations will keep the allocation alive by calling
+  // Refresh(). If the invocation is queued for the license instead, invocations
+  // will continue polling with Allocate() until allocation is successful.
+  rpc Allocate(AllocateRequest) returns (AllocateResponse) {}
+
+  // Refresh refreshes a license allocation while an invocation is still
+  // potentially using the license. If the invocation fails to refresh the
+  // allocation, the underlying license may be allocated to another invocation.
+  rpc Refresh(RefreshRequest) returns (RefreshResponse) {}
+
+  // LicensesStatus returns the status of all license types, as reported by both
+  // the LicenseManager and the underlying license servers.
+  rpc LicensesStatus(LicensesStatusRequest) returns (LicensesStatusResponse) {}
+}
+
+message AllocateRequest {
+  // Licenses to acquire for this invocation.
+  //
+  // Invocations that need multiple of the same license type should insert
+  // duplicate entries in this field.
+  //
+  // Implementations currently only support reserving once license per
+  // invocation, though future implementations may allow for allocations of
+  // multiple and of different types.
+  repeated License license = 1; // required
+
+  // Owning entity issuing the allocation request. Used for logging purposes
+  // only. This could be the name of the user or system issuing the request.
+  string owner = 2; // required
+
+  // Build tag of the allocation request. This tag does not need to be unique
+  // across multiple AllocateRequests, and may be used to associate multiple
+  // such requests with one higher-level task. Typically the Bazel build
+  // invocation ID is used here.
+  string build_tag = 3; // required
+
+  // If this is not the first AllocateRequest message sent for this
+  // invocation, then this is the invocation_id in a previous AllocateResponse
+  // sent, so that this invocation can queue properly. Otherwise, this field
+  // should be left blank.
+  string invocation_id = 4;
+}
+
+message AllocateResponse {
+  oneof response_type {
+    // Returned when allocation is successful; the invocation should be able
+    // to proceed while simultaneously calling Refresh().
+    LicenseAllocated license_allocated = 1;
+
+    // Returned when allocation is unsuccessful due to license contention.
+    // The invocation should continue to poll by calling Allocate() passing
+    // the invocation_id returned in this message.
+    Queued queued = 2;
+  }
+}
+
+message Queued {
+  // Opaque identifier for this invocation, determined by the server. This ID
+  // associates the invocation with a specific spot in the queue; it should be
+  // used in subsequent AllocateRequest messages or the invocation will be
+  // placed at the back of the queue.
+  string invocation_id = 1;
+
+  // Time at which client should issue its next AllocateRequest. The client
+  // should issue its next poll after this time; if it fails to poll for
+  // significantly longer (>5s) it may be moved to the back of the queue.
+  google.protobuf.Timestamp next_poll_time = 2;
+}
+
+message LicenseAllocated {
+  // Opaque identifier for this invocation, determined by the server. This ID
+  // should be used by the client in subsequent RefreshRequests for this
+  // license.
+  string invocation_id = 1;
+
+  // Time at which the allocated license should be refreshed. The client should
+  // issue a RefreshRequest for this invocation_id after this time; if it fails
+  // to refresh for significantly longer (>5s) its allocation may expire.
+  google.protobuf.Timestamp license_refresh_time = 2;
+}
+
+message RefreshRequest {
+  // Opaque identifier for this invocation, as returned by the server in the
+  // AllocateResponse that allocated this license.
+  string invocation_id = 1; // required
+
+  // If true, the invocation is indicating that it no longer requires the
+  // allocated license, and the server should deallocate it. The resulting
+  // RefreshResponse can be expected to have `allocated` == false.
+  bool release = 2;
+}
+
+message RefreshResponse {
+  // AllocateResponse that allocated this license.
+  string invocation_id = 1;
+
+  // Whether the license is still allocated. If false, the invocation should
+  // be killed immediately.
+  bool allocated = 2;
+
+  // Time at which the request license will be revoked. The client should
+  // issue another RefreshRequest for this invocation_id before this time.
+  google.protobuf.Timestamp license_refresh_deadline = 3;
+}
+
+message LicensesStatusRequest {
+  // Empty request
+}
+
+message LicensesStatusResponse {
+  // Stats for each managed license vendor/feature combination.
+  repeated LicenseStats license_stats = 1;
+}
+
+message LicenseStats {
+  // License to which these stats apply.
+  License license = 1;
+
+  // Time at which these stats were accurate. Slightly stale stats may be
+  // returned due to the underlying polling interval, and stats are not an
+  // indication of whether a subsequent AllocateRequest will immediately
+  // result in an allocation.
+  google.protobuf.Timestamp timestamp = 2;
+
+  // Number of licenses available in total, as reported by the underlying
+  // license server.
+  uint32 total_license_count = 3;
+
+  // Number of licenses currently in use, as reported by the underlying
+  // license server.
+  uint32 in_use_count = 4;
+
+  // Number of licenses currently allocated, as reported by the
+  // LicenseManager. This should be less than or equal to in_use_count.
+  uint32 allocated_count = 5;
+}
+
+message License {
+  // Lower-case vendor name, such as `xilinx` or `cadence`.
+  string vendor = 1; // required
+
+  // Case-sensitive feature that this license is for, such as
+  // `Vivado_System_Edition` or `HLS`. These are defined by the underlying
+  // license server.
+  string feature = 2; // required
+}

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -53,7 +53,7 @@ service LicenseManager {
   //
   // Returns:
   //   * NOT_FOUND if the allocation is not known to the server.
-  rpc Release(ReleaseReqeust) returns (ReleaseResponse) {}
+  rpc Release(ReleaseRequest) returns (ReleaseResponse) {}
 
   // LicensesStatus returns the status of all license types, as reported by both
   // the LicenseManager and the underlying license servers.
@@ -138,6 +138,15 @@ message RefreshResponse {
   // Time at which the request license will be revoked. The client should
   // issue another RefreshRequest for this invocation_id before this time.
   google.protobuf.Timestamp license_refresh_deadline = 3;
+}
+
+message ReleaseRequest {
+  // AllocateResponse that allocated this license.
+  string invocation_id = 1;
+}
+
+message ReleaseResponse {
+  // Empty response
 }
 
 message LicensesStatusRequest {

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -30,12 +30,30 @@ service LicenseManager {
   // If successful, invocations will keep the allocation alive by calling
   // Refresh(). If the invocation is queued for the license instead, invocations
   // will continue polling with Allocate() until allocation is successful.
+  //
+  // Returns:
+  //   * NOT_FOUND if the license type is not known to the server
+  //   * RESOURCE_EXHAUSTED if the license type is known but there are currently
+  //     no licenses of that type available
   rpc Allocate(AllocateRequest) returns (AllocateResponse) {}
 
   // Refresh refreshes a license allocation while an invocation is still
   // potentially using the license. If the invocation fails to refresh the
   // allocation, the underlying license may be allocated to another invocation.
+  //
+  // Returns:
+  //   * NOT_FOUND if allocation is not known to the server, and the client
+  //     should kill the invocation.
   rpc Refresh(RefreshRequest) returns (RefreshResponse) {}
+
+  // Release returns an allocated license to the pool. This should be called by
+  // clients to return licenses so they can be quickly allocated to other
+  // processes in the pool; otherwise, the server will need to wait for the
+  // client to time out issuing Refresh calls.
+  //
+  // Returns:
+  //   * NOT_FOUND if the allocation is not known to the server.
+  rpc Release(ReleaseReqeust) returns (ReleaseResponse) {}
 
   // LicensesStatus returns the status of all license types, as reported by both
   // the LicenseManager and the underlying license servers.
@@ -102,30 +120,20 @@ message LicenseAllocated {
   // license.
   string invocation_id = 1;
 
-  // Time at which the allocated license should be refreshed. The client should
-  // issue a RefreshRequest for this invocation_id after this time; if it fails
-  // to refresh for significantly longer (>5s) its allocation may expire.
-  google.protobuf.Timestamp license_refresh_time = 2;
+  // Time at which the request license will be revoked. The client should issue
+  // a RefreshRequest for this invocation_id before this time.
+  google.protobuf.Timestamp license_refresh_deadline = 2;
 }
 
 message RefreshRequest {
   // Opaque identifier for this invocation, as returned by the server in the
   // AllocateResponse that allocated this license.
   string invocation_id = 1; // required
-
-  // If true, the invocation is indicating that it no longer requires the
-  // allocated license, and the server should deallocate it. The resulting
-  // RefreshResponse can be expected to have `allocated` == false.
-  bool release = 2;
 }
 
 message RefreshResponse {
   // AllocateResponse that allocated this license.
   string invocation_id = 1;
-
-  // Whether the license is still allocated. If false, the invocation should
-  // be killed immediately.
-  bool allocated = 2;
 
   // Time at which the request license will be revoked. The client should
   // issue another RefreshRequest for this invocation_id before this time.

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -155,10 +155,6 @@ message LicenseStats {
   // license server.
   uint32 total_license_count = 3;
 
-  // Number of licenses currently in use, as reported by the underlying
-  // license server.
-  uint32 in_use_count = 4;
-
   // Number of licenses currently allocated, as reported by the
   // LicenseManager. This should be less than or equal to in_use_count.
   uint32 allocated_count = 5;


### PR DESCRIPTION
This change adds a gRPC definition for the license_manager service,
intended to supplant the existing license service under `//manager` with
a protocol that uses multiple unary RPCs instead of a bidirectional
streaming RPC, in an effort to clarify the implementation of both the
client and the server.

Requirements and more info can be found in: https://docs.google.com/document/d/1TNqbBprpcNU9tTHVCFzRwaQoHlGFdjkw221C5p9UsAw/edit

Tested: All targets build:

```
bazel build //license_manager/...
```

Jira: INFRA-90