### PR TITLE
bazel presubmit: Run tests in `bazel test` step

### DIFF
--- a/infra/cloudbuild/helpers/bazel_test.sh
+++ b/infra/cloudbuild/helpers/bazel_test.sh
@@ -24,4 +24,4 @@ if [[ ! -s "${TARGETS_FILE}" ]]; then
   exit 0
 fi
 
-cat "${TARGETS_FILE}" | xargs bazel build
+cat "${TARGETS_FILE}" | xargs bazel test


### PR DESCRIPTION
In enkit, the presubmit test step is erroneously running `bazel build` instead of `bazel test`.