### PR TITLE
gee: fix for git v2.17.1 worktree remove

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2541,8 +2541,12 @@ function gee__revert() {
       ADDED+=("${F}")
     fi
   done
-  _git checkout "${PARENT_BRANCH}" -- "${MODIFIED[@]}"
-  _git rm "${ADDED[@]}"
+  if [[ "${#MODIFIED[@]}" -ne 0 ]]; then
+    _git checkout "${PARENT_BRANCH}" -- "${MODIFIED[@]}"
+  fi
+  if [[ "${#ADDED[@]}" -ne 0 ]]; then
+    _git rm "${ADDED[@]}"
+  fi
 }
 
 ##########################################################################
@@ -2966,7 +2970,8 @@ function gee__remove_branch() {
   SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
 
   _checkout_or_die "${MAIN}"
-  _git worktree remove "${BR}"
+  # --force is required for git v2.17.1, or the remove operation will always fail.
+  _git worktree remove --force "${BR}"
   _git branch -D "${BR}"
   if _remote_branch_exists origin "${BR}"; then
     _git_can_fail push origin --delete "${BR}"


### PR DESCRIPTION
There's a bug in git verison 2.17.1, which happens to be the version currently
installed in the hardware container.

The bug: "git worktree remove $BR" is always failing with the error message:
  "fatal: working trees containing submodules cannot be moved or removed"

However, inspection of the client reveals that no submodules are present.
The issue can be resolved in two ways: by upgrading to a more recent git, or
by adding a "--force" option to "git worktree remove."

Since updating "git" requires updating a large set of shared libraries that
could impact EDA tools, I opted for the latter option.

