### PR TITLE
license_manager: Implement server handlers

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -778,8 +778,8 @@ def go_repositories():
     go_repository(
         name = "com_github_google_go_cmp",
         importpath = "github.com/google/go-cmp",
-        sum = "h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=",
-        version = "v0.5.5",
+        sum = "h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=",
+        version = "v0.5.6",
     )
     go_repository(
         name = "com_github_google_go_github",
@@ -822,8 +822,8 @@ def go_repositories():
     go_repository(
         name = "com_github_google_uuid",
         importpath = "github.com/google/uuid",
-        sum = "h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=",
-        version = "v1.1.2",
+        sum = "h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=",
+        version = "v1.3.0",
     )
 
     go_repository(
@@ -1553,6 +1553,12 @@ def go_repositories():
         importpath = "github.com/pquerna/cachecontrol",
         sum = "h1:BLqxdwZ6j771IpSCRx7s/GJjXHUE00Hmu7/YegCGdzA=",
         version = "v0.0.0-20200921180117-858c6e7e6b7e",
+    )
+    go_repository(
+        name = "com_github_prashantv_gostub",
+        importpath = "github.com/prashantv/gostub",
+        sum = "h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=",
+        version = "v1.0.0",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.10.0
+	github.com/fullstorydev/grpcurl v1.8.5 // indirect
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-lintpack/lintpack v0.5.2 // indirect
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 // indirect
@@ -33,7 +34,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/kataras/muxie v1.1.1
@@ -68,7 +69,8 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
 	google.golang.org/api v0.30.0
-	google.golang.org/grpc v1.36.0
+	google.golang.org/grpc v1.37.0
+	google.golang.org/protobuf v1.26.0
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,10 @@ require (
 	github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547 // indirect
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/kataras/muxie v1.1.1
@@ -44,6 +46,7 @@ require (
 	github.com/pelletier/go-toml v1.8.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
+	github.com/prashantv/gostub v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/bombsimon/wsl/v3 v3.2.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/charithe/durationcheck v0.0.6/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
@@ -89,6 +90,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/containerd v1.4.3 h1:ijQT13JedHSHrQGWFcGEwzcNKrAGIiZ+jSD5QQG07SY=
@@ -137,8 +139,10 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d h1:QyzYnTnPE15SQyUeqU6qLbWxMkwyAyu+vGksa0b7j00=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/esimonov/ifshort v1.0.1/go.mod h1:yZqNJUrNn20K8Q9n2CrjTKYyVEmX209Hgu+M1LBpeZE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -149,6 +153,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fullstorydev/grpcurl v1.8.5 h1:xYZBGwhLFuHx6VZLdANGx7Ffb/dlY8JZlJz76/TxclM=
+github.com/fullstorydev/grpcurl v1.8.5/go.mod h1:hmAJ/1FHD4xEdiTQS4Byb5NHVVGZr9iGy8CnX0t6ftA=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -296,6 +302,7 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gookit/color v1.3.6/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gordonklaus/ineffassign v0.0.0-20210225214923-2e10b2664254/go.mod h1:M9mZEtGIsR1oDaZagNPNG9iq9n2HrhZ17dsXk73V3Lw=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -344,6 +351,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jgautheron/goconst v1.4.0/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
+github.com/jhump/protoreflect v1.10.1 h1:iH+UZfsbRE6vpyZH7asAjTPWJf7RJbpZ9j/N3lDlKs0=
+github.com/jhump/protoreflect v1.10.1/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
 github.com/jingyugao/rowserrcheck v0.0.0-20210130005344-c6a0c12dd98d/go.mod h1:/EZlaYCnEX24i7qdVhT9du5JrtFWYRQr67bVgR7JJC8=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
@@ -432,6 +441,7 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20160627004424-a22cb81b2ecd/go.mod h1:o96d
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
+github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/nishanths/predeclared v0.2.1/go.mod h1:HvkGJcA3naj4lOwnFXFDkFxVtSqQMB9sbB1usJ+xjQE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -873,11 +883,13 @@ golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200622203043-20e05c1c8ffa/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200625211823-6506e20df31f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1021,6 +1033,7 @@ google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.37.0 h1:uSZWeQJX5j11bIQ4AJoj+McDBo29cY1MCoC1wO3ts+c=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
@@ -1038,6 +1051,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/go.sum
+++ b/go.sum
@@ -261,7 +261,9 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -287,6 +289,8 @@ github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -463,6 +467,8 @@ github.com/polyfloyd/go-errorlint v0.0.0-20201127212506-19bd8db6546f/go.mod h1:w
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e h1:BLqxdwZ6j771IpSCRx7s/GJjXHUE00Hmu7/YegCGdzA=
 github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e/go.mod h1:hoLfEwdY11HjRfKFH6KqnPsfxlo3BP6bJehpDv8t6sQ=
+github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
+github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8TlhkEU0on0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -543,6 +549,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tchap/zapext v1.0.0 h1:qPxfRLzqYzemT+Pgs5VoH8NGU5YS7cgCnhcqRGkmrXc=

--- a/lib/config/datastore/BUILD.bazel
+++ b/lib/config/datastore/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lib/config:go_default_library",
-        "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_google_cloud_go_datastore//:go_default_library",
         "@org_golang_google_api//option:go_default_library",
     ],

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -61,31 +61,8 @@ service LicenseManager {
 }
 
 message AllocateRequest {
-  // Licenses to acquire for this invocation.
-  //
-  // Invocations that need multiple of the same license type should insert
-  // duplicate entries in this field.
-  //
-  // Implementations currently only support reserving once license per
-  // invocation, though future implementations may allow for allocations of
-  // multiple and of different types.
-  repeated License licenses = 1; // required
-
-  // Owning entity issuing the allocation request. Used for logging purposes
-  // only. This could be the name of the user or system issuing the request.
-  string owner = 2; // required
-
-  // Build tag of the allocation request. This tag does not need to be unique
-  // across multiple AllocateRequests, and may be used to associate multiple
-  // such requests with one higher-level task. Typically the Bazel build
-  // invocation ID is used here.
-  string build_tag = 3; // required
-
-  // If this is not the first AllocateRequest message sent for this
-  // invocation, then this is the invocation_id in a previous AllocateResponse
-  // sent, so that this invocation can queue properly. Otherwise, this field
-  // should be left blank.
-  string invocation_id = 4;
+  // Invocation details for this allocation
+  Invocation invocation = 1; // required
 }
 
 message AllocateResponse {
@@ -126,26 +103,10 @@ message LicenseAllocated {
 }
 
 message RefreshRequest {
-  // Licenses to refresh.
-  //
-  // Implementations currently only support reserving once license per
-  // invocation, though future implementations may allow for allocations of
-  // multiple and of different types.
-  repeated License licenses = 1; // required
-
-  // Owning entity issuing the allocation request. Used for logging purposes
-  // only. This could be the name of the user or system issuing the request.
-  string owner = 2; // required
-
-  // Build tag of the allocation request. This tag does not need to be unique
-  // across multiple AllocateRequests, and may be used to associate multiple
-  // such requests with one higher-level task. Typically the Bazel build
-  // invocation ID is used here.
-  string build_tag = 3; // required
-
-  // Invocation ID returned in the Allocate() call that resulted in an
-  // allocation.
-  string invocation_id = 4; // required
+  // Existing invocation to refresh. Must have been allocated by a call to
+  // Allocate() successfully (not queued).
+  // Must have invocation_id set.
+  Invocation invocation = 1; // required
 }
 
 message RefreshResponse {
@@ -197,6 +158,37 @@ message LicenseStats {
   // LicenseManager. If this number is >0, then allocated_count should equal
   // total_license_count.
   uint32 queued_count = 6;
+}
+
+message Invocation {
+  // Licenses to acquire for this invocation.
+  //
+  // Invocations that need multiple of the same license type should insert
+  // duplicate entries in this field.
+  //
+  // Implementations currently only support reserving once license per
+  // invocation, though future implementations may allow for allocations of
+  // multiple and of different types.
+  repeated License licenses = 1; // required
+
+  // Owning entity issuing the allocation request. Used for logging purposes
+  // only. This could be the name of the user or system issuing the request.
+  // This must be sent on every Allocate() and Refresh() call in case the
+  // server is restarted.
+  string owner = 2; // required
+
+  // Build tag of the allocation request. This tag does not need to be unique
+  // across multiple AllocateRequests, and may be used to associate multiple
+  // such requests with one higher-level task. Typically the Bazel build
+  // invocation ID is used here. This must be sent on every Allocate() and
+  // Refresh() call in case the server is restarted.
+  string build_tag = 3; // required
+
+  // The server-generated ID for this invocation. In the initial Allocate()
+  // call, this can be blank for the initial request (to receive a generated
+  // one in the response) but subsequent Allocate() calls to refresh a queue
+  // position or Refresh() calls should have this field set.
+  string id = 4;
 }
 
 message License {

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -126,9 +126,26 @@ message LicenseAllocated {
 }
 
 message RefreshRequest {
-  // Opaque identifier for this invocation, as returned by the server in the
-  // AllocateResponse that allocated this license.
-  string invocation_id = 1; // required
+  // Licenses to refresh.
+  //
+  // Implementations currently only support reserving once license per
+  // invocation, though future implementations may allow for allocations of
+  // multiple and of different types.
+  repeated License licenses = 1; // required
+
+  // Owning entity issuing the allocation request. Used for logging purposes
+  // only. This could be the name of the user or system issuing the request.
+  string owner = 2; // required
+
+  // Build tag of the allocation request. This tag does not need to be unique
+  // across multiple AllocateRequests, and may be used to associate multiple
+  // such requests with one higher-level task. Typically the Bazel build
+  // invocation ID is used here.
+  string build_tag = 3; // required
+
+  // Invocation ID returned in the Allocate() call that resulted in an
+  // allocation.
+  string invocation_id = 4; // required
 }
 
 message RefreshResponse {
@@ -175,6 +192,11 @@ message LicenseStats {
   // Number of licenses currently allocated, as reported by the
   // LicenseManager. This should be less than or equal to in_use_count.
   uint32 allocated_count = 5;
+
+  // Number of invocations queued for a license, as reported by the
+  // LicenseManager. If this number is >0, then allocated_count should equal
+  // total_license_count.
+  uint32 queued_count = 6;
 }
 
 message License {

--- a/license_manager/proto/license_manager.proto
+++ b/license_manager/proto/license_manager.proto
@@ -69,7 +69,7 @@ message AllocateRequest {
   // Implementations currently only support reserving once license per
   // invocation, though future implementations may allow for allocations of
   // multiple and of different types.
-  repeated License license = 1; // required
+  repeated License licenses = 1; // required
 
   // Owning entity issuing the allocation request. Used for logging purposes
   // only. This could be the name of the user or system issuing the request.

--- a/license_manager/server/main.go
+++ b/license_manager/server/main.go
@@ -10,7 +10,8 @@ import (
 
 func main() {
 	grpcs := grpc.NewServer()
-	lmpb.RegisterLicenseManagerServer(grpcs, &service.Service{})
+	s := service.New()
+	lmpb.RegisterLicenseManagerServer(grpcs, s)
 
 	server.Run(nil, grpcs)
 }

--- a/license_manager/service/BUILD.bazel
+++ b/license_manager/service/BUILD.bazel
@@ -7,8 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//license_manager/proto:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )
 
@@ -17,9 +19,15 @@ go_test(
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//lib/errdiff:go_default_library",
         "//license_manager/proto:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_prashantv_gostub//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/license_manager/service/BUILD.bazel
+++ b/license_manager/service/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["service.go"],
+    srcs = [
+        "license.go",
+        "service.go",
+    ],
     importpath = "github.com/enfabrica/enkit/license_manager/service",
     visibility = ["//visibility:public"],
     deps = [

--- a/license_manager/service/license.go
+++ b/license_manager/service/license.go
@@ -53,11 +53,7 @@ func (l *license) Promote() {
 // GetAllocated returns an invocation by ID if the invocation is allocated a
 // license, or nil otherwise.
 func (l *license) GetAllocated(invID string) *invocation {
-	inv, ok := l.allocations[invID]
-	if !ok {
-		return nil
-	}
-	return inv
+	return l.allocations[invID]
 }
 
 // ExpireAllocations removes all allocations for invocations that have not
@@ -118,7 +114,6 @@ func (l *license) GetStats(name string) *lmpb.LicenseStats {
 func (l *license) Forget(invID string) int {
 	count := 0
 	newAllocations := map[string]*invocation{}
-	newQueue := []*invocation{}
 	for k, v := range l.allocations {
 		if k != invID {
 			newAllocations[k] = v
@@ -127,6 +122,7 @@ func (l *license) Forget(invID string) int {
 		}
 	}
 
+	newQueue := []*invocation{}
 	for _, inv := range l.queue {
 		if inv.ID != invID {
 			newQueue = append(newQueue, inv)

--- a/license_manager/service/license.go
+++ b/license_manager/service/license.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"strings"
+	"time"
+
+	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// license manages allocations and queued invocations for a single license
+// type.
+type license struct {
+	totalAvailable int                    // Constant total number of licenses available for invocations.
+	queue          []*invocation          // List of invocations waiting for a license, in FIFO order.
+	allocations    map[string]*invocation // Map of invocation ID to invocation data for an allocated license.
+}
+
+// formatLicenseType returns a unique string for a particular vendor/feature
+// combination.
+func formatLicenseType(l *lmpb.License) string {
+	return strings.Join([]string{l.GetVendor(), l.GetFeature()}, "::")
+}
+
+// Enqueue puts the supplied invocation at the back of the queue.
+func (l *license) Enqueue(inv *invocation) {
+	l.queue = append(l.queue, inv)
+}
+
+// Allocate attempts to associate the supplied invocation with a license, if
+// one is available. Returns whether a license was successfully allocated.
+func (l *license) Allocate(inv *invocation) bool {
+	if len(l.allocations) >= l.totalAvailable {
+		return false
+	}
+	l.allocations[inv.ID] = inv
+	return true
+}
+
+// Promote attempts to promote queued requests to allocations until either no
+// licenses remain or no queued requests remain.
+func (l *license) Promote() {
+	numFree := l.totalAvailable - len(l.allocations)
+	numAllocated := 0
+	for i := 0; i < numFree && i < len(l.queue); i++ {
+		l.allocations[l.queue[i].ID] = l.queue[i]
+		numAllocated++
+	}
+	l.queue = l.queue[numAllocated:]
+}
+
+// GetAllocated returns an invocation by ID if the invocation is allocated a
+// license, or nil otherwise.
+func (l *license) GetAllocated(invID string) *invocation {
+	inv, ok := l.allocations[invID]
+	if !ok {
+		return nil
+	}
+	return inv
+}
+
+// ExpireAllocations removes all allocations for invocations that have not
+// checked in since `expiry`.
+func (l *license) ExpireAllocations(expiry time.Time) {
+	newAllocations := map[string]*invocation{}
+	for k, v := range l.allocations {
+		if v.LastCheckin.After(expiry) {
+			newAllocations[k] = v
+		}
+	}
+	l.allocations = newAllocations
+}
+
+// ExpireQueued removes all queued invocations that have not checked in since
+// `expiry`.
+func (l *license) ExpireQueued(expiry time.Time) {
+	newQueued := []*invocation{}
+	for _, inv := range l.queue {
+		if inv.LastCheckin.After(expiry) {
+			newQueued = append(newQueued, inv)
+		}
+	}
+	l.queue = newQueued
+}
+
+// GetQueued returns an invocation by ID if the invocation is queued, or nil
+// otherwise.
+func (l *license) GetQueued(invID string) *invocation {
+	for _, inv := range l.queue {
+		if inv.ID == invID {
+			return inv
+		}
+	}
+	return nil
+}
+
+// GetStats returns a LicenseStats message for this license type.
+func (l *license) GetStats(name string) *lmpb.LicenseStats {
+	fields := strings.SplitN(name, "::", 2)
+	if len(fields) != 2 {
+		fields = []string{"<UNKNOWN>", name}
+	}
+	return &lmpb.LicenseStats{
+		License: &lmpb.License{
+			Vendor:  fields[0],
+			Feature: fields[1],
+		},
+		Timestamp:         timestamppb.New(timeNow()),
+		TotalLicenseCount: uint32(l.totalAvailable),
+		AllocatedCount:    uint32(len(l.allocations)),
+		QueuedCount:       uint32(len(l.queue)),
+	}
+}
+
+// Forget removes invocations matching the specified ID from allocations and
+// the queue.
+func (l *license) Forget(invID string) int {
+	count := 0
+	newAllocations := map[string]*invocation{}
+	newQueue := []*invocation{}
+	for k, v := range l.allocations {
+		if k != invID {
+			newAllocations[k] = v
+		} else {
+			count++
+		}
+	}
+
+	for _, inv := range l.queue {
+		if inv.ID != invID {
+			newQueue = append(newQueue, inv)
+		} else {
+			count++
+		}
+	}
+
+	l.allocations = newAllocations
+	l.queue = newQueue
+	return count
+}

--- a/license_manager/service/service.go
+++ b/license_manager/service/service.go
@@ -2,33 +2,248 @@ package service
 
 import (
 	"context"
+	"strings"
+	"sync"
+	"time"
 
 	lmpb "github.com/enfabrica/enkit/license_manager/proto"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type Service struct{}
+type Service struct {
+	mu           sync.Mutex
+	currentState state
+	licenses     map[string]*license
+
+	queueRefreshDuration      time.Duration
+	allocationRefreshDuration time.Duration
+}
+
+type license struct {
+	totalAvailable int
+	queue          []*invocation
+	allocations    map[string]*invocation
+}
+
+type invocation struct {
+	ID          string
+	Owner       string
+	BuildTag    string
+	LastCheckin time.Time
+}
+
+type state int
+
+const (
+	stateStarting state = iota
+	stateRunning
+)
+
+var (
+	generateRandomID = func() (string, error) {
+		id, err := uuid.NewRandom()
+		if err != nil {
+			return "", err
+		}
+		return id.String(), nil
+	}
+
+	timeNow = time.Now
+)
+
+// janitor runs in a loop to cleanup allocations and queue spots that have not
+// been refreshed in a sufficient amount of time.
+func (s *Service) janitor() {
+	// Pick a time t = now + n to expire queue spots and allocation requests
+	// For each license type
+	//   For each allocation
+	//     If allocation is not refreshed by deadline, remove it
+	//     Place it in the "recently expired" list
+	// For each license type
+	//   For each queued invocation, first to last
+	//     If queue spot is not refreshed by deadline, remove it
+	//       Place it in the "recently expired" list
+	//     If state == RUNNING and allocation is available, pop off queue and move it to allocated
+	// For each recently expired allocation
+	//   If past threshold, delete
+}
+
+func formatLicenseType(l *lmpb.License) string {
+	return strings.Join([]string{l.GetVendor(), l.GetFeature()}, "::")
+}
+
+func (l *license) Enqueue(inv *invocation) {
+	l.queue = append(l.queue, inv)
+}
+
+func (l *license) Promote() {
+	numFree := l.totalAvailable - len(l.allocations)
+	numAllocated := 0
+	for i := 0; i < numFree && i < len(l.queue); i++ {
+		l.allocations[l.queue[i].ID] = l.queue[i]
+		numAllocated++
+	}
+	l.queue = l.queue[numAllocated:]
+}
+
+func (l *license) GetAllocated(invID string) *invocation {
+	inv, ok := l.allocations[invID]
+	if !ok {
+		return nil
+	}
+	return inv
+}
+
+func (l *license) GetQueued(invID string) *invocation {
+	for _, inv := range l.queue {
+		if inv.ID == invID {
+			return inv
+		}
+	}
+	return nil
+}
+
+func (l *license) RefreshAllocated(invID string) bool {
+	inv, ok := l.allocations[invID]
+	if !ok {
+		return false
+	}
+	inv.LastCheckin = timeNow()
+	return true
+}
 
 func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmpb.AllocateResponse, error) {
-	// If invocation is already allocated, return allocation
-	// Otherwise, get spot in queue
-	//   If request has an ID, find that spot in the queue or error
-	//   Otherwise, request goes at the back of the queue for that license
-	// Attempt to allocate available licenses to everyone in queue
-	// If not at the front of the queue, return queue spot
-	// (At the front of the queue)
-	// If license not available, return queue spot
-	// Allocate license and return allocation
-	return nil, status.Errorf(codes.Unimplemented, "Allocate() is not yet implemented")
+	if len(req.GetLicenses()) != 1 {
+		return nil, status.Errorf(codes.InvalidArgument, "licenses must have exactly one license spec")
+	}
+	licenseType := formatLicenseType(req.GetLicenses()[0])
+	lic, ok := s.licenses[licenseType]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "unknown license type: %q", licenseType)
+	}
+	invocationID := req.GetInvocationId()
+	if invocationID == "" {
+		var err error
+		invocationID, err = generateRandomID()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to generate invocation_id: %v", err)
+		}
+		inv := &invocation{
+			ID:          invocationID,
+			Owner:       req.GetOwner(),
+			BuildTag:    req.GetBuildTag(),
+			LastCheckin: timeNow(),
+		}
+		lic.Enqueue(inv)
+
+		switch s.currentState {
+		case stateStarting:
+		case stateRunning:
+			lic.Promote()
+		default:
+			return nil, status.Errorf(codes.Internal, "unhandled state: %v", s.currentState)
+		}
+	}
+
+	// Is the invocation_id already allocated?
+	if inv := lic.GetAllocated(invocationID); inv != nil {
+		inv.LastCheckin = timeNow()
+		//     Yes - return allocation success
+		return &lmpb.AllocateResponse{
+			ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
+				LicenseAllocated: &lmpb.LicenseAllocated{
+					InvocationId:           invocationID,
+					LicenseRefreshDeadline: timestamppb.New(timeNow().Add(s.allocationRefreshDuration)),
+				},
+			},
+		}, nil
+	}
+	// Is the invocation_id already queued?
+	if inv := lic.GetQueued(invocationID); inv != nil {
+		inv.LastCheckin = timeNow()
+		return &lmpb.AllocateResponse{
+			ResponseType: &lmpb.AllocateResponse_Queued{
+				Queued: &lmpb.Queued{
+					InvocationId: invocationID,
+					NextPollTime: timestamppb.New(timeNow().Add(s.queueRefreshDuration)),
+				},
+			},
+		}, nil
+	}
+	switch s.currentState {
+	case stateStarting:
+		inv := &invocation{
+			ID:          invocationID,
+			Owner:       req.GetOwner(),
+			BuildTag:    req.GetBuildTag(),
+			LastCheckin: timeNow(),
+		}
+		lic.Enqueue(inv)
+		return &lmpb.AllocateResponse{
+			ResponseType: &lmpb.AllocateResponse_Queued{
+				Queued: &lmpb.Queued{
+					InvocationId: invocationID,
+					NextPollTime: timestamppb.New(timeNow().Add(s.queueRefreshDuration)),
+				},
+			},
+		}, nil
+	case stateRunning:
+		return nil, status.Errorf(codes.FailedPrecondition, "invocation_id not found: %q", invocationID)
+	default:
+		return nil, status.Errorf(codes.Internal, "state not handled: %v", s.currentState)
+	}
+}
+
+func (s *Service) refreshAll(invID string) int {
+	refreshCount := 0
+	for _, lic := range s.licenses {
+		if lic.RefreshAllocated(invID) {
+			refreshCount++
+		}
+	}
+	return refreshCount
 }
 
 func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.RefreshResponse, error) {
+	invID := req.GetInvocationId()
+	if invID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "invocation_id must be set")
+	}
+	numUpdated := s.refreshAll(invID)
+	if numUpdated == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "invocation_id not allocated a license: %v", invID)
+	}
+	// If state == STARTUP
+	//   Get invocation_id
+	//     No invocation_id -> error
+	//   Is the invocation_id allocated?
+	//     Yes - return allocation success
+	//     Update last check time
+	//   invocation_id is not allocated, but assumed to be allocated. Allocate if there is room
+	//     Error if no allocations left
+	//
+	// If state == RUNNING
+	//   Get invocation_id
+	//     No invocation_id -> error
+	//   Is the invocation_id allocated?
+	//     Yes - return refresh response
+	//     Update last check time
+	//   Is the invocation_id recently expired?
+	//     Yes - log metric
+	//   invocation_id is not allocated - return error
 	return nil, status.Errorf(codes.Unimplemented, "Refresh() is not yet implemented")
 }
 
 func (s *Service) Release(ctx context.Context, req *lmpb.ReleaseRequest) (*lmpb.ReleaseResponse, error) {
+	// Get invocation_id
+	//   No invocation_id -> error
+	// Is the invocation_id allocated?
+	//   Yes - remove allocation
+	// invocation_id is not allocated - return error
 	return nil, status.Errorf(codes.Unimplemented, "Release() is not yet implemented")
 }
 

--- a/license_manager/service/service.go
+++ b/license_manager/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,36 +13,77 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// Service implements the LicenseManager gRPC service.
 type Service struct {
-	mu           sync.Mutex
-	currentState state
-	licenses     map[string]*license
+	mu           sync.Mutex          // Protects the following members from concurrent access
+	currentState state               // State of the server
+	licenses     map[string]*license // Queues and allocations, managed per-license-type
 
-	queueRefreshDuration      time.Duration
-	allocationRefreshDuration time.Duration
+	queueRefreshDuration      time.Duration // Queue entries not refreshed within this duration are expired
+	allocationRefreshDuration time.Duration // Allocations not refreshed within this duration are expired
 }
 
-type license struct {
-	totalAvailable int
-	queue          []*invocation
-	allocations    map[string]*invocation
+func New() *Service {
+	service := &Service{
+		currentState: stateStarting,
+		// TODO: Read this from a config file and pass it in
+		licenses: map[string]*license{
+			"xilinx::foo": &license{
+				totalAvailable: 2,
+				allocations:    map[string]*invocation{},
+			},
+			"xilinx::bar": &license{
+				totalAvailable: 2,
+				allocations:    map[string]*invocation{},
+			},
+		},
+		queueRefreshDuration:      5 * time.Second,
+		allocationRefreshDuration: 5 * time.Second,
+	}
+
+	go func(s *Service) {
+		t := time.NewTicker(1 * time.Second)
+		defer t.Stop()
+		for {
+			<-t.C
+			s.janitor()
+		}
+	}(service)
+
+	go func(s *Service) {
+		<-time.After(10 * time.Second)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.currentState = stateRunning
+	}(service)
+
+	return service
 }
 
+// invocation maps to a particular command invocation that has requested a
+// license, and its associated metadata.
 type invocation struct {
-	ID          string
-	Owner       string
-	BuildTag    string
-	LastCheckin time.Time
+	ID          string    // Server-generated unique ID
+	Owner       string    // Client-provided owner
+	BuildTag    string    // Client-provided build tag. May not be unique across invocations
+	LastCheckin time.Time // Time the invocation last had its queue position/allocation refreshed.
 }
 
 type state int
 
 const (
+	// Startup state during which server "adopts" unknown allocations. This is a
+	// relatively short period (roughly 2x a refresh period) which helps
+	// transition existing invocations in the event of a server restart without
+	// unnecessarily cancelling invocations.
 	stateStarting state = iota
+	// Normal operating state.
 	stateRunning
 )
 
 var (
+	// generateRandomID returns a UUIDv4 string, and can be stubbed out for unit
+	// tests.
 	generateRandomID = func() (string, error) {
 		id, err := uuid.NewRandom()
 		if err != nil {
@@ -52,12 +92,17 @@ var (
 		return id.String(), nil
 	}
 
+	// timeNow returns the current time, and can be stubbed out for unit tests.
 	timeNow = time.Now
 )
 
 // janitor runs in a loop to cleanup allocations and queue spots that have not
-// been refreshed in a sufficient amount of time.
+// been refreshed in a sufficient amount of time, as well as to promote queued
+// licenses to allocations.
 func (s *Service) janitor() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Don't expire or promote anything during startup.
 	if s.currentState == stateStarting {
 		return
 	}
@@ -70,101 +115,12 @@ func (s *Service) janitor() {
 	}
 }
 
-func formatLicenseType(l *lmpb.License) string {
-	return strings.Join([]string{l.GetVendor(), l.GetFeature()}, "::")
-}
-
-func (l *license) Enqueue(inv *invocation) {
-	l.queue = append(l.queue, inv)
-}
-
-func (l *license) Allocate(inv *invocation) bool {
-	if len(l.allocations) >= l.totalAvailable {
-		return false
-	}
-	l.allocations[inv.ID] = inv
-	return true
-}
-
-func (l *license) Promote() {
-	numFree := l.totalAvailable - len(l.allocations)
-	numAllocated := 0
-	for i := 0; i < numFree && i < len(l.queue); i++ {
-		l.allocations[l.queue[i].ID] = l.queue[i]
-		numAllocated++
-	}
-	l.queue = l.queue[numAllocated:]
-}
-
-func (l *license) GetAllocated(invID string) *invocation {
-	inv, ok := l.allocations[invID]
-	if !ok {
-		return nil
-	}
-	return inv
-}
-
-func (l *license) ExpireAllocations(expiry time.Time) {
-	newAllocations := map[string]*invocation{}
-	for k, v := range l.allocations {
-		if v.LastCheckin.After(expiry) {
-			newAllocations[k] = v
-		}
-	}
-	l.allocations = newAllocations
-}
-
-func (l *license) ExpireQueued(expiry time.Time) {
-	newQueued := []*invocation{}
-	for _, inv := range l.queue {
-		if inv.LastCheckin.After(expiry) {
-			newQueued = append(newQueued, inv)
-		}
-	}
-	l.queue = newQueued
-}
-
-func (l *license) GetQueued(invID string) *invocation {
-	for _, inv := range l.queue {
-		if inv.ID == invID {
-			return inv
-		}
-	}
-	return nil
-}
-
-func (l *license) GetStats(name string) *lmpb.LicenseStats {
-	fields := strings.SplitN(name, "::", 2)
-	if len(fields) != 2 {
-		fields = []string{"<UNKNOWN>", name}
-	}
-	return &lmpb.LicenseStats{
-		License: &lmpb.License{
-			Vendor:  fields[0],
-			Feature: fields[1],
-		},
-		Timestamp:         timestamppb.New(timeNow()),
-		TotalLicenseCount: uint32(l.totalAvailable),
-		AllocatedCount:    uint32(len(l.allocations)),
-		QueuedCount:       uint32(len(l.queue)),
-	}
-}
-
-func (l *license) Forget(invID string) int {
-	count := 0
-	newAllocations := map[string]*invocation{}
-	for k, v := range l.allocations {
-		if k != invID {
-			newAllocations[k] = v
-		} else {
-			count++
-		}
-	}
-	l.allocations = newAllocations
-	return count
-}
-
+// Allocate allocates a license to the requesting invocation, or queues the
+// request if none are available. See the proto docstrings for more details.
 func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmpb.AllocateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(req.GetLicenses()) != 1 {
 		return nil, status.Errorf(codes.InvalidArgument, "licenses must have exactly one license spec")
 	}
@@ -174,7 +130,10 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 		return nil, status.Errorf(codes.NotFound, "unknown license type: %q", licenseType)
 	}
 	invocationID := req.GetInvocationId()
+
 	if invocationID == "" {
+		// This is the first AllocationRequest by this invocation. Generate an ID
+		// and queue it.
 		var err error
 		invocationID, err = generateRandomID()
 		if err != nil {
@@ -197,10 +156,13 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 		}
 	}
 
-	// Is the invocation_id already allocated?
+	// Invocation ID should now be known and either queued (due to the above
+	// insert, or from a previous request) or allocated (promoted from the queue
+	// by above, or asynchronously by the janitor).
+
 	if inv := lic.GetAllocated(invocationID); inv != nil {
+		// Invocation is allocated
 		inv.LastCheckin = timeNow()
-		//     Yes - return allocation success
 		return &lmpb.AllocateResponse{
 			ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
 				LicenseAllocated: &lmpb.LicenseAllocated{
@@ -210,8 +172,8 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 			},
 		}, nil
 	}
-	// Is the invocation_id already queued?
 	if inv := lic.GetQueued(invocationID); inv != nil {
+		// Invocation is queued
 		inv.LastCheckin = timeNow()
 		return &lmpb.AllocateResponse{
 			ResponseType: &lmpb.AllocateResponse_Queued{
@@ -222,8 +184,11 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 			},
 		}, nil
 	}
+	// Invocation is not allocated or queued
 	switch s.currentState {
 	case stateStarting:
+		// This invocation was previously queued before the server restart; add it
+		// back to the queue.
 		inv := &invocation{
 			ID:          invocationID,
 			Owner:       req.GetOwner(),
@@ -240,13 +205,19 @@ func (s *Service) Allocate(ctx context.Context, req *lmpb.AllocateRequest) (*lmp
 			},
 		}, nil
 	case stateRunning:
+		// This invocation is unknown (possibly expired)
 		return nil, status.Errorf(codes.FailedPrecondition, "invocation_id not found: %q", invocationID)
 	default:
 		return nil, status.Errorf(codes.Internal, "state not handled: %v", s.currentState)
 	}
 }
 
+// Refresh serves as a keepalive to refresh an allocation while an invocation
+// is still using it. See the proto docstrings for more info.
 func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.RefreshResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(req.GetLicenses()) != 1 {
 		return nil, status.Errorf(codes.InvalidArgument, "licenses must have exactly one license spec")
 	}
@@ -263,6 +234,7 @@ func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.
 	if !ok {
 		switch s.currentState {
 		case stateStarting:
+			// "Adopt" this invocation and allocate it a license, if possible.
 			inv := &invocation{
 				ID:          invID,
 				Owner:       req.GetOwner(),
@@ -281,6 +253,7 @@ func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.
 			return nil, status.Errorf(codes.FailedPrecondition, "invocation_id not allocated: %q", invID)
 		}
 	}
+	// Update the time and return the next check interval
 	inv.LastCheckin = timeNow()
 	return &lmpb.RefreshResponse{
 		InvocationId:           invID,
@@ -288,7 +261,13 @@ func (s *Service) Refresh(ctx context.Context, req *lmpb.RefreshRequest) (*lmpb.
 	}, nil
 }
 
+// Release returns an allocated license and/or unqueues the specified
+// invocation ID across all license types. See the proto docstrings for more
+// details.
 func (s *Service) Release(ctx context.Context, req *lmpb.ReleaseRequest) (*lmpb.ReleaseResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	invID := req.GetInvocationId()
 	if invID == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "invocation_id must be set")
@@ -303,7 +282,12 @@ func (s *Service) Release(ctx context.Context, req *lmpb.ReleaseRequest) (*lmpb.
 	return &lmpb.ReleaseResponse{}, nil
 }
 
+// LicensesStatus returns the status for every license type. See the proto
+// docstrings for more details.
 func (s *Service) LicensesStatus(ctx context.Context, req *lmpb.LicensesStatusRequest) (*lmpb.LicensesStatusResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	res := &lmpb.LicensesStatusResponse{}
 	for name, lic := range s.licenses {
 		res.LicenseStats = append(res.LicenseStats, lic.GetStats(name))

--- a/license_manager/service/service_test.go
+++ b/license_manager/service/service_test.go
@@ -2,31 +2,522 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/enfabrica/enkit/lib/errdiff"
 	lmpb "github.com/enfabrica/enkit/license_manager/proto"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestAllocateUnimplemented(t *testing.T) {
-	ctx := context.Background()
-	s := &Service{}
-	req := &lmpb.AllocateRequest{}
-
-	_, err := s.Allocate(ctx, req)
-	assert.Equal(t, codes.Unimplemented, status.Code(err))
+func testService(initialState state) *Service {
+	return &Service{
+		currentState: initialState,
+		licenses: map[string]*license{
+			"xilinx::feature_foo": &license{
+				totalAvailable: 2,
+				queue:          []*invocation{},
+				allocations:    map[string]*invocation{},
+			},
+		},
+		queueRefreshDuration:      5 * time.Second,
+		allocationRefreshDuration: 7 * time.Second,
+	}
 }
 
-func TestRefreshUnimplemented(t *testing.T) {
-	ctx := context.Background()
-	s := &Service{}
-	req := &lmpb.RefreshRequest{}
+func (s *Service) withAllocation(licenseType string, inv *invocation) *Service {
+	m := s.licenses[licenseType].allocations
+	if m == nil {
+		m = map[string]*invocation{}
+	}
+	m[inv.ID] = inv
+	s.licenses[licenseType].allocations = m
+	return s
+}
 
-	_, err := s.Refresh(ctx, req)
-	assert.Equal(t, codes.Unimplemented, status.Code(err))
+func (s *Service) withQueued(licenseType string, inv *invocation) *Service {
+	s.licenses[licenseType].queue = append(s.licenses[licenseType].queue, inv)
+	return s
+}
+
+func assertProtoEqual(t *testing.T, got proto.Message, want proto.Message) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("Proto messages do not match:\n%s\n", diff)
+	}
+}
+
+func assertCmp(t *testing.T, got interface{}, want interface{}, opts ...cmp.Option) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
+		t.Errorf("Objects are not equal:\n%s\n", diff)
+	}
+}
+
+type fakeID struct {
+	counter int64
+}
+
+func (f *fakeID) Generate() (string, error) {
+	f.counter++
+	return strconv.FormatInt(f.counter, 10), nil
+}
+
+// Allocate
+//     license type not known -> error NOT FOUND
+//     State == STARTUP, no invocation_id -> invocation_id created, invocation enqueued
+//     State == STARTUP, invocation_id allocated -> allocation success
+//     State == STARTUP, invocation_id queued -> queued
+//     State == STARTUP, invocation_id not found -> queued
+//   State == RUNNING, no invocation_id, license available -> invocation_id created, invocation allocated
+//     State == RUNNING, no invocation_id, no license available -> invocation_id created, invocation queued
+//     State == RUNNING, invocation_id allocated -> allocation success
+//     State == RUNNING, invocation_id not found -> error
+func TestAllocate(t *testing.T) {
+	start := time.Now()
+	currentTime := start
+	now := &currentTime
+
+	testCases := []struct {
+		desc         string
+		server       *Service
+		req          *lmpb.AllocateRequest
+		want         *lmpb.AllocateResponse
+		wantErrCode  codes.Code
+		wantErr      string
+		wantLicenses map[string]*license
+	}{
+		{
+			desc:   "too many licenses",
+			server: testService(stateStarting),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "",
+			},
+			wantErrCode: codes.InvalidArgument,
+			wantErr:     "exactly one license spec",
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations:    map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc:   "unknown license type",
+			server: testService(stateStarting),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "unknown_feature"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "",
+			},
+			wantErrCode: codes.NotFound,
+			wantErr:     "unknown license type",
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations:    map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc:   "new invocations only enqueued during startup",
+			server: testService(stateStarting),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_Queued{
+					Queued: &lmpb.Queued{
+						InvocationId: "1",
+						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue: []*invocation{
+						&invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+					},
+					allocations: map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc: "returns allocation success when allocated during startup",
+			server: testService(stateStarting).withAllocation("xilinx::feature_foo", &invocation{
+				ID:       "1",
+				Owner:    "unit_test",
+				BuildTag: "tag_1234",
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "1",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &lmpb.LicenseAllocated{
+						InvocationId:           "1",
+						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations: map[string]*invocation{
+						"1": &invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+					},
+				},
+			},
+		},
+		{
+			desc: "returns queued when invocation already in queue during startup",
+			server: testService(stateStarting).withQueued("xilinx::feature_foo", &invocation{
+				ID:       "1",
+				Owner:    "unit_test",
+				BuildTag: "tag_1234",
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "1",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_Queued{
+					Queued: &lmpb.Queued{
+						InvocationId: "1",
+						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue: []*invocation{
+						&invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+					},
+					allocations: map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc: "returns queued when invocation_id not found during startup",
+			server: testService(stateStarting).withQueued("xilinx::feature_foo", &invocation{
+				ID:          "1",
+				Owner:       "unit_test",
+				BuildTag:    "tag_1234",
+				LastCheckin: start,
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_2345",
+				InvocationId: "2",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_Queued{
+					Queued: &lmpb.Queued{
+						InvocationId: "2",
+						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue: []*invocation{
+						&invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+						&invocation{ID: "2", Owner: "unit_test", BuildTag: "tag_2345", LastCheckin: start},
+					},
+					allocations: map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc: "returns error when invocation_id not found during running state",
+			server: testService(stateRunning).withQueued("xilinx::feature_foo", &invocation{
+				ID:          "1",
+				Owner:       "unit_test",
+				BuildTag:    "tag_1234",
+				LastCheckin: start,
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_2345",
+				InvocationId: "2",
+			},
+			wantErrCode: codes.FailedPrecondition,
+			wantErr:     "invocation_id not found",
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue: []*invocation{
+						&invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+					},
+					allocations: map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc: "queues invocation when no license available while running",
+			server: testService(stateRunning).withAllocation("xilinx::feature_foo", &invocation{
+				ID:          "5",
+				Owner:       "unit_test",
+				BuildTag:    "tag_1",
+				LastCheckin: start,
+			}).withAllocation("xilinx::feature_foo", &invocation{
+				ID:          "8",
+				Owner:       "unit_test",
+				BuildTag:    "tag_2",
+				LastCheckin: start,
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:    "unit_test",
+				BuildTag: "tag_3",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_Queued{
+					Queued: &lmpb.Queued{
+						InvocationId: "1",
+						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue: []*invocation{
+						&invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_3", LastCheckin: start},
+					},
+					allocations: map[string]*invocation{
+						"5": &invocation{ID: "5", Owner: "unit_test", BuildTag: "tag_1", LastCheckin: start},
+						"8": &invocation{ID: "8", Owner: "unit_test", BuildTag: "tag_2", LastCheckin: start},
+					},
+				},
+			},
+		},
+		{
+			desc: "returns allocation success when allocated during running state",
+			server: testService(stateRunning).withAllocation("xilinx::feature_foo", &invocation{
+				ID:       "1",
+				Owner:    "unit_test",
+				BuildTag: "tag_1234",
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:        "unit_test",
+				BuildTag:     "tag_1234",
+				InvocationId: "1",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &lmpb.LicenseAllocated{
+						InvocationId:           "1",
+						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations: map[string]*invocation{
+						"1": &invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_1234", LastCheckin: start},
+					},
+				},
+			},
+		},
+		{
+			desc: "returns allocation success for new request when license available while running",
+			server: testService(stateRunning).withAllocation("xilinx::feature_foo", &invocation{
+				ID:          "2",
+				Owner:       "unit_test",
+				BuildTag:    "tag_1",
+				LastCheckin: start,
+			}),
+			req: &lmpb.AllocateRequest{
+				Licenses: []*lmpb.License{
+					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				},
+				Owner:    "unit_test",
+				BuildTag: "tag_2",
+			},
+			want: &lmpb.AllocateResponse{
+				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &lmpb.LicenseAllocated{
+						InvocationId:           "1",
+						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
+					},
+				},
+			},
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations: map[string]*invocation{
+						"1": &invocation{ID: "1", Owner: "unit_test", BuildTag: "tag_2", LastCheckin: start},
+						"2": &invocation{ID: "2", Owner: "unit_test", BuildTag: "tag_1", LastCheckin: start},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			idGen := &fakeID{}
+			stubs := gostub.Stub(&generateRandomID, idGen.Generate)
+			stubs.Stub(&timeNow, func() time.Time {
+				return *now
+			})
+			defer stubs.Reset()
+
+			got, gotErr := tc.server.Allocate(ctx, tc.req)
+
+			assertCmp(t, tc.server.licenses, tc.wantLicenses, cmp.AllowUnexported(invocation{}, license{}))
+			assert.Equal(t, tc.wantErrCode.String(), status.Code(gotErr).String())
+			errdiff.Check(t, gotErr, tc.wantErr)
+			if gotErr != nil {
+				return
+			}
+			assertProtoEqual(t, tc.want, got)
+		})
+	}
+}
+
+//
+// Refresh
+//     State == STARTUP, no invocation_id -> error
+//   State == STARTUP, invocation_id allocated -> refresh success
+//   State == STARTUP, invocation_id not allocated, license available -> allocate and refresh success
+//   State == STARTUP, invocation_id not allocated, license not available -> error
+//   State == RUNNING, no invocation_id -> error
+//   State == RUNNING, invocation_id allocated -> refresh success
+//   State == RUNNING, invocation_id not allocated -> error
+//
+// Release
+//   no invocation_id -> error
+//   invocation_id allocated -> deallocate successfully
+//   invocation_id not allocated -> error
+//
+// janitor
+//   expires stale queued license requests
+//   expires stale allocations
+//   promotes queued license requests
+//   expires stale allocations and promotes queued license requests
+//   removes stale "recently expired" allocations
+
+func TestRefresh(t *testing.T) {
+	start := time.Now()
+	currentTime := start
+	now := &currentTime
+
+	testCases := []struct {
+		desc         string
+		server       *Service
+		req          *lmpb.RefreshRequest
+		want         *lmpb.RefreshResponse
+		wantErrCode  codes.Code
+		wantErr      string
+		wantLicenses map[string]*license
+	}{
+		{
+			desc:        "error when invocation_id not set",
+			server:      testService(stateStarting),
+			req:         &lmpb.RefreshRequest{},
+			wantErrCode: codes.InvalidArgument,
+			wantErr:     "invocation_id must be set",
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations:    map[string]*invocation{},
+				},
+			},
+		},
+		{
+			desc:   "error when invocation_id not found during running state",
+			server: testService(stateRunning),
+			req: &lmpb.RefreshRequest{
+				InvocationId: "1",
+			},
+			wantErrCode: codes.FailedPrecondition,
+			wantErr:     "invocation_id not allocated",
+			wantLicenses: map[string]*license{
+				"xilinx::feature_foo": &license{
+					totalAvailable: 2,
+					queue:          []*invocation{},
+					allocations:    map[string]*invocation{},
+				},
+			},
+		},
+		// testcases
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			idGen := &fakeID{}
+			stubs := gostub.Stub(&generateRandomID, idGen.Generate)
+			stubs.Stub(&timeNow, func() time.Time {
+				return *now
+			})
+			defer stubs.Reset()
+
+			got, gotErr := tc.server.Refresh(ctx, tc.req)
+
+			assertCmp(t, tc.server.licenses, tc.wantLicenses, cmp.AllowUnexported(invocation{}, license{}))
+			assert.Equal(t, tc.wantErrCode.String(), status.Code(gotErr).String())
+			errdiff.Check(t, gotErr, tc.wantErr)
+			if gotErr != nil {
+				return
+			}
+			assertProtoEqual(t, tc.want, got)
+		})
+	}
 }
 
 func TestReleaseUnimplemented(t *testing.T) {

--- a/license_manager/service/service_test.go
+++ b/license_manager/service/service_test.go
@@ -101,13 +101,15 @@ func TestAllocate(t *testing.T) {
 			desc:   "too many licenses",
 			server: testService(stateStarting),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "",
 			},
 			wantErrCode: codes.InvalidArgument,
 			wantErr:     "exactly one license spec",
@@ -123,12 +125,14 @@ func TestAllocate(t *testing.T) {
 			desc:   "unknown license type",
 			server: testService(stateStarting),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "unknown_feature"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "unknown_feature"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "",
 			},
 			wantErrCode: codes.NotFound,
 			wantErr:     "unknown license type",
@@ -144,12 +148,14 @@ func TestAllocate(t *testing.T) {
 			desc:   "new invocations only enqueued during startup",
 			server: testService(stateStarting),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_Queued{
@@ -177,12 +183,14 @@ func TestAllocate(t *testing.T) {
 				BuildTag: "tag_1234",
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "1",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "1",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
@@ -210,12 +218,14 @@ func TestAllocate(t *testing.T) {
 				BuildTag: "tag_1234",
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "1",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "1",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_Queued{
@@ -244,12 +254,14 @@ func TestAllocate(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2345",
+					Id:       "2",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_2345",
-				InvocationId: "2",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_Queued{
@@ -279,12 +291,14 @@ func TestAllocate(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2345",
+					Id:       "2",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_2345",
-				InvocationId: "2",
 			},
 			wantErrCode: codes.FailedPrecondition,
 			wantErr:     "invocation_id not found",
@@ -312,11 +326,13 @@ func TestAllocate(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_3",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_3",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_Queued{
@@ -347,12 +363,14 @@ func TestAllocate(t *testing.T) {
 				BuildTag: "tag_1234",
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1234",
+					Id:       "1",
 				},
-				Owner:        "unit_test",
-				BuildTag:     "tag_1234",
-				InvocationId: "1",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
@@ -381,11 +399,13 @@ func TestAllocate(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.AllocateRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			want: &lmpb.AllocateResponse{
 				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
@@ -448,11 +468,13 @@ func TestRefresh(t *testing.T) {
 			desc:   "error when invocation_id not set",
 			server: testService(stateStarting),
 			req: &lmpb.RefreshRequest{
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			wantErrCode: codes.InvalidArgument,
 			wantErr:     "invocation_id must be set",
@@ -468,13 +490,15 @@ func TestRefresh(t *testing.T) {
 			desc:   "error when multiple licenses specified",
 			server: testService(stateStarting),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "1",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+				Invocation: &lmpb.Invocation{
+					Id: "1",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			wantErrCode: codes.InvalidArgument,
 			wantErr:     "exactly one license spec",
@@ -490,12 +514,14 @@ func TestRefresh(t *testing.T) {
 			desc:   "allocates when invocation_id not found during starting state",
 			server: testService(stateStarting),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "1",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Id: "1",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			want: &lmpb.RefreshResponse{
 				InvocationId:           "1",
@@ -520,12 +546,14 @@ func TestRefresh(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "5",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Id: "5",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_1",
 			},
 			want: &lmpb.RefreshResponse{
 				InvocationId:           "5",
@@ -555,12 +583,14 @@ func TestRefresh(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "1",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Id: "1",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			wantErrCode: codes.ResourceExhausted,
 			wantErr:     "no available licenses",
@@ -579,12 +609,14 @@ func TestRefresh(t *testing.T) {
 			desc:   "error when invocation_id not found during running state",
 			server: testService(stateRunning),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "1",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Id: "1",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_2",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_2",
 			},
 			wantErrCode: codes.FailedPrecondition,
 			wantErr:     "invocation_id not allocated",
@@ -605,12 +637,14 @@ func TestRefresh(t *testing.T) {
 				LastCheckin: start,
 			}),
 			req: &lmpb.RefreshRequest{
-				InvocationId: "5",
-				Licenses: []*lmpb.License{
-					&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+				Invocation: &lmpb.Invocation{
+					Id: "5",
+					Licenses: []*lmpb.License{
+						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					},
+					Owner:    "unit_test",
+					BuildTag: "tag_1",
 				},
-				Owner:    "unit_test",
-				BuildTag: "tag_1",
 			},
 			want: &lmpb.RefreshResponse{
 				InvocationId:           "5",


### PR DESCRIPTION
This change contains the bulk of the server handler implementation, along with associated unit tests.

The service proto is tweaked:

* More fields are added to `RefreshRequest` to better handle the case where the server is adopting existing allocations after a restart. The client must pass all the information (license type, owner, build_tag, etc.) during RefreshRequests in case the server has restarted; otherwise, the server won't know which license to allocate, who it is allocated to, etc.
* Common fields between RefreshRequest and AllocateRequest are deduplicated to an Invocation message.
* Repeated fields are pluralized
* Queued license count added to LicensesStats response

Jira: INFRA-90