### PR TITLE
enkit bazel affected-targets: Create cache dir

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -24,6 +24,10 @@ func GetAffectedTargets(start string, end string) ([]string, error) {
 		return nil, fmt.Errorf("failed to get user's cache dir: %w", err)
 	}
 	cacheDir = filepath.Join(cacheDir, "enkit", "bazel")
+	err = os.MkdirAll(cacheDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make root cache dir: %w", err)
+	}
 	startOutputBase, err := ioutil.TempDir(cacheDir, "output_base_*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary output_base: %w", err)


### PR DESCRIPTION
This change ensures the root cache dir exists before trying to create
new directories inside of it.

Tested: Allows `enkit bazel affected-targets list` to not error against the enkit repo in Cloud Build

Jira: INFRA-52