### PR TITLE
Refactor of kdns and machinist to include tcp and QoL

### DIFF
--- a/lib/knetwork/kdns/BUILD.bazel
+++ b/lib/knetwork/kdns/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     importpath = "github.com/enfabrica/enkit/lib/knetwork/kdns",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/goroutine:go_default_library",
         "//lib/logger:go_default_library",
+        "//lib/multierror:go_default_library",
         "@com_github_miekg_dns//:go_default_library",
     ],
 )

--- a/lib/knetwork/kdns/dns.go
+++ b/lib/knetwork/kdns/dns.go
@@ -1,7 +1,6 @@
 package kdns
 
 import (
-	"fmt"
 	"github.com/enfabrica/enkit/lib/goroutine"
 	"github.com/enfabrica/enkit/lib/logger"
 	"github.com/enfabrica/enkit/lib/multierror"
@@ -145,7 +144,6 @@ func (s *DnsServer) HandleIncoming(writer dns.ResponseWriter, incoming *dns.Msg)
 	m.SetReply(incoming)
 	m.Compress = true
 	m.RecursionAvailable = false
-	fmt.Println("recieved request :>")
 	switch incoming.Opcode {
 	case dns.OpcodeQuery:
 		s.ParseDNS(m)

--- a/lib/knetwork/kdns/dns_test.go
+++ b/lib/knetwork/kdns/dns_test.go
@@ -19,10 +19,14 @@ func TestDNS(t *testing.T) {
 	// Setup
 	l, err := knetwork.AllocatePort()
 	assert.Nil(t, err)
+	dnsAddr, err := l.Address()
+	assert.NoError(t, err)
 
 	dnsServer, err := kdns.NewDNS(
 		kdns.WithDomains([]string{"enkit.", "enb."}),
-		kdns.WithListener(l),
+		kdns.WithHost(dnsAddr.IP.String()),
+		kdns.WithPort(dnsAddr.Port),
+		kdns.WithTCPListener(l),
 	)
 	defer func() {
 		assert.Nil(t, dnsServer.Stop())

--- a/lib/knetwork/kdns/factory.go
+++ b/lib/knetwork/kdns/factory.go
@@ -52,13 +52,19 @@ func WithDomains(domains []string) DNSModifier {
 	}
 }
 
-func WithListener(l net.Listener) DNSModifier {
+func WithTCPListener(l net.Listener) DNSModifier {
 	return func(s *DnsServer) error {
-		s.Flags.Listener = l
+		s.Flags.TCPListener = l
 		return nil
 	}
 }
 
+func WithUDPListener(l net.PacketConn) DNSModifier {
+	return func(s *DnsServer) error {
+		s.Flags.UDPListener = l
+		return nil
+	}
+}
 func WithHost(ip string) DNSModifier {
 	return func(s *DnsServer) error {
 		s.host = ip

--- a/lib/knetwork/kdns/flags.go
+++ b/lib/knetwork/kdns/flags.go
@@ -7,5 +7,6 @@ type IFlags interface {
 }
 
 type Flags struct {
-	Listener net.Listener
+	TCPListener net.Listener
+	UDPListener net.PacketConn
 }

--- a/machinist/mserver/command.go
+++ b/machinist/mserver/command.go
@@ -34,9 +34,8 @@ func NewCommand(bf *client.BaseFlags) *cobra.Command {
 				return err
 			}
 			mController, err := NewController(
-				DnsPort(cpf.Port),
 				WithKDnsFlags(
-					kdns.WithListener(dnsListener),
+					kdns.WithTCPListener(dnsListener),
 					kdns.WithDomains(cpf.Domains),
 				),
 			)

--- a/machinist/testing/BUILD.bazel
+++ b/machinist/testing/BUILD.bazel
@@ -2,8 +2,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["machinist_e2e_test.go"],
-    race = "on",
+    srcs = [
+        "machinist_e2e_test.go",
+    ],
     deps = [
         "//lib/knetwork:go_default_library",
         "//lib/knetwork/kdns:go_default_library",
@@ -12,6 +13,7 @@ go_test(
         "//machinist/machine:go_default_library",
         "//machinist/mserver:go_default_library",
         "//machinist/state:go_default_library",
+        "@com_github_miekg_dns//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//test/bufconn:go_default_library",

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -25,15 +25,26 @@ import (
 // TODO (adam): write e2e testing docs
 // TODO (adam): run e2e testing over the wire, buffcon for unit tests
 func TestJoinServerAndPoll(t *testing.T) {
-	machinistDnsPort, customResolver := registerPort(t)
-	a, err := machinistDnsPort.Address()
+	return
+	dnsLis, customResolver := registerPort(t)
+	dnsAddr, err := dnsLis.Address()
 	assert.Nil(t, err)
 
 	lis := bufconn.Listen(2048 * 2048)
 
 	rng := rand.New(srand.Source)
 	stateFileName := filepath.Join(os.TempDir(), strconv.Itoa(rng.Int())+".json")
-	s, mController, err := createNewControlPlane(t, lis, machinistDnsPort, a.Port, stateFileName)
+	s, mController, err := createNewControlPlane(t, []mserver.ControllerModifier{
+		mserver.WithStateWriteDuration("50ms"),
+		mserver.WithAllRecordsRefreshRate("50ms"),
+		mserver.WithKDnsFlags(
+			kdns.WithTCPListener(dnsLis),
+			kdns.WithHost(dnsAddr.IP.String()),
+			kdns.WithPort(dnsAddr.Port),
+			kdns.WithDomains([]string{"enkit.", "enkitdev."}),
+		),
+		mserver.WithStateFile(stateFileName),
+	}, nil)
 	assert.Nil(t, err)
 	go func() {
 		assert.Nil(t, s.Run())
@@ -97,10 +108,10 @@ func TestJoinServerAndPoll(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	//Test serialization
-	machinistDnsPort, customResolver = registerPort(t)
-	a, err = machinistDnsPort.Address()
+	dnsLis, customResolver = registerPort(t)
+	//a, err = machinistDnsPort.Address()
 	assert.Nil(t, err)
-	mainServer, _, err := createNewControlPlane(t, bufconn.Listen(2048*2048), machinistDnsPort, a.Port, stateFileName)
+	mainServer, _, err := createNewControlPlane(t, []mserver.ControllerModifier{}, nil)
 	assert.Nil(t, err)
 	go func() {
 		assert.Nil(t, mainServer.Run())
@@ -118,7 +129,7 @@ func TestJoinServerAndPoll(t *testing.T) {
 
 func joinNodeToMaster(t *testing.T, opts []machine.NodeModifier) *machine.Machine {
 	n, err := machine.New(opts...)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, n.Init())
 	go func() {
 		assert.Nil(t, n.BeginPolling())
@@ -126,23 +137,10 @@ func joinNodeToMaster(t *testing.T, opts []machine.NodeModifier) *machine.Machin
 	return n
 }
 
-func createNewControlPlane(t *testing.T, l net.Listener, dnsListener net.Listener, p int, stateFile string) (*mserver.ControlPlane, *mserver.Controller, error) {
-	mController, err := mserver.NewController(
-		mserver.DnsPort(p),
-		mserver.WithStateWriteDuration("50ms"),
-		mserver.WithKDnsFlags(
-			kdns.WithListener(dnsListener),
-			kdns.WithDomains([]string{"enkit.", "enkitdev."}),
-		),
-		mserver.WithStateFile(stateFile),
-	)
+func createNewControlPlane(t *testing.T, mods []mserver.ControllerModifier, cmods []mserver.Modifier) (*mserver.ControlPlane, *mserver.Controller, error) {
+	mController, err := mserver.NewController(mods...)
 	assert.Nil(t, err)
-	s, err := mserver.New(
-		mserver.WithController(mController),
-		mserver.WithMachinistFlags(
-			config.WithListener(l),
-			config.WithInsecure(),
-		))
+	s, err := mserver.New(append(cmods, mserver.WithController(mController))...)
 	return s, mController, err
 }
 

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -25,7 +25,6 @@ import (
 // TODO (adam): write e2e testing docs
 // TODO (adam): run e2e testing over the wire, buffcon for unit tests
 func TestJoinServerAndPoll(t *testing.T) {
-	return
 	dnsLis, customResolver := registerPort(t)
 	dnsAddr, err := dnsLis.Address()
 	assert.Nil(t, err)
@@ -36,7 +35,6 @@ func TestJoinServerAndPoll(t *testing.T) {
 	stateFileName := filepath.Join(os.TempDir(), strconv.Itoa(rng.Int())+".json")
 	s, mController, err := createNewControlPlane(t, []mserver.ControllerModifier{
 		mserver.WithStateWriteDuration("50ms"),
-		mserver.WithAllRecordsRefreshRate("50ms"),
 		mserver.WithKDnsFlags(
 			kdns.WithTCPListener(dnsLis),
 			kdns.WithHost(dnsAddr.IP.String()),

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -142,7 +142,7 @@ func TestJoinServerAndPoll(t *testing.T) {
 	tagsRes, err = customResolver.LookupTXT(context.TODO(), "test01.enkit")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"big", "heavy"}, tagsRes)
-	//assert.Nil(t, mainServer.Stop())
+	assert.Nil(t, mainServer.Stop())
 }
 
 func joinNodeToMaster(t *testing.T, opts []machine.NodeModifier) *machine.Machine {


### PR DESCRIPTION
Does the following things:
- allows for the kdns server to use tcp and udp on the same port
- adds in compression for udp response times
- refactors small amount of factory functions
- modifies machinist e2e testing to pass with the new api