### PR TITLE
license_manager: Add server boilerplate

### DIFF
--- a/lib/server/run.go
+++ b/lib/server/run.go
@@ -12,7 +12,16 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+// Run runs the specified HTTP handlers and/or gRPC server on a port specified
+// by the `PORT` environment variable. If no HTTP mux or gRPC server is provided
+// (is nil), one with default routes/services will be started, respectively.
 func Run(mux *http.ServeMux, grpcs *grpc.Server) {
+	if mux == nil {
+		mux = http.NewServeMux()
+	}
+	if grpcs == nil {
+		grpcs = grpc.NewServer()
+	}
 	reflection.Register(grpcs)
 
 	port := os.Getenv("PORT")
@@ -21,7 +30,7 @@ func Run(mux *http.ServeMux, grpcs *grpc.Server) {
 	}
 
 	log.Printf("Opening port %s - will be available at http://127.0.0.1:%s/", port, port)
-	listener, err := net.Listen("tcp", ":"+port)
+	listener, err := net.Listen("tcp", net.JoinHostPort("", port))
 	if err != nil {
 		log.Fatalf("failed to listen: %s", err)
 	}

--- a/license_manager/server/BUILD.bazel
+++ b/license_manager/server/BUILD.bazel
@@ -6,11 +6,10 @@ go_library(
     importpath = "github.com/enfabrica/enkit/license_manager/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/server:go_default_library",
         "//license_manager/proto:go_default_library",
         "//license_manager/service:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//reflection:go_default_library",
     ],
 )
 

--- a/license_manager/server/BUILD.bazel
+++ b/license_manager/server/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/license_manager/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//license_manager/proto:go_default_library",
+        "//license_manager/service:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//reflection:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "license_manager",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/license_manager/server/main.go
+++ b/license_manager/server/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"net"
+	"strconv"
+
+	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+	"github.com/enfabrica/enkit/license_manager/service"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+var (
+	port = flag.Int("port", 8080, "Port for gRPC services")
+)
+
+func main (){
+	flag.Parse()
+
+	addr := net.JoinHostPort("", strconv.FormatInt(int64(*port), 10))
+	listen, err := net.Listen("tcp", addr)
+	if err != nil {
+		glog.Fatalf("Failed to listen on %q: %v", addr, err)
+	}
+	server := grpc.NewServer()
+	lmpb.RegisterLicenseManagerServer(server, &service.Service{})
+	reflection.Register(server)
+
+	glog.Infof("Listening for gRPC requests on %s...", addr)
+	err = server.Serve(listen)
+	if err != nil {
+		glog.Fatalf("Failed to serve: %v", err)
+	}
+}

--- a/license_manager/server/main.go
+++ b/license_manager/server/main.go
@@ -1,37 +1,16 @@
 package main
 
 import (
-	"flag"
-	"net"
-	"strconv"
-
+	"github.com/enfabrica/enkit/lib/server"
 	lmpb "github.com/enfabrica/enkit/license_manager/proto"
 	"github.com/enfabrica/enkit/license_manager/service"
 
-	"github.com/golang/glog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
-var (
-	port = flag.Int("port", 8080, "Port for gRPC services")
-)
+func main() {
+	grpcs := grpc.NewServer()
+	lmpb.RegisterLicenseManagerServer(grpcs, &service.Service{})
 
-func main (){
-	flag.Parse()
-
-	addr := net.JoinHostPort("", strconv.FormatInt(int64(*port), 10))
-	listen, err := net.Listen("tcp", addr)
-	if err != nil {
-		glog.Fatalf("Failed to listen on %q: %v", addr, err)
-	}
-	server := grpc.NewServer()
-	lmpb.RegisterLicenseManagerServer(server, &service.Service{})
-	reflection.Register(server)
-
-	glog.Infof("Listening for gRPC requests on %s...", addr)
-	err = server.Serve(listen)
-	if err != nil {
-		glog.Fatalf("Failed to serve: %v", err)
-	}
+	server.Run(nil, grpcs)
 }

--- a/license_manager/service/BUILD.bazel
+++ b/license_manager/service/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//license_manager/proto:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],

--- a/license_manager/service/BUILD.bazel
+++ b/license_manager/service/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["service.go"],
+    importpath = "github.com/enfabrica/enkit/license_manager/service",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//license_manager/proto:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["service_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//license_manager/proto:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
+)

--- a/license_manager/service/service.go
+++ b/license_manager/service/service.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+
+	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type Service struct {}
+
+func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmpb.AllocateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Allocate() is not yet implemented")
+}
+
+func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.RefreshResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Refresh() is not yet implemented")
+}
+
+func (s *Service) LicensesStatus(ctx context.Context, req *lmpb.LicensesStatusRequest) (*lmpb.LicensesStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "LicensesStatus() is not yet implemented")
+}

