### PR TITLE
flextape: Return queue position to client

### DIFF
--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -85,6 +85,11 @@ message Queued {
   // placed at the back of the queue.
   string invocation_id = 1;
 
+  // Location of this invocation in the queue. Invocations in position 1 are
+  // next to be allocated, with higher positions getting allocations later than
+  // lower positions.
+  uint32 queue_position = 3;
+
   // Time at which client should issue its next AllocateRequest. The client
   // should issue its next poll after this time; if it fails to poll for
   // significantly longer (>5s) it may be moved to the back of the queue.

--- a/flextape/service/license.go
+++ b/flextape/service/license.go
@@ -23,9 +23,11 @@ func formatLicenseType(l *fpb.License) string {
 	return strings.Join([]string{l.GetVendor(), l.GetFeature()}, "::")
 }
 
-// Enqueue puts the supplied invocation at the back of the queue.
-func (l *license) Enqueue(inv *invocation) {
+// Enqueue puts the supplied invocation at the back of the queue. Returns the
+// 1-based index the invocation was queued at.
+func (l *license) Enqueue(inv *invocation) uint32 {
 	l.queue = append(l.queue, inv)
+	return uint32(len(l.queue))
 }
 
 // Allocate attempts to associate the supplied invocation with a license, if
@@ -81,14 +83,15 @@ func (l *license) ExpireQueued(expiry time.Time) {
 }
 
 // GetQueued returns an invocation by ID if the invocation is queued, or nil
-// otherwise.
-func (l *license) GetQueued(invID string) *invocation {
-	for _, inv := range l.queue {
+// otherwise. If the returned invocation is not nil, the 1-based index (queue
+// position) is also returned.
+func (l *license) GetQueued(invID string) (*invocation, uint32) {
+	for i, inv := range l.queue {
 		if inv.ID == invID {
-			return inv
+			return inv, uint32(i+1)
 		}
 	}
-	return nil
+	return nil, 0
 }
 
 // GetStats returns a LicenseStats message for this license type.

--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -172,7 +172,7 @@ func (s *Service) Allocate(ctx context.Context, req *fpb.AllocateRequest) (*fpb.
 			},
 		}, nil
 	}
-	if inv := lic.GetQueued(invocationID); inv != nil {
+	if inv, pos := lic.GetQueued(invocationID); inv != nil {
 		// Invocation is queued
 		inv.LastCheckin = timeNow()
 		return &fpb.AllocateResponse{
@@ -180,6 +180,7 @@ func (s *Service) Allocate(ctx context.Context, req *fpb.AllocateRequest) (*fpb.
 				Queued: &fpb.Queued{
 					InvocationId: invocationID,
 					NextPollTime: timestamppb.New(timeNow().Add(s.queueRefreshDuration)),
+					QueuePosition: pos,
 				},
 			},
 		}, nil
@@ -197,12 +198,13 @@ func (s *Service) Allocate(ctx context.Context, req *fpb.AllocateRequest) (*fpb.
 		BuildTag:    invMsg.GetBuildTag(),
 		LastCheckin: timeNow(),
 	}
-	lic.Enqueue(inv)
+	pos := lic.Enqueue(inv)
 	return &fpb.AllocateResponse{
 		ResponseType: &fpb.AllocateResponse_Queued{
 			Queued: &fpb.Queued{
 				InvocationId: invocationID,
 				NextPollTime: timestamppb.New(timeNow().Add(s.queueRefreshDuration)),
+				QueuePosition: pos,
 			},
 		},
 	}, nil

--- a/flextape/service/service_test.go
+++ b/flextape/service/service_test.go
@@ -162,6 +162,7 @@ func TestAllocate(t *testing.T) {
 					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						QueuePosition: 1,
 					},
 				},
 			},
@@ -232,6 +233,7 @@ func TestAllocate(t *testing.T) {
 					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						QueuePosition: 1,
 					},
 				},
 			},
@@ -268,6 +270,7 @@ func TestAllocate(t *testing.T) {
 					Queued: &fpb.Queued{
 						InvocationId: "2",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						QueuePosition: 2,
 					},
 				},
 			},
@@ -339,6 +342,7 @@ func TestAllocate(t *testing.T) {
 					Queued: &fpb.Queued{
 						InvocationId: "1",
 						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						QueuePosition: 1,
 					},
 				},
 			},


### PR DESCRIPTION
The client should log to the user the status of the license acquisition
progress when queued. Currently, there's not much progress the client
can communicate, other than that it's queued.

This change modifies the server to return the queue position so that
clients can communicate this to the user, providing user visibility that
in fact progress is being made (or the queue appears to be stalled).

Tested: Unit tests

Jira: INFRA-139