### PR TITLE
gee: unbreak gui mergetool for older versions of git

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.7"
+readonly VERSION="0.2.8"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -1192,7 +1192,12 @@ function _interactive_conflict_resolution() {
             fi
             ;;
           [Gg])
-            _git mergetool --gui "${FILE}"
+            local GUI_MERGETOOL
+            GUI_MERGETOOL="$(git config --get merge.guitool)"
+            if [[ -z "${GUI_MERGETOOL}" ]]; then
+              GUI_MERGETOOL=meld  # default
+            fi
+            _git mergetool --tool="${GUI_MERGETOOL}" --no-prompt "${FILE}"
             M="$("${GIT}" diff --check "${FILE}" | grep -c "conflict marker" | cat)"
             if (( M == 0 )); then
               DONE=1


### PR DESCRIPTION
The hardware image is still running git 2.17, which doesn't support the
"git mergetool --guitool" option.  So, we emulate that option by manually
specifying a --tool="${GUI_MERGETOOL}".

The good news: this works.
The bad news: the "meld" GUI merge tool in the hw container is also broken.

One step at a time.

PR generated by '' from branch gee_guitool.

Commits:
*  1b39c00 support older git that doesn't implement guitool
