### PR TITLE
gee bash_setup: set GEE_BINARY

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3512,6 +3512,8 @@ streamline the use of gee.  The following functions are exported:
 
   "gee": invokes "gee $@"
   "gcd": rapidly change between gee branch directories.
+
+Also sets GEE_BINARY to point to this copy of gee.
 EOT
 
 function gee__bash_setup() {


### PR DESCRIPTION
Supporing users installing gee in weird places:

"gee bash_setup" now sets the GEE_BINARY variable to point to the version of
gee that was just invoked, so that all future invocations of gee will look
in that location.

That is:

eval "$(~/my/strange/path/gee bash_setup)"

Now works intuitively, with ~/my/strange/path/gee being invoked by the gee
bash function from that point forward.

PR generated by jonathan from branch which_gee.

Commits:
*  da2476f gee bash_setup: set GEE_BINARY
