### PR TITLE
lib/bazel: Don't swallow errors when keep_going not set

### DIFF
--- a/lib/bazel/options.go
+++ b/lib/bazel/options.go
@@ -90,15 +90,11 @@ func (o *queryOptions) Args() []string {
 // filterError filters out expected error codes based on the provided query
 // arguments.
 func (o *queryOptions) filterError(err error) error {
-	if err == nil || !o.keepGoing {
-		return nil
-	}
-
 	var execErr *exec.ExitError
 	if errors.As(err, &execErr) {
 		// PARTIAL_ANALYSIS_FAILURE is expected when --keep_going is passed
 		// https://github.com/bazelbuild/bazel/blob/86409b7a248d1cb966268451f9aa4db0763c3eb2/src/main/java/com/google/devtools/build/lib/util/ExitCode.java#L38
-		if execErr.ExitCode() == 3 {
+		if execErr.ExitCode() == 3 && o.keepGoing {
 			return nil
 		}
 	}

--- a/lib/bazel/options_test.go
+++ b/lib/bazel/options_test.go
@@ -1,10 +1,23 @@
 package bazel
 
 import (
+	"errors"
+	"fmt"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// exitError manufactures a *exec.ExitError with a specified return code.
+func exitError(retcode int) error{
+	// exec.ExitError wraps os.ProcessState which is opaque, so there's no way to
+	// construct an error via the normal means.
+	// Instead, exec a script which exits with the specified code, and then return
+	// the error that the stdlib generated for us.
+	_, err := exec.Command("bash", "-c", fmt.Sprintf("exit %d", retcode)).Output()
+	return err
+}
 
 func TestQueryOptionsArgs(t *testing.T) {
 	tempLog, err := WithTempWorkspaceRulesLog()
@@ -23,4 +36,39 @@ func TestQueryOptionsArgs(t *testing.T) {
 	assert.Contains(t, got, "--order_output=no")
 	assert.Contains(t, got, "--keep_going")
 	assert.Contains(t, got, "--experimental_workspace_rules_log_file")
+}
+
+func TestQueryOptionsFilterError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		options *queryOptions
+		err error
+		wantErr bool
+	} {
+		{
+			desc: "default propagates all errors",
+			options: &queryOptions{},
+			err: errors.New("some error"),
+			wantErr: true,
+		},
+		{
+			desc: "keep_going ignores exit code 3",
+			options: &queryOptions{keepGoing: true},
+			err: exitError(3),
+			wantErr: false,
+		},
+		{
+			desc: "keep_going propagates exit code 4",
+			options: &queryOptions{keepGoing: true},
+			err: exitError(4),
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func (t *testing.T) {
+			gotErr := tc.options.filterError(tc.err)
+
+			assert.Equalf(t, gotErr != nil, tc.wantErr, "gotErr was '%v' but wantErr was %v", gotErr, tc.wantErr)
+		})
+	}
 }


### PR DESCRIPTION
This change fixes an issue where errors are not propagated when
keep_going is not set.

Tested: Added unit tests

Jira: INFRA-148