### PR TITLE
INFRA-107: Implement flextape support in existing client

### DIFF
--- a/flextape/client/BUILD.bazel
+++ b/flextape/client/BUILD.bazel
@@ -1,9 +1,22 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["client.go"],
     importpath = "github.com/enfabrica/enkit/flextape/client",
     visibility = ["//manager/client:__pkg__"],
-    deps = ["@org_golang_google_grpc//:go_default_library"],
+    deps = ["//flextape/proto:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//flextape/proto:go_default_library",
+        "//lib/errdiff:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
+    ],
 )

--- a/flextape/client/client.go
+++ b/flextape/client/client.go
@@ -1,12 +1,155 @@
 package client
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"time"
 
-	"google.golang.org/grpc"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
 )
 
-func RunCommandWithLicense(conn *grpc.ClientConn, username string, vendor string, feature string, timeout time.Duration, cmd string, args ...string) error {
-	return fmt.Errorf("flextape client not yet implemented")
+var runCommand = func(ctx context.Context, result chan error, cmd string, args ...string) {
+	job := exec.CommandContext(ctx, cmd, args...)
+	job.Stdout = os.Stdout
+	job.Stderr = os.Stderr
+
+	result <- job.Run()
+}
+
+// LicenseClient wraps a FlextapeClient for a specific license acquisition.
+type LicenseClient struct {
+	client     fpb.FlextapeClient
+	invocation *fpb.Invocation
+	licenseErr chan error
+}
+
+// New returns a LicenseClient that can be used to guard command invocations
+// with the specified license.
+func New(client fpb.FlextapeClient, username string, vendor string, feature string, buildTag string) *LicenseClient {
+	return &LicenseClient{
+		client: client,
+		invocation: &fpb.Invocation{
+			Licenses: []*fpb.License{
+				&fpb.License{
+					Vendor:  vendor,
+					Feature: feature,
+				},
+			},
+			Owner:    username,
+			BuildTag: buildTag,
+		},
+		licenseErr: make(chan error),
+	}
+}
+
+// Guard wraps the specified command with the license acquire/refresh/release
+// lifecycle.
+func (c *LicenseClient) Guard(ctx context.Context, cmd string, args ...string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	// Get license
+	err := c.acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain license: %w", err)
+	}
+
+	jobResult := make(chan error)
+	go c.refresh(ctx)
+	go runCommand(ctx, jobResult, cmd, args...)
+
+	defer c.release(3 * time.Second)
+
+	select {
+	case err := <-c.licenseErr:
+		// License lost prematurely
+		cancel()
+		// Wait for command to fail/be killed
+		<-jobResult
+		return fmt.Errorf("lost license and killed job: %w", err)
+	case err := <-jobResult:
+		// Command has finished, either with success or error
+		if err != nil {
+			return fmt.Errorf("job failed: %w", err)
+		}
+		// Stop refreshing
+		cancel()
+		<-c.licenseErr
+		return nil
+	}
+}
+
+// acquire returns nil if the license is successfully acquired, or an error if
+// acquisition failed.
+func (c *LicenseClient) acquire(ctx context.Context) error {
+	req := &fpb.AllocateRequest{
+		Invocation: c.invocation,
+	}
+
+	for {
+		res, err := c.client.Allocate(ctx, req)
+		if err != nil {
+			return fmt.Errorf("Allocate() failure: %w", err)
+		}
+
+		switch r := res.GetResponseType().(type) {
+		case *fpb.AllocateResponse_LicenseAllocated:
+			req.GetInvocation().Id = r.LicenseAllocated.GetInvocationId()
+			return nil
+		case *fpb.AllocateResponse_Queued:
+			req.GetInvocation().Id = r.Queued.GetInvocationId()
+			sleepTime := min(time.Until(r.Queued.GetNextPollTime().AsTime())*4/5, time.Second)
+			time.Sleep(sleepTime)
+			continue
+		default:
+			return fmt.Errorf("unhandled response type %T", r)
+		}
+	}
+}
+
+// refresh refreshes the license in a loop until the context is finished.
+func (c *LicenseClient) refresh(ctx context.Context) {
+	defer close(c.licenseErr)
+	for {
+		req := &fpb.RefreshRequest{
+			Invocation: c.invocation,
+		}
+
+		res, err := c.client.Refresh(ctx, req)
+		if err != nil {
+			c.licenseErr <- fmt.Errorf("Refresh() failure: %w", err)
+		}
+
+		sleepTime := min(time.Until(res.GetLicenseRefreshDeadline().AsTime())*4/5, time.Second)
+
+		select {
+		case <-time.After(sleepTime):
+			continue
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// release notifies the server that the license is no longer required.
+func (c *LicenseClient) release(d time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+
+	req := &fpb.ReleaseRequest{
+		InvocationId: c.invocation.GetId(),
+	}
+
+	_, err := c.client.Release(ctx, req)
+	if err != nil {
+		return fmt.Errorf("error releasing license: %w", err)
+	}
+	return nil
+}
+
+func min(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/flextape/client/client_test.go
+++ b/flextape/client/client_test.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	fpb "github.com/enfabrica/enkit/flextape/proto"
+	"github.com/enfabrica/enkit/lib/errdiff"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type fakeClient struct {
+	allocateCallCount int
+	allocateResponses []*fpb.AllocateResponse
+	refreshCallCount int
+	refreshResponses []*fpb.RefreshResponse
+	refreshCancel func()
+}
+
+func (c *fakeClient) Allocate(context.Context, *fpb.AllocateRequest, ...grpc.CallOption) (*fpb.AllocateResponse, error) {
+	c.allocateCallCount++
+	if c.allocateCallCount-1 < len(c.allocateResponses) {
+		return c.allocateResponses[c.allocateCallCount-1], nil
+	}
+	return nil, fmt.Errorf("no responses left for Allocate()")
+}
+
+func (c *fakeClient) Refresh(context.Context, *fpb.RefreshRequest, ...grpc.CallOption) (*fpb.RefreshResponse, error) {
+	c.refreshCallCount++
+	if len(c.refreshResponses) == 0 {
+		c.refreshCancel()
+		return nil, fmt.Errorf("no responses")
+	}
+	if c.refreshCallCount == len(c.refreshResponses) {
+		c.refreshCancel()
+	}
+	return c.refreshResponses[c.refreshCallCount-1], nil
+}
+
+func (c *fakeClient) Release(context.Context, *fpb.ReleaseRequest, ...grpc.CallOption) (*fpb.ReleaseResponse, error) {
+	return nil, fmt.Errorf("Release() not implemented")
+}
+
+func (c *fakeClient) LicensesStatus(context.Context, *fpb.LicensesStatusRequest, ...grpc.CallOption) (*fpb.LicensesStatusResponse, error) {
+	return nil, fmt.Errorf("LicensesStatus() not implemented")
+}
+
+func TestLicenseClientAcquire(t *testing.T) {
+	now := timestamppb.Now()
+	testCases := []struct {
+		desc              string
+		allocateResponses []*fpb.AllocateResponse
+		wantCallCount     int
+		wantErr           string
+	}{
+		{
+			desc: "allocate immediate success",
+			allocateResponses: []*fpb.AllocateResponse{
+				&fpb.AllocateResponse{
+					ResponseType: &fpb.AllocateResponse_LicenseAllocated{
+						LicenseAllocated: &fpb.LicenseAllocated{
+							InvocationId:           "a",
+							LicenseRefreshDeadline: now,
+						},
+					},
+				},
+			},
+			wantCallCount: 1,
+		},
+		{
+			desc: "polls while queued",
+			allocateResponses: []*fpb.AllocateResponse{
+				&fpb.AllocateResponse{
+					ResponseType: &fpb.AllocateResponse_Queued{
+						Queued: &fpb.Queued{
+							InvocationId: "a",
+							NextPollTime: now,
+						},
+					},
+				},
+				&fpb.AllocateResponse{
+					ResponseType: &fpb.AllocateResponse_Queued{
+						Queued: &fpb.Queued{
+							InvocationId: "a",
+							NextPollTime: now,
+						},
+					},
+				},
+				&fpb.AllocateResponse{
+					ResponseType: &fpb.AllocateResponse_Queued{
+						Queued: &fpb.Queued{
+							InvocationId: "a",
+							NextPollTime: now,
+						},
+					},
+				},
+				&fpb.AllocateResponse{
+					ResponseType: &fpb.AllocateResponse_LicenseAllocated{
+						LicenseAllocated: &fpb.LicenseAllocated{
+							InvocationId:           "a",
+							LicenseRefreshDeadline: now,
+						},
+					},
+				},
+			},
+			wantCallCount: 4,
+		},
+		{
+			desc:              "propagates errors",
+			allocateResponses: []*fpb.AllocateResponse{},
+			wantCallCount:     1,
+			wantErr:           "Allocate() failure",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fake := &fakeClient{
+				allocateResponses: tc.allocateResponses,
+			}
+			client := &LicenseClient{
+				client: fake,
+				invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{
+							Vendor:  "xilinx",
+							Feature: "foo",
+						},
+					},
+					Owner:    "unittest",
+					BuildTag: "test",
+				},
+			}
+
+			ctx := context.Background()
+			gotErr := client.acquire(ctx)
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+			assert.Equal(t, tc.wantCallCount, fake.allocateCallCount)
+		})
+	}
+}
+
+func TestLicenseClientRefresh(t *testing.T) {
+	now := timestamppb.Now()
+	testCases := []struct {
+		desc             string
+		refreshResponses []*fpb.RefreshResponse
+		wantCallCount    int
+		wantErr          string
+	}{
+		{
+			desc: "loops until context completed",
+			refreshResponses: []*fpb.RefreshResponse{
+				&fpb.RefreshResponse{
+					InvocationId:           "a",
+					LicenseRefreshDeadline: now,
+				},
+				&fpb.RefreshResponse{
+					InvocationId:           "a",
+					LicenseRefreshDeadline: now,
+				},
+				&fpb.RefreshResponse{
+					InvocationId:           "a",
+					LicenseRefreshDeadline: now,
+				},
+			},
+			wantCallCount: 3,
+		},
+		{
+			desc: "propagates error",
+			wantCallCount: 1,
+			wantErr: "Refresh() failure",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func (t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			fake := &fakeClient{
+				refreshResponses: tc.refreshResponses,
+				refreshCancel: cancel,
+			}
+			client := &LicenseClient{
+				client: fake,
+				invocation: &fpb.Invocation{
+					Licenses: []*fpb.License{
+						&fpb.License{
+							Vendor:  "xilinx",
+							Feature: "foo",
+						},
+					},
+					Owner:    "unittest",
+					BuildTag: "test",
+				},
+				licenseErr: make(chan error),
+			}
+
+			go client.refresh(ctx)
+			gotErr := <-client.licenseErr
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+			assert.Equal(t, tc.wantCallCount, fake.refreshCallCount)
+		})
+	}
+}

--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -33,8 +33,8 @@ service Flextape {
   //
   // Returns:
   //   * NOT_FOUND if the license type is not known to the server
-  //   * RESOURCE_EXHAUSTED if the license type is known but there are currently
-  //     no licenses of that type available
+  //   * INVALID_ARGUMENT if the request is malformed (see request type for
+  //     details)
   rpc Allocate(AllocateRequest) returns (AllocateResponse) {}
 
   // Refresh refreshes a license allocation while an invocation is still

--- a/manager/client/BUILD.bazel
+++ b/manager/client/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//flextape/client:go_default_library",
+        "//flextape/proto:go_default_library",
         "//manager/rpc:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",


### PR DESCRIPTION
This change creates:

* a client library for Flextape communication
* unit tests for said library
* a codepath in the existing license manager client that uses Flextape
  communication, triggered via environment variable

Tested: In addition to the above:

```
 # Ran flextape server
 bazel run //flextape/server:flextape
 # Monitor license status
 watch -x -n 1 grpc_cli call localhost:6433 Flextape.LicensesStatus ''
 # Run a bunch of client instances wrapping a `sleep` call
 for i in $(seq 1 10); do (LICENSE_SERVER_IMPL=flextape bazel-bin/manager/client/client_/client localhost 6433 xilinx bar sleep 5 &); sleep 1; done
 # Watch licenses get allocated, invocations get queued
```

Jira: INFRA-107