### PR TITLE
INFRA-115: Rename license_manager to flextape

### DIFF
--- a/flextape/README.md
+++ b/flextape/README.md
@@ -1,0 +1,18 @@
+# Flextape
+
+Flextape is our out-of-band license management server that gates individual
+actions run via bazel until the required license is available from the
+vendor-provided flexlm license server.
+
+This is necessary since the vendor-provided solutions do not support queueing,
+causing actions to fail if there is too much concurrency with other actions that
+require the same license type.
+
+The `flextape` server maintains a count of licenses out-of-band with the
+vendor-provided license manager, and individual actions are wrapped with a
+client that obtains a token from the `flextape` server before running their
+command. The `flextape` protocol has keepalive mechanisms that will aggressively
+expire the token if clients become unresponsive, unblocking subsequent actions.
+
+More details in [this
+doc](https://docs.google.com/document/d/1TNqbBprpcNU9tTHVCFzRwaQoHlGFdjkw221C5p9UsAw/edit).

--- a/flextape/proto/BUILD.bazel
+++ b/flextape/proto/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
-    name = "license_manager_proto",
-    srcs = ["license_manager.proto"],
+    name = "flextape_proto",
+    srcs = ["flextape.proto"],
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
@@ -12,16 +12,16 @@ proto_library(
 )
 
 go_proto_library(
-    name = "license_manager_go_proto",
+    name = "flextape_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/enfabrica/enkit/license_manager/proto",
-    proto = ":license_manager_proto",
+    importpath = "github.com/enfabrica/enkit/flextape/proto",
+    proto = ":flextape_proto",
     visibility = ["//visibility:public"],
 )
 
 go_library(
     name = "go_default_library",
-    embed = [":license_manager_go_proto"],
-    importpath = "github.com/enfabrica/enkit/license_manager/proto",
+    embed = [":flextape_go_proto"],
+    importpath = "github.com/enfabrica/enkit/flextape/proto",
     visibility = ["//visibility:public"],
 )

--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package license_manager.proto;
+package flextape.proto;
 
 import "google/protobuf/timestamp.proto";
 
@@ -13,7 +13,7 @@ import "google/protobuf/timestamp.proto";
 //     are ultimately fetched from and returned to a vendor-specific license
 //     server.
 //
-//     Licenses are "allocated" when the LicenseManager frontend associates it
+//     Licenses are "allocated" when the Flextape frontend associates it
 //     with an invocation.
 //
 //     Licenses are "in use" when the invocation actually uses a license from
@@ -25,7 +25,7 @@ import "google/protobuf/timestamp.proto";
 //     Invocations may use a license, and to do so they must be allocated one
 //     before the underlying hardware toolchain process is allowed to execute.
 
-service LicenseManager {
+service Flextape {
   // Allocate attempts to allocate a specific license type for this invocation.
   // If successful, invocations will keep the allocation alive by calling
   // Refresh(). If the invocation is queued for the license instead, invocations
@@ -56,7 +56,7 @@ service LicenseManager {
   rpc Release(ReleaseRequest) returns (ReleaseResponse) {}
 
   // LicensesStatus returns the status of all license types, as reported by both
-  // the LicenseManager and the underlying license servers.
+  // the Flextape and the underlying license servers.
   rpc LicensesStatus(LicensesStatusRequest) returns (LicensesStatusResponse) {}
 }
 
@@ -151,11 +151,11 @@ message LicenseStats {
   uint32 total_license_count = 3;
 
   // Number of licenses currently allocated, as reported by the
-  // LicenseManager. This should be less than or equal to in_use_count.
+  // Flextape. This should be less than or equal to in_use_count.
   uint32 allocated_count = 5;
 
   // Number of invocations queued for a license, as reported by the
-  // LicenseManager. If this number is >0, then allocated_count should equal
+  // Flextape. If this number is >0, then allocated_count should equal
   // total_license_count.
   uint32 queued_count = 6;
 }

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -3,18 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "github.com/enfabrica/enkit/license_manager/server",
+    importpath = "github.com/enfabrica/enkit/flextape/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//flextape/proto:go_default_library",
+        "//flextape/service:go_default_library",
         "//lib/server:go_default_library",
-        "//license_manager/proto:go_default_library",
-        "//license_manager/service:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )
 
 go_binary(
-    name = "license_manager",
+    name = "flextape",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/enfabrica/enkit/lib/server"
-	lmpb "github.com/enfabrica/enkit/license_manager/proto"
-	"github.com/enfabrica/enkit/license_manager/service"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
+	"github.com/enfabrica/enkit/flextape/service"
 
 	"google.golang.org/grpc"
 )
@@ -11,7 +11,7 @@ import (
 func main() {
 	grpcs := grpc.NewServer()
 	s := service.New()
-	lmpb.RegisterLicenseManagerServer(grpcs, s)
+	fpb.RegisterFlextapeServer(grpcs, s)
 
 	server.Run(nil, grpcs)
 }

--- a/flextape/service/BUILD.bazel
+++ b/flextape/service/BUILD.bazel
@@ -6,10 +6,10 @@ go_library(
         "license.go",
         "service.go",
     ],
-    importpath = "github.com/enfabrica/enkit/license_manager/service",
+    importpath = "github.com/enfabrica/enkit/flextape/service",
     visibility = ["//visibility:public"],
     deps = [
-        "//license_manager/proto:go_default_library",
+        "//flextape/proto:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
@@ -22,8 +22,8 @@ go_test(
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//flextape/proto:go_default_library",
         "//lib/errdiff:go_default_library",
-        "//license_manager/proto:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_prashantv_gostub//:go_default_library",

--- a/flextape/service/license.go
+++ b/flextape/service/license.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -19,7 +19,7 @@ type license struct {
 
 // formatLicenseType returns a unique string for a particular vendor/feature
 // combination.
-func formatLicenseType(l *lmpb.License) string {
+func formatLicenseType(l *fpb.License) string {
 	return strings.Join([]string{l.GetVendor(), l.GetFeature()}, "::")
 }
 
@@ -92,13 +92,13 @@ func (l *license) GetQueued(invID string) *invocation {
 }
 
 // GetStats returns a LicenseStats message for this license type.
-func (l *license) GetStats(name string) *lmpb.LicenseStats {
+func (l *license) GetStats(name string) *fpb.LicenseStats {
 	fields := strings.SplitN(name, "::", 2)
 	if len(fields) != 2 {
 		fields = []string{"<UNKNOWN>", name}
 	}
-	return &lmpb.LicenseStats{
-		License: &lmpb.License{
+	return &fpb.LicenseStats{
+		License: &fpb.License{
 			Vendor:  fields[0],
 			Feature: fields[1],
 		},

--- a/flextape/service/service_test.go
+++ b/flextape/service/service_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/enfabrica/enkit/lib/errdiff"
-	lmpb "github.com/enfabrica/enkit/license_manager/proto"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -91,8 +91,8 @@ func TestAllocate(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		server       *Service
-		req          *lmpb.AllocateRequest
-		want         *lmpb.AllocateResponse
+		req          *fpb.AllocateRequest
+		want         *fpb.AllocateResponse
 		wantErrCode  codes.Code
 		wantErr      string
 		wantLicenses map[string]*license
@@ -100,11 +100,11 @@ func TestAllocate(t *testing.T) {
 		{
 			desc:   "too many licenses",
 			server: testService(stateStarting),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+						&fpb.License{Vendor: "xilinx", Feature: "feature_bar"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
@@ -124,10 +124,10 @@ func TestAllocate(t *testing.T) {
 		{
 			desc:   "unknown license type",
 			server: testService(stateStarting),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "unknown_feature"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "unknown_feature"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
@@ -147,19 +147,19 @@ func TestAllocate(t *testing.T) {
 		{
 			desc:   "new invocations only enqueued during startup",
 			server: testService(stateStarting),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
 					Id:       "",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_Queued{
-					Queued: &lmpb.Queued{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_Queued{
+					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
 					},
@@ -182,19 +182,19 @@ func TestAllocate(t *testing.T) {
 				Owner:    "unit_test",
 				BuildTag: "tag_1234",
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
 					Id:       "1",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
-					LicenseAllocated: &lmpb.LicenseAllocated{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &fpb.LicenseAllocated{
 						InvocationId:           "1",
 						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 					},
@@ -217,19 +217,19 @@ func TestAllocate(t *testing.T) {
 				Owner:    "unit_test",
 				BuildTag: "tag_1234",
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
 					Id:       "1",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_Queued{
-					Queued: &lmpb.Queued{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_Queued{
+					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
 					},
@@ -253,19 +253,19 @@ func TestAllocate(t *testing.T) {
 				BuildTag:    "tag_1234",
 				LastCheckin: start,
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2345",
 					Id:       "2",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_Queued{
-					Queued: &lmpb.Queued{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_Queued{
+					Queued: &fpb.Queued{
 						InvocationId: "2",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
 					},
@@ -290,10 +290,10 @@ func TestAllocate(t *testing.T) {
 				BuildTag:    "tag_1234",
 				LastCheckin: start,
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2345",
@@ -325,18 +325,18 @@ func TestAllocate(t *testing.T) {
 				BuildTag:    "tag_2",
 				LastCheckin: start,
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_3",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_Queued{
-					Queued: &lmpb.Queued{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_Queued{
+					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
 					},
@@ -362,19 +362,19 @@ func TestAllocate(t *testing.T) {
 				Owner:    "unit_test",
 				BuildTag: "tag_1234",
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1234",
 					Id:       "1",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
-					LicenseAllocated: &lmpb.LicenseAllocated{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &fpb.LicenseAllocated{
 						InvocationId:           "1",
 						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 					},
@@ -398,18 +398,18 @@ func TestAllocate(t *testing.T) {
 				BuildTag:    "tag_1",
 				LastCheckin: start,
 			}),
-			req: &lmpb.AllocateRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.AllocateRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
 				},
 			},
-			want: &lmpb.AllocateResponse{
-				ResponseType: &lmpb.AllocateResponse_LicenseAllocated{
-					LicenseAllocated: &lmpb.LicenseAllocated{
+			want: &fpb.AllocateResponse{
+				ResponseType: &fpb.AllocateResponse_LicenseAllocated{
+					LicenseAllocated: &fpb.LicenseAllocated{
 						InvocationId:           "1",
 						LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 					},
@@ -458,8 +458,8 @@ func TestRefresh(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		server       *Service
-		req          *lmpb.RefreshRequest
-		want         *lmpb.RefreshResponse
+		req          *fpb.RefreshRequest
+		want         *fpb.RefreshResponse
 		wantErrCode  codes.Code
 		wantErr      string
 		wantLicenses map[string]*license
@@ -467,10 +467,10 @@ func TestRefresh(t *testing.T) {
 		{
 			desc:   "error when invocation_id not set",
 			server: testService(stateStarting),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
@@ -489,12 +489,12 @@ func TestRefresh(t *testing.T) {
 		{
 			desc:   "error when multiple licenses specified",
 			server: testService(stateStarting),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "1",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_bar"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+						&fpb.License{Vendor: "xilinx", Feature: "feature_bar"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
@@ -513,17 +513,17 @@ func TestRefresh(t *testing.T) {
 		{
 			desc:   "allocates when invocation_id not found during starting state",
 			server: testService(stateStarting),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "1",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
 				},
 			},
-			want: &lmpb.RefreshResponse{
+			want: &fpb.RefreshResponse{
 				InvocationId:           "1",
 				LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 			},
@@ -545,17 +545,17 @@ func TestRefresh(t *testing.T) {
 				BuildTag:    "tag_1",
 				LastCheckin: start,
 			}),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "5",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1",
 				},
 			},
-			want: &lmpb.RefreshResponse{
+			want: &fpb.RefreshResponse{
 				InvocationId:           "5",
 				LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 			},
@@ -582,11 +582,11 @@ func TestRefresh(t *testing.T) {
 				BuildTag:    "tag_2",
 				LastCheckin: start,
 			}),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "1",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
@@ -608,11 +608,11 @@ func TestRefresh(t *testing.T) {
 		{
 			desc:   "error when invocation_id not found during running state",
 			server: testService(stateRunning),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "1",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_2",
@@ -636,17 +636,17 @@ func TestRefresh(t *testing.T) {
 				BuildTag:    "tag_1",
 				LastCheckin: start,
 			}),
-			req: &lmpb.RefreshRequest{
-				Invocation: &lmpb.Invocation{
+			req: &fpb.RefreshRequest{
+				Invocation: &fpb.Invocation{
 					Id: "5",
-					Licenses: []*lmpb.License{
-						&lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+					Licenses: []*fpb.License{
+						&fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 					},
 					Owner:    "unit_test",
 					BuildTag: "tag_1",
 				},
 			},
-			want: &lmpb.RefreshResponse{
+			want: &fpb.RefreshResponse{
 				InvocationId:           "5",
 				LicenseRefreshDeadline: timestamppb.New(start.Add(7 * time.Second)),
 			},
@@ -692,8 +692,8 @@ func TestRelease(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		server       *Service
-		req          *lmpb.ReleaseRequest
-		want         *lmpb.ReleaseResponse
+		req          *fpb.ReleaseRequest
+		want         *fpb.ReleaseResponse
 		wantErrCode  codes.Code
 		wantErr      string
 		wantLicenses map[string]*license
@@ -706,7 +706,7 @@ func TestRelease(t *testing.T) {
 				BuildTag:    "tag_1",
 				LastCheckin: start,
 			}),
-			req:         &lmpb.ReleaseRequest{},
+			req:         &fpb.ReleaseRequest{},
 			wantErrCode: codes.InvalidArgument,
 			wantErr:     "invocation_id must be set",
 			wantLicenses: map[string]*license{
@@ -732,8 +732,8 @@ func TestRelease(t *testing.T) {
 				BuildTag:    "tag_2",
 				LastCheckin: start,
 			}),
-			req:  &lmpb.ReleaseRequest{InvocationId: "5"},
-			want: &lmpb.ReleaseResponse{},
+			req:  &fpb.ReleaseRequest{InvocationId: "5"},
+			want: &fpb.ReleaseResponse{},
 			wantLicenses: map[string]*license{
 				"xilinx::feature_foo": &license{
 					totalAvailable: 2,
@@ -757,8 +757,8 @@ func TestRelease(t *testing.T) {
 				BuildTag:    "tag_2",
 				LastCheckin: start,
 			}),
-			req:  &lmpb.ReleaseRequest{InvocationId: "5"},
-			want: &lmpb.ReleaseResponse{},
+			req:  &fpb.ReleaseRequest{InvocationId: "5"},
+			want: &fpb.ReleaseResponse{},
 			wantLicenses: map[string]*license{
 				"xilinx::feature_foo": &license{
 					totalAvailable: 2,
@@ -782,7 +782,7 @@ func TestRelease(t *testing.T) {
 				BuildTag:    "tag_2",
 				LastCheckin: start,
 			}),
-			req:         &lmpb.ReleaseRequest{InvocationId: "4"},
+			req:         &fpb.ReleaseRequest{InvocationId: "4"},
 			wantErrCode: codes.FailedPrecondition,
 			wantErr:     "invocation_id not found",
 			wantLicenses: map[string]*license{
@@ -828,8 +828,8 @@ func TestLicensesStatus(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		server       *Service
-		req          *lmpb.LicensesStatusRequest
-		want         *lmpb.LicensesStatusResponse
+		req          *fpb.LicensesStatusRequest
+		want         *fpb.LicensesStatusResponse
 		wantErrCode  codes.Code
 		wantErr      string
 		wantLicenses map[string]*license
@@ -852,11 +852,11 @@ func TestLicensesStatus(t *testing.T) {
 				BuildTag:    "tag_3",
 				LastCheckin: start,
 			}),
-			req: &lmpb.LicensesStatusRequest{},
-			want: &lmpb.LicensesStatusResponse{
-				LicenseStats: []*lmpb.LicenseStats{
-					&lmpb.LicenseStats{
-						License:           &lmpb.License{Vendor: "xilinx", Feature: "feature_foo"},
+			req: &fpb.LicensesStatusRequest{},
+			want: &fpb.LicensesStatusResponse{
+				LicenseStats: []*fpb.LicenseStats{
+					&fpb.LicenseStats{
+						License:           &fpb.License{Vendor: "xilinx", Feature: "feature_foo"},
 						TotalLicenseCount: 2,
 						AllocatedCount:    2,
 						QueuedCount:       1,


### PR DESCRIPTION
This change renames our license manager server to flextape by:

* changing the top-level directory name
* changing the proto and service names

A README is added to explain what this is since it is no longer clear
from the file name.

Jira: INFRA-115