### PR TITLE
gee repair: fix remote.origin.fetch setting.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.3"
+readonly VERSION="0.2.4"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file


### PR DESCRIPTION
Users who ran an older version of gee might see an incorrect
remote.origin.fetch setting.  "gee repair" will now detect and fix this issue.

PR generated by jonathan from branch gee_fix_origin.

Commits:
*  0ee5854 gee repair: fix remote.origin.fetch setting.
