### PR TITLE
INFRA-123: Write bazel command output to tempfiles

### DIFF
--- a/lib/bazel/BUILD.bazel
+++ b/lib/bazel/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "affected_targets_test.go",
+        "exec_test.go",
         "options_test.go",
         "pattern_test.go",
         "query_test.go",

--- a/lib/bazel/exec_test.go
+++ b/lib/bazel/exec_test.go
@@ -1,0 +1,56 @@
+package bazel
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+type fakeCommand struct {
+	runErr         error
+	closeErr       error
+	stdout         io.ReadCloser
+	stdoutContents []byte
+	stdoutErr      error
+	stderr         io.ReadCloser
+	stderrErr      error
+}
+
+func (c *fakeCommand) Run() error {
+	return c.runErr
+}
+
+func (c *fakeCommand) Close() error {
+	return c.closeErr
+}
+
+func (c *fakeCommand) Stdout() (io.ReadCloser, error) {
+	if c.stdoutErr != nil {
+		return nil, c.stdoutErr
+	}
+	return c.stdout, nil
+}
+
+func (c *fakeCommand) Stderr() (io.ReadCloser, error) {
+	if c.stderrErr != nil {
+		return nil, c.stderrErr
+	}
+	return c.stderr, nil
+}
+
+func (c *fakeCommand) StdoutContents() ([]byte, error) {
+	contents, err := ioutil.ReadAll(c.stdout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdout file: %w", err)
+	}
+	return contents, nil
+}
+
+func (c *fakeCommand) StderrContents() string {
+	contents, err := ioutil.ReadAll(c.stderr)
+	if err != nil {
+		return "<failed to read stderr contents>"
+	}
+	return string(bytes.TrimSpace(contents))
+}


### PR DESCRIPTION
This change modifies how `bazel` commands are run inside enkit to dump
both stdout and stderr to temporary files. This simplifies command
running, which no longer requires goroutines and negotiating an io.Pipe,
and allows for the code to log stdout/stderr output on command failure.
This in turn will let us debug why bazel commands fail in the presubmit.

Tested:

affected-targets tested locally against this change:

```
bazel run //enkit bazel affected-targets list --start=master --end=infra/123 --loglevel-console=debug

Affected targets:
//lib/bazel:go_default_test
//lib/bazel:go_default_library
//lib/bazel/commands:go_default_library
//enkit:go_default_library
//enkit:enkit-win-amd64
//enkit:enkit-linux-amd64
//enkit:enkit-darwin-amd64
//enkit:enkit
//enkit:deploy
//:gazelle-runner
//:gazelle
//:buildifier

Affected tests:
//lib/bazel:go_default_test
```

Jira: INFRA-123