### PR TITLE
bazel astore: Create function to format astore URLs

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -1,3 +1,13 @@
+def astore_url(package, uid, instance = "https://astore.corp.enfabrica.net"):
+    """Returns a URL for a particular package version from astore."""
+    if not package.startswith("/"):
+        package = "/" + package
+    return "{}/d{}?u={}".format(
+        instance,
+        package,
+        uid,
+    )
+
 def _astore_upload(ctx):
     push = ctx.actions.declare_file("astore_upload.sh")
 


### PR DESCRIPTION
This change adds an `astore_url` function that can be used to return a
formatted URL for a particular package + version tuple. This allows
WORKSPACE file authors to think in terms of this tuple rather than
having to encode/decode astore URLs manually.

This turns:

```
kernel_tree_version(
    name = "enfvm-ubuntu-hirsute",
    package = "enfvm-5.11.22+enf-1634151087-g17b4193",
    sha256 = "37f4d4b270854b65416a2d071f4fc06b50262eb11ad32ee38f5e9143b9f5a624",
    url = "https://astore.corp.enfabrica.net/d/kernel/enf/hirsute-25.27/vm/enf-kernel.tar.gz",
)
```

into:

```
kernel_tree_version(
    name = "enfvm-ubuntu-hirsute",
    package = "enfvm-5.11.22+enf-1634151087-g17b4193",
    sha256 = "37f4d4b270854b65416a2d071f4fc06b50262eb11ad32ee38f5e9143b9f5a624",
    url = astore_url(
        package = "/kernel/enf/hirsute-25.27/vm/enf-kernel.tar.gz",
        uid = "h6rdi5rdeu44pndi75icc8szk6bm8dnj",
    ),
)
```

Tested: Locally in internal with the above change, while overriding the
`enkit` dependency with this change.