--- a/license_manager/service/service.go
+++ b/license_manager/service/service.go
@@ -12,6 +12,15 @@ import (
 type Service struct{}
 
 func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmpb.AllocateResponse, error) {
+	// If invocation is already allocated, return allocation
+	// Otherwise, get spot in queue
+	//   If request has an ID, find that spot in the queue or error
+	//   Otherwise, request goes at the back of the queue for that license
+	// Attempt to allocate available licenses to everyone in queue
+	// If not at the front of the queue, return queue spot
+	// (At the front of the queue)
+	// If license not available, return queue spot
+	// Allocate license and return allocation
 	return nil, status.Errorf(codes.Unimplemented, "Allocate() is not yet implemented")
 }
 

--- a/license_manager/service/service.go
+++ b/license_manager/service/service.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type Service struct {}
+type Service struct{}
 
 func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmpb.AllocateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "Allocate() is not yet implemented")
@@ -17,6 +17,10 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 
 func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.RefreshResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "Refresh() is not yet implemented")
+}
+
+func (s *Service) Release(ctx context.Context, req *lmpb.ReleaseRequest) (*lmpb.ReleaseResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Release() is not yet implemented")
 }
 
 func (s *Service) LicensesStatus(ctx context.Context, req *lmpb.LicensesStatusRequest) (*lmpb.LicensesStatusResponse, error) {

--- a/license_manager/service/service_test.go
+++ b/license_manager/service/service_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestAllocateUnimplemented(t *testing.T) {
+	ctx := context.Background()
+	s := &Service{}
+	wantCode := codes.Unimplemented
+	req := &lmpb.AllocateRequest{}
+
+	_, err := s.Allocate(ctx, req)
+	if gotCode := status.Code(err); gotCode != wantCode {
+		t.Errorf("got code %v; want code %v", gotCode, wantCode)
+	}
+}
+
+func TestRefreshUnimplemented(t *testing.T) {
+	ctx := context.Background()
+	s := &Service{}
+	wantCode := codes.Unimplemented
+	req := &lmpb.RefreshRequest{}
+
+	_, err := s.Refresh(ctx, req)
+	if gotCode := status.Code(err); gotCode != wantCode {
+		t.Errorf("got code %v; want code %v", gotCode, wantCode)
+	}
+}
+
+func TestLicensesStatusUnimplemented(t *testing.T) {
+	ctx := context.Background()
+	s := &Service{}
+	wantCode := codes.Unimplemented
+	req := &lmpb.LicensesStatusRequest{}
+
+	_, err := s.LicensesStatus(ctx, req)
+	if gotCode := status.Code(err); gotCode != wantCode {
+		t.Errorf("got code %v; want code %v", gotCode, wantCode)
+	}
+}

--- a/license_manager/service/service_test.go
+++ b/license_manager/service/service_test.go
@@ -6,6 +6,7 @@ import (
 
 	lmpb "github.com/enfabrica/enkit/license_manager/proto"
 
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -13,47 +14,35 @@ import (
 func TestAllocateUnimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{}
-	wantCode := codes.Unimplemented
 	req := &lmpb.AllocateRequest{}
 
 	_, err := s.Allocate(ctx, req)
-	if gotCode := status.Code(err); gotCode != wantCode {
-		t.Errorf("got code %v; want code %v", gotCode, wantCode)
-	}
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
 }
 
 func TestRefreshUnimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{}
-	wantCode := codes.Unimplemented
 	req := &lmpb.RefreshRequest{}
 
 	_, err := s.Refresh(ctx, req)
-	if gotCode := status.Code(err); gotCode != wantCode {
-		t.Errorf("got code %v; want code %v", gotCode, wantCode)
-	}
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
 }
 
 func TestReleaseUnimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{}
-	wantCode := codes.Unimplemented
 	req := &lmpb.ReleaseRequest{}
 
 	_, err := s.Release(ctx, req)
-	if gotCode := status.Code(err); gotCode != wantCode {
-		t.Errorf("got code %v; want code %v", gotCode, wantCode)
-	}
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
 }
 
 func TestLicensesStatusUnimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{}
