### PR TITLE
lib/token: add support for asymmetric encryption.

### DIFF
--- a/lib/token/BUILD.bazel
+++ b/lib/token/BUILD.bazel
@@ -10,12 +10,16 @@ go_library(
     ],
     importpath = "github.com/enfabrica/enkit/lib/token",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_crypto//nacl/sign:go_default_library"],
+    deps = [
+        "@org_golang_x_crypto//nacl/box:go_default_library",
+        "@org_golang_x_crypto//nacl/sign:go_default_library",
+    ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
+        "asymmetric_test.go",
         "symmetric_test.go",
         "time_test.go",
         "token_test.go",

--- a/lib/token/asymmetric.go
+++ b/lib/token/asymmetric.go
@@ -2,9 +2,11 @@ package token
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 
+	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/sign"
 )
 
@@ -100,4 +102,137 @@ func (t *SigningEncoder) Decode(ctx context.Context, value []byte) (context.Cont
 		return ctx, nil, fmt.Errorf("signature did not match")
 	}
 	return ctx, data, nil
+}
+
+const AsymmetricKeyLength = 32
+
+type AsymmetricKey [AsymmetricKeyLength]byte
+
+func (k *AsymmetricKey) ToByte() *[AsymmetricKeyLength]byte {
+	return (*[AsymmetricKeyLength]byte)(k)
+}
+
+const AsymmetricNonceLength = 24
+
+type AsymmetricNonce [AsymmetricNonceLength]byte
+
+func (n *AsymmetricNonce) ToByte() *[AsymmetricNonceLength]byte {
+	return (*[AsymmetricNonceLength]byte)(n)
+}
+
+func AsymmetricKeyFromSlice(key []byte) (*AsymmetricKey, error) {
+	parsedAsymmetricKey := AsymmetricKey{}
+	if copy(parsedAsymmetricKey[:], key) != AsymmetricKeyLength || len(key) > AsymmetricKeyLength {
+		return nil, fmt.Errorf("invalid key length - must be %d bytes", AsymmetricKeyLength)
+	}
+	return &parsedAsymmetricKey, nil
+}
+
+func AsymmetricKeyFromString(key string) (*AsymmetricKey, error) {
+	return AsymmetricKeyFromSlice([]byte(key))
+}
+
+func AsymmetricKeyFromHex(key string) (*AsymmetricKey, error) {
+	slice, err := hex.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+	return AsymmetricKeyFromSlice(slice)
+}
+
+func AsymmetricNonceFromSlice(nonce []byte) (*AsymmetricNonce, error) {
+	parsedAsymmetricNonce := AsymmetricNonce{}
+	if copy(parsedAsymmetricNonce[:], nonce) != AsymmetricNonceLength || len(nonce) > AsymmetricNonceLength {
+		return nil, fmt.Errorf("invalid nonce length - must be %d bytes", AsymmetricNonceLength)
+	}
+	return &parsedAsymmetricNonce, nil
+}
+
+// AsymmetricEncoder is a BinaryEncoder capable of encrypting data with a public key
+// and decoding it using a public and private key pair.
+//
+// AsymmetricEncoder is based on the naccl library, it is pretty much an interface
+// adapter around the OpenAnonymous and SealAnonymous functions.
+type AsymmetricEncoder struct {
+	rng       *rand.Rand
+	priv, pub *AsymmetricKey
+}
+
+type AsymmetricSetter func(*AsymmetricEncoder) error
+
+func UsePrivateKey(key *AsymmetricKey) AsymmetricSetter {
+	return func(be *AsymmetricEncoder) error {
+		be.priv = key
+		return nil
+	}
+}
+
+func UsePublicKey(key *AsymmetricKey) AsymmetricSetter {
+	return func(be *AsymmetricEncoder) error {
+		be.pub = key
+		return nil
+	}
+}
+
+func UseKeyPair(pub, priv *AsymmetricKey) AsymmetricSetter {
+	return func(be *AsymmetricEncoder) error {
+		if err := UsePublicKey(pub)(be); err != nil {
+			return err
+		}
+		return UsePrivateKey(priv)(be)
+	}
+}
+
+// GenerateAsymmetricKeys generates a public key and private key.
+func GenerateAsymmetricKeys(rng *rand.Rand) (*AsymmetricKey, *AsymmetricKey, error) {
+	pub, priv, err := box.GenerateKey(rng)
+	return (*AsymmetricKey)(pub), (*AsymmetricKey)(priv), err
+}
+
+// Creates a new random public and private key, or return error.
+func WithGeneratedAsymmetricKey() AsymmetricSetter {
+	return func(be *AsymmetricEncoder) error {
+		pub, priv, err := GenerateAsymmetricKeys(be.rng)
+		if err != nil {
+			return err
+		}
+		return UseKeyPair(pub, priv)(be)
+	}
+}
+
+func NewAsymmetricEncoder(rng *rand.Rand, setters ...AsymmetricSetter) (*AsymmetricEncoder, error) {
+	be := &AsymmetricEncoder{rng: rng}
+	for _, setter := range setters {
+		if err := setter(be); err != nil {
+			return nil, err
+		}
+	}
+
+	if be.pub == nil {
+		return nil, fmt.Errorf("a public key MUST always be provided")
+	}
+	return be, nil
+}
+
+func (t *AsymmetricEncoder) Encode(data []byte) ([]byte, error) {
+	return box.SealAnonymous(nil, data, t.pub.ToByte(), t.rng)
+}
+
+func (t *AsymmetricEncoder) Decode(ctx context.Context, ciphertext []byte) (context.Context, []byte, error) {
+	if t.priv == nil {
+		return ctx, nil, fmt.Errorf("a private key MUST be provided to decode the data")
+	}
+	original, ok := box.OpenAnonymous(nil, ciphertext, t.pub.ToByte(), t.priv.ToByte())
+	if !ok {
+		return ctx, nil, fmt.Errorf("error deciphering asymmetric data")
+	}
+	return ctx, original, nil
+}
+
+func (t *AsymmetricEncoder) PrivateKey() *AsymmetricKey {
+	return t.priv
+}
+
+func (t *AsymmetricEncoder) PublicKey() *AsymmetricKey {
+	return t.pub
 }

