### PR TITLE
Fix flakey e2e test with item comparison

### DIFF
--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -111,7 +111,7 @@ func TestJoinServerAndPoll(t *testing.T) {
 	assert.Equal(t, 2, len(allRecordsRes))
 	assert.Nil(t, s.Stop())
 	assert.Nil(t, lis.Close())
-	assert.Equal(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
+	assert.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
 	time.Sleep(20 * time.Millisecond)
 
 	//Test serialization


### PR DESCRIPTION
changes a assert.Equal to be assert.ElementsMatch, was causing a flakey error when the data is right but in the wrong order