### PR TITLE
Allow kernel_test targets to take a dependency on another module

### DIFF
--- a/bazel/linux/run_um_kunit_tests.template
+++ b/bazel/linux/run_um_kunit_tests.template
@@ -2,7 +2,10 @@
 
 set -e
 
-MODULE=$(dirname $(realpath {module}))
 TMPOUTPUT=$TEST_TMPDIR/.output
-{kernel} ubd0={rootfs} hostfs=$MODULE uml_dir=$TEST_TMPDIR | tee $TMPOUTPUT
+HOSTFS="$(mktemp -d)"
+cp $(realpath {module}) $HOSTFS
+cp $(realpath {deps}) $HOSTFS
+
+{kernel} ubd0={rootfs} hostfs=${HOSTFS} uml_dir=$TEST_TMPDIR rw | tee $TMPOUTPUT
 {parser} parse < $TMPOUTPUT


### PR DESCRIPTION
Signed-off-by: Raghu Raja <raghu@enfabrica.net>


---

With this rule, I am able to express a dependency as below:

```
@ -46,5 +46,6 @@ kernel_test(
     name = "xxx",
     kernel_image = "@testing-latest-kernel-image",
     module = ":yyy",
+    deps = "//foo/bar:zzz",
     rootfs_image = "@testing-latest-rootfs",
 )
```