-	wantCode := codes.Unimplemented
 	req := &lmpb.LicensesStatusRequest{}
 
 	_, err := s.LicensesStatus(ctx, req)
-	if gotCode := status.Code(err); gotCode != wantCode {
-		t.Errorf("got code %v; want code %v", gotCode, wantCode)
-	}
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
 }

--- a/license_manager/service/service_test.go
+++ b/license_manager/service/service_test.go
@@ -34,6 +34,18 @@ func TestRefreshUnimplemented(t *testing.T) {
 	}
 }
 
+func TestReleaseUnimplemented(t *testing.T) {
+	ctx := context.Background()
+	s := &Service{}
+	wantCode := codes.Unimplemented
+	req := &lmpb.ReleaseRequest{}
+
+	_, err := s.Release(ctx, req)
+	if gotCode := status.Code(err); gotCode != wantCode {
+		t.Errorf("got code %v; want code %v", gotCode, wantCode)
+	}
+}
+
 func TestLicensesStatusUnimplemented(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{}


### PR DESCRIPTION
This change adds:
* A LicenseManager service with all handlers returning unimplemented
* Tests for said service expecting unimplemented for all methods
* A server binary that starts the LicenseManager service on a port
  specified by flag.

Design and more info: https://docs.google.com/document/d/1TNqbBprpcNU9tTHVCFzRwaQoHlGFdjkw221C5p9UsAw/edit#

Tested: Builds and all unit tests pass:

```
bazel test //license_manager/...
```

Server starts:

```
[~/dev/enkit] (license_manager_server_boilerplate)
sminor-> bazel run //license_manager/server:license_manager -- --port=8081 --alsologtostderr &
[1] 9262
[=== 2021-10-01 05:21:39 === SUCCESS ===]

[~/dev/enkit] (license_manager_server_boilerplate)
sminor-> INFO: Invocation ID: 7742f725-9df7-43e2-96a4-49bbe64969b0
INFO: Analyzed target //license_manager/server:license_manager (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //license_manager/server:license_manager up-to-date:
  bazel-bin/license_manager/server/license_manager_/license_manager
INFO: Elapsed time: 0.254s, Critical Path: 0.06s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
I1001 05:21:39.325719    9270 main.go:32] Listening for gRPC requests on :8081...

[~/dev/enkit] (license_manager_server_boilerplate)
sminor-> grpc_cli ls -l localhost:8081
filename: reflection/grpc_reflection_v1alpha/reflection.proto
package: grpc.reflection.v1alpha;
service ServerReflection {
  rpc ServerReflectionInfo(stream grpc.reflection.v1alpha.ServerReflectionRequest) returns (stream grpc.reflection.v1alpha.ServerReflectionResponse) {}
}

filename: license_manager/proto/license_manager.proto
package: license_manager.proto;
service LicenseManager {
  rpc Allocate(license_manager.proto.AllocateRequest) returns (license_manager.proto.AllocateResponse) {}
  rpc Refresh(license_manager.proto.RefreshRequest) returns (license_manager.proto.RefreshResponse) {}
  rpc Release(license_manager.proto.ReleaseRequest) returns (license_manager.proto.ReleaseResponse) {}
  rpc LicensesStatus(license_manager.proto.LicensesStatusRequest) returns (license_manager.proto.LicensesStatusResponse) {}
}

[=== 2021-10-05 10:52:02 === SUCCESS ===]
```

Jira: INFRA-90