### PR TITLE
gee: suppress read failures.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.1"
+readonly VERSION="0.2.0"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file


### PR DESCRIPTION
Today I learned: bash's "read" command will terminate with a
non-zero exit code (crashing the whole script), if it is given
an empty stream to process (ie. it reads eof).

PR generated by jonathan from branch gee.

Commits:
*  91b77ef gee: suppress read failures.
