### PR TITLE
bazel presubmit: Issue parallel queries

### DIFF
--- a/lib/bazel/BUILD.bazel
+++ b/lib/bazel/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lib/bazel/proto:go_protos",
+        "//lib/goroutine:go_default_library",
         "//lib/logger:go_default_library",
         "//lib/multierror:go_default_library",
         "//lib/proto/delimited:go_default_library",


### PR DESCRIPTION
This change issues bazel queries in parallel to attempt to speed up the
changed target detection phase in Cloud Build.

Tested: https://console.cloud.google.com/cloud-build/builds;region=global/2904a0d7-5106-45a3-b7e3-b60ba43bf50e;step=2?project=cloud-build-290921

Lowers the query time from ~6min in aggregate to ~4.5min in parallel

Jira: INFRA-104