### PR TITLE
INFRA-107: Stub in support for flextape in the old client 

### DIFF
--- a/flextape/client/BUILD.bazel
+++ b/flextape/client/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client.go"],
+    importpath = "github.com/enfabrica/enkit/flextape/client",
+    visibility = ["//manager/client:__pkg__"],
+    deps = ["@org_golang_google_grpc//:go_default_library"],
+)

--- a/flextape/client/client.go
+++ b/flextape/client/client.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+func RunCommandWithLicense(conn *grpc.ClientConn, username string, vendor string, feature string, timeout time.Duration, cmd string, args ...string) error {
+	return fmt.Errorf("flextape client not yet implemented")
+}

--- a/manager/client/BUILD.bazel
+++ b/manager/client/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/enfabrica/enkit/manager/client",
     visibility = ["//visibility:private"],
     deps = [
+        "//flextape/client:go_default_library",
         "//manager/rpc:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/manager/client/main.go
+++ b/manager/client/main.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	rpc_license "github.com/enfabrica/enkit/manager/rpc"
-	"google.golang.org/grpc"
-	grpcCodes "google.golang.org/grpc/codes"
-	grpcStatus "google.golang.org/grpc/status"
 	"io"
 	"log"
 	"os"
@@ -15,6 +11,13 @@ import (
 	"os/user"
 	"strings"
 	"time"
+
+	rpc_license "github.com/enfabrica/enkit/manager/rpc"
+	"github.com/enfabrica/enkit/flextape/client"
+
+	"google.golang.org/grpc"
+	grpcCodes "google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 func run(timeout time.Duration, cmd string, args ...string) {
@@ -93,15 +96,21 @@ func main() {
 	timeout := flag.Duration("timeout", 7200*time.Second, "Max time waiting in license queue")
 	flag.Parse()
 	vendor, feature, cmd, args := os.Args[3], os.Args[4], os.Args[5], os.Args[6:]
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
-	defer conn.Close()
-	if err != nil {
-		log.Fatalf("Connection failed: %s \n", err)
-	}
-	client := rpc_license.NewLicenseClient(conn)
 	user, err := user.Current()
 	if err != nil {
 		log.Fatalf("Failed to get username: %s \n", err)
 	}
-	polling(client, user.Username, quantity, vendor, feature, *timeout, cmd, args...)
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Connection failed: %s \n", err)
+	}
+	defer conn.Close()
+
+	if os.Getenv("LICENSE_SERVER_IMPL") != "flextape" {
+		c := rpc_license.NewLicenseClient(conn)
+		polling(c, user.Username, quantity, vendor, feature, *timeout, cmd, args...)
+	} else {
+		client.RunCommandWithLicense(conn, user.Username, vendor, feature, *timeout, cmd, args...)
+		log.Fatalf("flextape client not yet implemented")
+	}
 }


### PR DESCRIPTION
This change modifies the current license manager client to allow for
switching between old and new implementations based on the environment
variable `LICENSE_SERVER_IMPL`. Main is reorganized a tad to make this
clean.

Tested: Started a `flextape` server locally, and ran:

```
bazel run //manager/client:client -- localhost 6433 xilinx feature /bin/true --help
```

which prints:

```
2021/10/27 20:56:46 Error receiving message: rpc error: code = Unimplemented desc = unknown service license.License
```

(expected; flextape server does not implement the old protocol)

and then:

```
LICENSE_SERVER_IMPL=flextape bazel run //manager/client:client -- localhost 6433 xilinx feature /bin/true --help
```

which prints:

```
2021/10/27 20:56:59 flextape client not yet implemented
```

Jira: INFRA-107