### PR TITLE
testing: Add errdiff lib

### DIFF
--- a/lib/errdiff/BUILD.bazel
+++ b/lib/errdiff/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    testonly = True,
+    srcs = ["errdiff.go"],
+    importpath = "github.com/enfabrica/enkit/lib/errdiff",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["errdiff_test.go"],
+    embed = [":go_default_library"],
+)

--- a/lib/errdiff/errdiff.go
+++ b/lib/errdiff/errdiff.go
@@ -1,0 +1,34 @@
+package errdiff
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Substring checks that an error `got` matches the expectation `want`.
+// Empty `want` string means no error is expected; if not empty, `got` must be
+// non-nil and contain `want` as a substring to meet the expectation.
+// Returns an empty string if `got` meets the `want` expectation, or a string
+// containing an explanation of the discrepancy otherwise.
+//
+// Example use:
+//
+//   if diff := errdiff.Substring(gotErr, "some substring"); diff != "" {
+//     t.Error(diff)
+//   }
+func Substring(got error, want string) string {
+	switch {
+	case got == nil && want == "":
+		return ""
+	case got == nil && want != "":
+		return fmt.Sprintf("got no error; want error containing %q", want)
+	case got != nil && want == "":
+		return fmt.Sprintf("got error: '%v'; want no error", got)
+	case got != nil && want != "":
+		if strings.Contains(got.Error(), want) {
+			return ""
+		}
+		return fmt.Sprintf("got error: '%v'; want error containing substring: %q", got, want)
+	}
+	panic("unhandled case")
+}

--- a/lib/errdiff/errdiff.go
+++ b/lib/errdiff/errdiff.go
@@ -3,20 +3,10 @@ package errdiff
 import (
 	"fmt"
 	"strings"
+	"testing"
 )
 
-// Substring checks that an error `got` matches the expectation `want`.
-// Empty `want` string means no error is expected; if not empty, `got` must be
-// non-nil and contain `want` as a substring to meet the expectation.
-// Returns an empty string if `got` meets the `want` expectation, or a string
-// containing an explanation of the discrepancy otherwise.
-//
-// Example use:
-//
-//   if diff := errdiff.Substring(gotErr, "some substring"); diff != "" {
-//     t.Error(diff)
-//   }
-func Substring(got error, want string) string {
+func substring(got error, want string) string {
 	switch {
 	case got == nil && want == "":
 		return ""
@@ -31,4 +21,16 @@ func Substring(got error, want string) string {
 		return fmt.Sprintf("got error: '%v'; want error containing substring: %q", got, want)
 	}
 	panic("unhandled case")
+}
+
+// Check checks that an error `got` matches the expectation `want`.
+// Empty `want` string means no error is expected; if not empty, `got` must be
+// non-nil and contain `want` as a substring to meet the expectation.
+// Returns an empty string if `got` meets the `want` expectation, or a string
+// containing an explanation of the discrepancy otherwise.
+func Check(t *testing.T, got error, want string) {
+	t.Helper()
+	if diff := substring(got, want); diff != "" {
+		t.Error(diff)
+	}
 }

--- a/lib/errdiff/errdiff_test.go
+++ b/lib/errdiff/errdiff_test.go
@@ -1,0 +1,57 @@
+package errdiff
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSubstring(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err error
+		subStr string
+		wantDiff bool
+	} {
+		{
+			desc: "pass with nil error and no substring expectation",
+			err: nil,
+			subStr: "",
+			wantDiff: false,
+		},
+		{
+			desc: "pass when non-nil error contains substring",
+			err: errors.New("some error text"),
+			subStr: "error text",
+			wantDiff: false,
+		},
+		{
+			desc: "fail when non-nil error doesn't contain substring",
+			err: errors.New("some error text"),
+			subStr: "some other error",
+			wantDiff: true,
+		},
+		{
+			desc: "fail when non-nil error and empty substring expectation",
+			err: errors.New("some error text"),
+			subStr: "",
+			wantDiff: true,
+		},
+		{
+			desc: "fail when nil error and non-empty substring expectation",
+			err: nil,
+			subStr: "error text",
+			wantDiff: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func (t *testing.T) {
+			diff := Substring(tc.err, tc.subStr)
+			if tc.wantDiff && diff == "" {
+				t.Error("got no diff; wanted diff")
+			}
+			if !tc.wantDiff && diff != "" {
+				t.Errorf("got diff %q; want no diff", diff)
+			}
+		})
+	}
+}

--- a/lib/errdiff/errdiff_test.go
+++ b/lib/errdiff/errdiff_test.go
@@ -7,45 +7,45 @@ import (
 
 func TestSubstring(t *testing.T) {
 	testCases := []struct {
-		desc string
-		err error
-		subStr string
+		desc     string
+		err      error
+		subStr   string
 		wantDiff bool
-	} {
+	}{
 		{
-			desc: "pass with nil error and no substring expectation",
-			err: nil,
-			subStr: "",
+			desc:     "pass with nil error and no substring expectation",
+			err:      nil,
+			subStr:   "",
 			wantDiff: false,
 		},
 		{
-			desc: "pass when non-nil error contains substring",
-			err: errors.New("some error text"),
-			subStr: "error text",
+			desc:     "pass when non-nil error contains substring",
+			err:      errors.New("some error text"),
+			subStr:   "error text",
 			wantDiff: false,
 		},
 		{
-			desc: "fail when non-nil error doesn't contain substring",
-			err: errors.New("some error text"),
-			subStr: "some other error",
+			desc:     "fail when non-nil error doesn't contain substring",
+			err:      errors.New("some error text"),
+			subStr:   "some other error",
 			wantDiff: true,
 		},
 		{
-			desc: "fail when non-nil error and empty substring expectation",
-			err: errors.New("some error text"),
-			subStr: "",
+			desc:     "fail when non-nil error and empty substring expectation",
+			err:      errors.New("some error text"),
+			subStr:   "",
 			wantDiff: true,
 		},
 		{
-			desc: "fail when nil error and non-empty substring expectation",
-			err: nil,
-			subStr: "error text",
+			desc:     "fail when nil error and non-empty substring expectation",
+			err:      nil,
+			subStr:   "error text",
 			wantDiff: true,
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func (t *testing.T) {
-			diff := Substring(tc.err, tc.subStr)
+		t.Run(tc.desc, func(t *testing.T) {
+			diff := substring(tc.err, tc.subStr)
 			if tc.wantDiff && diff == "" {
 				t.Error("got no diff; wanted diff")
 			}


### PR DESCRIPTION
This change adds a testonly library called "errdiff" that allows unit
tests to easily see if errors match an expected substring.

This allows for a bit more fidelity than checks by the assert package,
as the latter only has functions for checking error presence (though
oftentimes the error expected in tests is not the one actually returned)
and exact error equivalence (though it may be difficult and/or brittle
to formulate an expectation on an exact error value).