### PR TITLE
cloud build: Add postsubmit

### DIFF
--- a/infra/cloudbuild/postsubmit_bazel.yaml
+++ b/infra/cloudbuild/postsubmit_bazel.yaml
@@ -20,6 +20,8 @@ steps:
     env:
       - "BAZEL_PROFILE=cloudbuild"
 
-timeout: 30m
+timeout: 20m
 options:
-  machineType: E2_MEDIUM
+  # The default of 1 vCPU cannot pull the container, build and test all of enkit
+  # in 1hr
+  machineType: E2_HIGHCPU_8

--- a/infra/cloudbuild/postsubmit_bazel.yaml
+++ b/infra/cloudbuild/postsubmit_bazel.yaml
@@ -1,0 +1,25 @@
+# Bazel Postsubmit Cloud Build
+#
+# This workflow defines a Bazel {build, test} postsubmit flow that ensures that
+# builds in enkit are healthy.
+
+steps:
+  - name: gcr.io/devops-284019/developer:stable
+    entrypoint: /usr/bin/bazelisk
+    args:
+      - build
+      - //...
+    env:
+      - "BAZEL_PROFILE=cloudbuild"
+
+  - name: gcr.io/devops-284019/developer:stable
+    entrypoint: /usr/bin/bazelisk
+    args:
+      - test
+      - //...
+    env:
+      - "BAZEL_PROFILE=cloudbuild"
+
+timeout: 30m
+options:
+  machineType: E2_MEDIUM


### PR DESCRIPTION
This change adds a postsubmit build that builds and tests all bazel
targets in enkit. This will be used to detect bad changes that should
trigger someone to roll back.

Jira: INFRA-189