### PR TITLE
INFRA-121: Fix bazel graph parsing for directory labels

### DIFF
--- a/lib/bazel/affected_targets_test.go
+++ b/lib/bazel/affected_targets_test.go
@@ -16,6 +16,7 @@ func testWorkspace(t *testing.T) *Workspace {
 	files := map[string][]byte{
 		"test/target/foo.txt":          []byte("Hello, world"),
 		"test/target/foo_modified.txt": []byte("Goodbye, world"),
+		"test/anotherdir/file.txt":     []byte("Another dir"),
 	}
 	sourceFS := testutil.NewFS(t, files)
 	genFS := testutil.NewFS(t, nil)
@@ -750,6 +751,36 @@ func TestCalculateAffected(t *testing.T) {
 				"//test/target:foo.txt",
 				"//test/target:foo_rule",
 			},
+		},
+		{
+			desc: "source file that points to dir",
+			startResults: &QueryResult{
+				Targets: map[string]*Target{
+					"//test:target": &Target{
+						Target: &bpb.Target{
+							Type: bpb.Target_SOURCE_FILE.Enum(),
+							SourceFile: &bpb.SourceFile{
+								Name: proto.String("//test:target"), // Actually a directory; shouldn't cause an error
+							},
+						},
+					},
+				},
+				workspace: testWorkspace(t),
+			},
+			endResults: &QueryResult{
+				Targets: map[string]*Target{
+					"//test:target": &Target{
+						Target: &bpb.Target{
+							Type: bpb.Target_SOURCE_FILE.Enum(),
+							SourceFile: &bpb.SourceFile{
+								Name: proto.String("//test:target"),
+							},
+						},
+					},
+				},
+				workspace: testWorkspace(t),
+			},
+			want: []string{},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Some labels in `internal` are actually directories. When this is the
case, these directory labels are used as commandline flags rather than
file contents. It is debatable if this should just be fixed in
`internal`, but in the meantime dependency detection can tolerate this
case.

When a "source file" label that actually represents a directory is
encountered, the hash of the "source file" should correspond simply to
the hash of the label itself. This resolves a "can't read: is a
directory"-type error when attempting to hash the underlying "file" for
a directory source file target.

Jira: INFRA-121