### PR TITLE
bazel presubmit: Remove --keep_going option

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -80,7 +80,7 @@ func GetAffectedTargets(start string, end string, log logger.Logger) ( /* change
 		func() error {
 			log.Infof("Querying dependency graph for 'before' workspace...")
 			var err error
-			startResults, err = startWorkspace.Query("deps(//...)", WithKeepGoing(), WithUnorderedOutput(), workspaceLogStart)
+			startResults, err = startWorkspace.Query("deps(//...)", WithUnorderedOutput(), workspaceLogStart)
 			if err != nil {
 				return fmt.Errorf("failed to query deps for start point: %w", err)
 			}
@@ -90,7 +90,7 @@ func GetAffectedTargets(start string, end string, log logger.Logger) ( /* change
 		func() error {
 			log.Infof("Querying dependency graph for 'after' workspace...")
 			var err error
-			endResults, err = endWorkspace.Query("deps(//...)", WithKeepGoing(), WithUnorderedOutput(), workspaceLogEnd)
+			endResults, err = endWorkspace.Query("deps(//...)", WithUnorderedOutput(), workspaceLogEnd)
 			if err != nil {
 				return fmt.Errorf("failed to query deps for end point: %w", err)
 			}


### PR DESCRIPTION
It should be possible to make all our repositories query-clean, which
means any change that introduces a query error should fail presubmit.

This change removes the `--keep_going` option from bazel queries, so
that queries must execute successfully in order for affected targets
detection to succeed.

Jira: INFRA-52