### PR TITLE
gee: alias hyphen to underscore in command names

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.0"
+readonly VERSION="0.2.1"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file


### PR DESCRIPTION
PR generated by jonathan from branch gee_hyphen.

Commits:
*  ef62169 allow hyphens in commands
