### PR TITLE
flextape: Add config definition and Xilinx config

### DIFF
--- a/flextape/proto/BUILD.bazel
+++ b/flextape/proto/BUILD.bazel
@@ -5,9 +5,16 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "flextape_proto",
     srcs = ["flextape.proto"],
-    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
+    deps = [
+        ":flextape_proto",
     ],
 )
 
@@ -15,13 +22,17 @@ go_proto_library(
     name = "flextape_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/enfabrica/enkit/flextape/proto",
-    proto = ":flextape_proto",
-    visibility = ["//visibility:public"],
+    protos = [
+        ":config_proto",
+        ":flextape_proto",
+    ],
 )
 
 go_library(
     name = "go_default_library",
-    embed = [":flextape_go_proto"],
+    embed = [
+        ":flextape_go_proto",
+    ],
     importpath = "github.com/enfabrica/enkit/flextape/proto",
     visibility = ["//visibility:public"],
 )

--- a/flextape/proto/BUILD.bazel
+++ b/flextape/proto/BUILD.bazel
@@ -2,6 +2,10 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
+# TODO: Make these definitions compatible with what gazelle wants to emit.
+
+# gazelle:ignore
+
 proto_library(
     name = "flextape_proto",
     srcs = ["flextape.proto"],

--- a/flextape/proto/config.proto
+++ b/flextape/proto/config.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package flextape.proto;
+
+import "flextape/proto/flextape.proto";
+
+option go_package = "github.com/enfabrica/enkit/flextape/proto";
+
+// Message used for server config file
+message Config {
+  // One LicenseConfig for each vendor::feature tuple.
+  // This should be configured from the license file the vendor provides.
+  repeated LicenseConfig license_configs = 1;
+}
+
+message LicenseConfig {
+  // vendor::feature tuple
+  flextape.proto.License license = 1;
+  // Total number of licenses that can be allocated.
+  uint32 quantity = 2;
+}

--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -4,6 +4,8 @@ package flextape.proto;
 
 import "google/protobuf/timestamp.proto";
 
+option go_package = "github.com/enfabrica/enkit/flextape/proto";
+
 // Describes a vendor-agnostic frontend for allocating licenses to hardware tool
 // command invocations.
 // Terminology:

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//flextape/service:go_default_library",
         "//lib/server:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
     ],
 )
 

--- a/flextape/server/config.textproto
+++ b/flextape/server/config.textproto
@@ -1,0 +1,167 @@
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "Vivado_System_Edition"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ISE_System_Edition"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "cmac_usplus"
+  }
+  quantity: 9999
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "sdnet_p4"
+  }
+  quantity: 1
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "hcam_base"
+  }
+  quantity: 1
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "tcam_10Mbits"
+  }
+  quantity: 1
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ChipScopePro_SIOTK"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ChipscopePro"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ISE"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "SysGen"
+  }
+  quantity: 6
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "XPS"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "HLS"
+  }
+  quantity: 6
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ISIM"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "PlanAhead"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "SDK"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "PartialReconfiguration"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "Simulation"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "Implementation"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "Analyzer"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "Synthesis"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "ModelComposer"
+  }
+  quantity: 3
+}

--- a/flextape/server/config.textproto
+++ b/flextape/server/config.textproto
@@ -1,3 +1,15 @@
+# TODO(INFRA-164): This is a bogus license for backwards-compatibility with the
+# old annotations, which name the bogus feature "vivado" instead of an actual
+# feature managed by the flexlm server. Once all rules name features below, we
+# should drop this license entry.
+license_configs {
+  license {
+    vendor: "xilinx"
+    feature: "vivado"
+  }
+  quantity: 3
+}
+
 license_configs {
   license {
     vendor: "xilinx"

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -1,16 +1,60 @@
 package main
 
 import (
-	"github.com/enfabrica/enkit/lib/server"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+
 	fpb "github.com/enfabrica/enkit/flextape/proto"
 	"github.com/enfabrica/enkit/flextape/service"
+	"github.com/enfabrica/enkit/lib/server"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
+var (
+	serviceConfig = flag.String("service_config", "", "Path to service configuration textproto")
+)
+
+func exitIf(err error) {
+	if err != nil {
+		// TODO: Use enkit logging libraries
+		log.Fatal(err)
+	}
+}
+
+func checkFlags() error {
+	if *serviceConfig == "" {
+		return fmt.Errorf("--service_config must be provided")
+	}
+	return nil
+}
+
+func loadConfig(path string) (*fpb.Config, error) {
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read config %q: %w", path, err)
+	}
+	var config fpb.Config
+	err = prototext.Unmarshal(contents, &config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse config %q: %w", path, err)
+	}
+	return &config, nil
+}
+
 func main() {
+	// TODO: Use enkit flag libraries
+	flag.Parse()
+	exitIf(checkFlags())
+
+	config, err := loadConfig(*serviceConfig)
+	exitIf(err)
+
 	grpcs := grpc.NewServer()
-	s := service.New()
+	s := service.New(config)
 	fpb.RegisterFlextapeServer(grpcs, s)
 
 	server.Run(nil, grpcs)


### PR DESCRIPTION
This change adds:

* A protobuf config definition, for a config file passed to the server
  on startup
* A flag on the server to provide the config file at runtime
* Server code to parse the config

Jira: INFRA-159