### PR TITLE
bestie: Add initial skeleton

### DIFF
--- a/bestie/proto/BUILD.bazel
+++ b/bestie/proto/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+# TODO: Make these definitions compatible with what gazelle wants to emit.
+
+# gazelle:ignore
+
+proto_library(
+    name = "hello_proto",
+    srcs = ["hello.proto"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "hello_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/enfabrica/enkit/bestie/proto",
+    protos = [
+        ":hello_proto",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [
+        ":hello_go_proto",
+    ],
+    importpath = "github.com/enfabrica/enkit/bestie/proto",
+    visibility = ["//bestie:__subpackages__"],
+)

--- a/bestie/proto/hello.proto
+++ b/bestie/proto/hello.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package bestie.proto;
+
+option go_package = "github.com/enfabrica/enkit/bestie/proto";
+
+service Greeter {
+  // "Hello-world"-style RPC for testing connectivity
+  rpc Greet(GreetRequest) returns (GreetResponse) {}
+}
+
+message GreetRequest {
+  // Name of entity to greet
+  string name = 1;
+}
+
+message GreetResponse {
+  // Greeting phrase
+  string greeting = 2;
+}

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/bestie/server",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bestie/proto:go_default_library",
+        "//lib/server:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "bestie",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "bestie_tar",
+    srcs = [":bestie"],
+    package_dir = "/enfabrica/bin",
+)
+
+container_image(
+    name = "bestie_image",
+    base = "@golang_base//image",
+    cmd = [
+        "/enfabrica/bin/bestie",
+    ],
+    tars = [
+        ":bestie_tar",
+    ],
+)
+
+container_push(
+    name = "bestie_image_push",
+    format = "Docker",
+    image = ":bestie_image",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/bestie",
+    # TODO: Change this tag to "live"
+    tag = "testing",
+)

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	hpb "github.com/enfabrica/enkit/bestie/proto"
+	"github.com/enfabrica/enkit/lib/server"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+)
+
+type GreeterService struct {
+}
+
+func (s *GreeterService) Greet(ctx context.Context, req *hpb.GreetRequest) (*hpb.GreetResponse, error) {
+	return &hpb.GreetResponse{
+		Greeting: fmt.Sprintf("Hello, %s!", req.GetName()),
+	}, nil
+}
+
+func main() {
+	grpcs := grpc.NewServer()
+	s := &GreeterService{}
+	hpb.RegisterGreeterServer(grpcs, s)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	server.Run(mux, grpcs)
+}


### PR DESCRIPTION
This change adds enough of a gRPC and HTTP application to:
* get something running on Google Cloud Run
* develop Bazel rules to deploy a container to Google Cloud Run

The initial gRPC service is a hello-world type service that is expected
to be deleted quickly; this is simply the quickest path to a working RPC
service for testing Cloud Run.

The binary also exports a /metrics endpoint, which we can use to test
HTTP fetches as a surrogate for an actual UI.

Tested: `bazel run //bestie/server:bestie` and successfully:
* did `grpc_cli` call of `Greet` RPC: `grpc_cli call localhost:6433 bestie.proto.Greeter.Greet 'name: "Scott"'`
* fetched metrics: `curl localhost:6433/metrics`

Jira: INFRA-193