### PR TITLE
gee: restart rebase flow after "picking" as rebase might have succeeded.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1215,7 +1215,11 @@ function _interactive_conflict_resolution() {
                   _die "Rebase command failed, but rebase is not in progress.  Bug!"
                 fi
                 _warn "Rebase operation had merge conflicts."
+              else
+                _info "Rebase succeeded."
               fi
+              RESTART=1
+              DONE=1
             fi
             ;;
           [Ss])


### PR DESCRIPTION
This is a quick fix to a bug I found in the conflict resolution flow.

PR generated by jonathan from branch gee_rebase_pick.

Commits:
*  1f7ba94 gee: restart rebase flow after "picking" as rebase might have succeeded.
