### PR TITLE
enkit: Add `bazel` subcommand

### DIFF
--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//astore/client/commands:go_default_library",
+        "//lib/bazel/commands:go_default_library",
         "//lib/client:go_default_library",
         "//lib/client/commands:go_default_library",
         "//lib/kflags/kcobra:go_default_library",

--- a/enkit/main.go
+++ b/enkit/main.go
@@ -5,6 +5,7 @@ import (
 
 	acommands "github.com/enfabrica/enkit/astore/client/commands"
 	bcommands "github.com/enfabrica/enkit/lib/client/commands"
+	bazelcmds "github.com/enfabrica/enkit/lib/bazel/commands"
 	tcommands "github.com/enfabrica/enkit/proxy/ptunnel/commands"
 
 	"github.com/enfabrica/enkit/lib/kflags/kcobra"
@@ -43,6 +44,9 @@ func main() {
 
 	agentCommand := tcommands.NewAgentCommand(base)
 	root.AddCommand(agentCommand)
+
+	bazel := bazelcmds.New(base)
+	root.AddCommand(bazel.Command)
 
 	base.Run(kcobra.HideFlags(set), populator, runner)
 }

--- a/lib/bazel/commands/BUILD.bazel
+++ b/lib/bazel/commands/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["commands.go"],
+    importpath = "github.com/enfabrica/enkit/lib/bazel/commands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/client:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/lib/bazel/commands/commands.go
+++ b/lib/bazel/commands/commands.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/enfabrica/enkit/lib/client"
+
+	"github.com/spf13/cobra"
+)
+
+type Root struct {
+	*cobra.Command
+	*client.BaseFlags
+}
+
+func New(base *client.BaseFlags) *Root {
+	root := NewRoot(base)
+
+	root.AddCommand(NewAffectedTargets(root).Command)
+
+	return root
+}
+
+func NewRoot(base *client.BaseFlags) *Root {
+	rc := &Root {
+		Command: &cobra.Command{
+			Use: "bazel",
+			Short: "Perform bazel helper actions",
+			SilenceUsage: true,
+			SilenceErrors: true,
+			Long: `bazel - performs helper bazel operations`,
+		},
+		BaseFlags: base,
+	}
+	return rc
+}
+
+type AffectedTargets struct {
+	*cobra.Command
+	root *Root
+
+	Start string
+	End string
+}
+
+func NewAffectedTargets(root *Root) *AffectedTargets {
+	command := &AffectedTargets{
+		Command: &cobra.Command{
+			Use: "affected-targets",
+			Short: "Operations involving changed bazel targets between two source revision points",
+			Aliases: []string{"at"},
+		},
+		root: root,
+	}
+
+	command.PersistentFlags().StringVarP(&command.Start, "start", "s", "HEAD", "Git committish of 'before' revision")
+	command.PersistentFlags().StringVarP(&command.End, "end", "e", "", "Git committish of 'end' revision, or empty for current dir with uncomitted changes")
+
+	command.AddCommand(NewAffectedTargetsList(command).Command)
+
+	return command
+}
+
+type AffectedTargetsList struct {
+	*cobra.Command
+	parent *AffectedTargets
+}
+
+func NewAffectedTargetsList(parent *AffectedTargets) *AffectedTargetsList {
+	command := &AffectedTargetsList {
+		Command: &cobra.Command{
+			Use: "list",
+			Short: "List affected targets between two source revision points",
+			Aliases: []string{"ls"},
+			Example: `  $ enkit bazel affected-targets list
+        List affected targets between the last commit and current uncommitted changes.
+
+  $ enkit bazel affected-targets list --start=HEAD~1 --end=HEAD
+        List affected targets in the most recent commit.`,
+		},
+		parent: parent,
+	}
+	command.Command.RunE = command.Run
+	return command
+}
+
+func (c *AffectedTargetsList) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("not yet implemented")
+}
+

--- a/lib/bazel/commands/commands.go
+++ b/lib/bazel/commands/commands.go
@@ -41,6 +41,7 @@ type AffectedTargets struct {
 
 	Start string
 	End string
+	Universe []string
 }
 
 func NewAffectedTargets(root *Root) *AffectedTargets {
@@ -55,6 +56,7 @@ func NewAffectedTargets(root *Root) *AffectedTargets {
 
 	command.PersistentFlags().StringVarP(&command.Start, "start", "s", "HEAD", "Git committish of 'before' revision")
 	command.PersistentFlags().StringVarP(&command.End, "end", "e", "", "Git committish of 'end' revision, or empty for current dir with uncomitted changes")
+	command.PersistentFlags().StringSliceVarP(&command.Universe, "universe", "u", []string{"//..."}, "Target universe in which to search for dependencies")
 
 	command.AddCommand(NewAffectedTargetsList(command).Command)
 

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -3,7 +3,7 @@ load("@//bazel:shellutils.bzl", "bats_test", "shellcheck_test")
 
 sh_library(
     name = "gee-lib",
-    srcs = [ "gee" ],
+    srcs = ["gee"],
 )
 
 bats_test(


### PR DESCRIPTION
This change adds a `bazel` subcommand tree to `enkit`, initiailly
populated with `bazel affected-targets list`. This command is not yet
implemented, but will eventually print the list of affected targets to
stdout.

Output of `enkit bazel affected-targets list --help`:

```
List affected targets between two source revision points

Usage:
  enkit bazel affected-targets list [flags]

Aliases:
  list, ls

Examples:
  $ enkit bazel affected-targets list
        List affected targets between the last commit and current uncommitted changes.

  $ enkit bazel affected-targets list --start=HEAD~1 --end=HEAD
        List affected targets in the most recent commit.

Flags:
  -h, --help   help for list

Global Flags:
  -e, --end string         Git committish of 'end' revision, or empty for current dir with uncomitted changes
      --help-all           Show all the flags available, even those that are less useful and normally hidden.
  -s, --start string       Git committish of 'before' revision (default "HEAD")
  -u, --universe strings   Target universe in which to search for dependencies (default [//...])
```

Doc: https://docs.google.com/document/d/1Omjh4IF5vTpR6bbPPRb_jDRsWs3QmsrBzs8Acyw4Y2I/edit#

Jira: INFRA-52