### PR TITLE
gee bash_setup: skip startup checks.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3509,7 +3509,9 @@ function main() {
   fi
   local cmdname="$1"; shift
   if type "gee__${cmdname}" >/dev/null 2>&1; then
-    _startup_checks
+    if [[ "${cmdname}" != "bash_setup" ]]; then
+      _startup_checks
+    fi
     "gee__${cmdname}" "$@"
     ABNORMAL=0
   else


### PR DESCRIPTION
If the user's ssh key isn't enrolled, eval "$(gee bash_setup)" breaks due to
the extra user interaction.  bash_setup should always just work.
