### PR TITLE
INFRA-120: Fix affected targets detection with generated files

### DIFF
--- a/lib/bazel/target.go
+++ b/lib/bazel/target.go
@@ -119,18 +119,9 @@ func (t *Target) getHash(w *Workspace) (uint32, error) {
 		}
 
 	case bpb.Target_GENERATED_FILE:
-		lbl, err := labelFromString(t.Target.GetGeneratedFile().GetName())
-		if err != nil {
-			return 0, err
-		}
-		f, err := w.bazelBin.Open(lbl.filePath())
-		if err != nil {
-			return 0, fmt.Errorf("can't find generated file %q: %w", lbl.filePath(), err)
-		}
-		defer f.Close()
-		if err := hashFile(h, f); err != nil {
-			return 0, err
-		}
+		// The hash of a generated file is based solely on the hash of the
+		// generating rule, which was handled above by adding all deps to the hash.
+		// No need to do anything more here.
 
 	case bpb.Target_PACKAGE_GROUP:
 		return 0, fmt.Errorf("PACKAGE_GROUP hashing not implemented")


### PR DESCRIPTION
Prior to this change, affected targets detection would attempt to read
and hash generated files, which don't actually exist.

The purpose of the hash is to detect when targets change. Generated
targets are based solely on the rule that generates them, so this change
ensures that:

* the generating rule is registered as a dependency of the
  generated-file target
* hashing the generated file target doesn't attempt to read any files

Tested: Added unit test for this case

Jira: INFRA-120