--- a/lib/token/asymmetric_test.go
+++ b/lib/token/asymmetric_test.go
@@ -1,0 +1,47 @@
+package token
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"testing"
+)
+
+func TestAsymmetricSimple(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	// A public key is mandatory!
+	_, err := NewAsymmetricEncoder(rng)
+	assert.Error(t, err)
+
+	ae, err := NewAsymmetricEncoder(rng, WithGeneratedAsymmetricKey())
+	assert.NoError(t, err)
+
+	text := []byte("When I give food to the poor, they call me a saint. When I ask why the poor have no food, they call me a socialist")
+
+	encoded, err := ae.Encode(text)
+	assert.NoError(t, err)
+	assert.True(t, len(encoded) > len(text))
+
+	_, original, err := ae.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, original, text)
+
+	// Try operations without a private key.
+	a2, err := NewAsymmetricEncoder(rng, UsePublicKey(ae.PublicKey()))
+	assert.NoError(t, err)
+
+	// Decoding should fail.
+	_, original, err = a2.Decode(context.Background(), encoded)
+	assert.Error(t, err)
+
+	// But encoding should succeed.
+	text2 := []byte("Despair is typical of those who do not understand the causes of evil, see no way out, and are incapable of struggle")
+	encoded, err = a2.Encode(text2)
+	assert.NoError(t, err)
+
+	// And can still be decoded with a private key.
+	_, original, err = ae.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, text2, original)
+}


### PR DESCRIPTION
This is adding in yet another encoder to allow encrypting
data using private and public keys.

Some of this code comes from astore, a next step could be
to refactor the internal astore code to use the token library.

Tested: unit test covering the most important part of the library.