### PR TITLE
lib/token: add multi encryption support.

### DIFF
--- a/lib/token/BUILD.bazel
+++ b/lib/token/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "asymmetric.go",
+        "multi.go",
         "symmetric.go",
         "time.go",
         "token.go",
@@ -11,6 +12,7 @@ go_library(
     importpath = "github.com/enfabrica/enkit/lib/token",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/multierror:go_default_library",
         "@org_golang_x_crypto//nacl/box:go_default_library",
         "@org_golang_x_crypto//nacl/sign:go_default_library",
     ],
@@ -20,6 +22,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "asymmetric_test.go",
+        "multi_test.go",
         "symmetric_test.go",
         "time_test.go",
         "token_test.go",

--- a/lib/token/multi.go
+++ b/lib/token/multi.go
@@ -1,0 +1,278 @@
+package token
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/enfabrica/enkit/lib/multierror"
+	"math"
+	"math/rand"
+)
+
+// CryptoFactory is a function capable of creating a new BinaryEncoder.
+//
+// If the supplied key parameter is nil, then a random key should be generated.
+// Returns a BinaryEncoder - used to perform encryption and decryption - the
+// key configured for the encoder (either supplied as a parameter to the function,
+// or generated randomly). In case of error, returns an error.
+//
+// Look at SymmetricCreator for an example. More details in the definition of
+// MultiKeyCryptoEncoder.
+type CryptoFactory func(rng *rand.Rand, key []byte) (BinaryEncoder, []byte, error)
+
+// Allocator is a function capable of creating a buffer to encrypt the data in.
+//
+// This can be used to either store the data in a specific place (eg, mmap) or
+// to avoid multiple allocations in the course of filling the buffer.
+type Allocator func([]byte, BinaryEncoder, []BinaryEncoder) []byte
+
+// MultiKeyCryptoEncoder provides an encoder capable of encrypting data with
+// multiple keys so it can be decrypted by any one of those keys.
+//
+// In literature, this is referred to as a Multi-Recipient Encryption Scheme [1],
+// that can be used to implement arbitrary naive/simple hybrid ciphers [2].
+//
+// Just like GPG or other puplar software, It works by:
+//
+// 1) Generating a random key and encrypting data with this random key.
+//    This is the Data Encryption Key, or DEK.
+//
+// 2) Encrypting this random key multiple times, once per recipient.
+//    Each recipient provides a Key Encryption Key, or KEK.
+//
+// In the implementation here:
+//
+// - data is encrypted with an arbitrary BinaryEncoder, which is instantiated
+//   through a CryptFactory, in charge of generating the key and initializing
+//   the cipher to use. CyrptoFactory generates the DEK.
+//
+// - the DEK is encrypted through one or more keyholders. Keyholders are just
+//   BinaryEncoders, symmetric or asymmetric, capable of encrypting the DEK
+//   with their own KEK.
+//
+// The use of a MultiKeyCryptoEncoder is very very simple. See the test for
+// more examples, but a basic use to encrypt data can look like:
+//
+//     keyholder1, err := NewAsymmetricEncoder(rng, UsePublicKey(recipient1))
+//     ...
+//     keyholder2, err := NewAsymmetricEncoder(rng, UsePublickKey(recipient2))
+//     ...
+//
+//     mke, err := NewMultiKeyCryptoEncoder(
+//                    rng, SymmetricCreator, WithKeyHolder(keyholder1, keyholder2))
+//     ...
+//     encoded, err := mke.Encode(data)
+//
+// While to decrypt the data, a single recipient could use something like:
+//
+//     mke, err := NewMultiKeyCryptoEncoder(
+//                    rng, SymmetricCreator, WithKeyHolder(keyholder1))
+//     ...
+//     _, decoded, err := mke.Decode(context.Background(), encoded)
+//
+// Now:
+//  - SymmetricCreator generates a random 256 bit key, and configures
+//    an AES256-GCM cipher to encrypt/decrypt the data. You can create your
+//    own factory to use any other algorithm.
+//
+//  - Keyholders are just other BinaryEncoders. You can use an AsymmetricEncoder,
+//    a Symmetric one, mix them, or even just store the DEK in cleartext if you
+//    really want to.
+//
+//  - MultiKeyCryptoEncoder is really agnostic to the encoder returned by
+//    the CryptoFactory, or used as keyholder.
+//
+//  - Each call to Encode() results in a new random key (and random nonces)
+//    being computed, and in all keyholders being invoked in turn to encrypt
+//    that key and store the result as part of the Encode()d message.
+//
+//  - If you use a MultiKeyCryptoEncoder to encrypt the data, you MUST use a
+//    MultiKeyCryptoEncoder to decrypt it.
+//
+//  - A MultiKeyCryptoEncoder will be able to decrypt the message as long as it
+//    has at least one keyholder capable of decrypting one of the encrypted keys.
+//
+//  - Authenticated encryption for all (keyholder and data encryption) is
+//    strongly recommended.
+//
+//    The MultiKeyCryptoEncoder stores very little metadata alongside each key
+//    (just the key length). When decrypting, it will try each key in turn
+//    until it finds one that (a) can be decrypted without errors, and (b) can
+//    decrypt the entire message without errors.
+//
+//    If neither the keyholder nor the data encryption uses authenticated
+//    encryption (or is chained with NewChainedEncoder with some form of
+//    MAC/hashing/checksumming), it is likely that a Decode() will result in
+//    garbage, as the operation will succeed even in the presence of invalid
+//    keys (same that would happen with the wrong key and a non-authenticated
+//    scheme).
+//
+//  - The data returned by a MultiKeyCryptoEncoder is neither signed nor
+//    authenticated.  A receiver or MITM could modify the data and make
+//    undetectable changes to the layout by, for example, removing or adding
+//    keys, or corrupting the framing that indicates the lenght of each
+//    stored copy of the key.
+//
+//    If this is undesireable, you can chain the encoder with another signing
+//    or encrypting encoder. But assuming both KEK and DEK are used with an
+//    authenticated encryption scheme risk should be minimal if any (extra
+//    keys will be rejected, corruption in key or data will be detected).
+//
+// [1]: https://www.cc.gatech.edu/~aboldyre/papers/bbks.pdf
+//      https://www.cc.gatech.edu/~aboldyre/papers/bbks.pdf
+// [2]: https://en.wikipedia.org/wiki/Hybrid_cryptosystem
+type MultiKeyCryptoEncoder struct {
+	rng       *rand.Rand
+	allocate  Allocator
+	creator   CryptoFactory
+	keyholder []BinaryEncoder
+}
+
+type MultiKeyCryptoSetter func(*MultiKeyCryptoEncoder) error
+
+func WithKeyHolder(be ...BinaryEncoder) MultiKeyCryptoSetter {
+	return func(mke *MultiKeyCryptoEncoder) error {
+		mke.keyholder = append(mke.keyholder, be...)
+		return nil
+	}
+}
+
+func WithAllocator(allocator Allocator) MultiKeyCryptoSetter {
+	return func(mke *MultiKeyCryptoEncoder) error {
+		mke.allocate = allocator
+		return nil
+	}
+}
+
+var DefaultAllocator Allocator = func(buffer []byte, cipher BinaryEncoder, keyciphers []BinaryEncoder) []byte {
+	// A 256 bit key is 32 bytes, same for a 256 bits nonce.
+	// An authenticated encryption scheme can add X more bytes (16? 32?) of some form of MAC.
+	//
+	// Per key, and per message, we have to store a varint of up to ~8 bytes.
+	// Approximate Key + Nonce + MAC bytes + varint per key stored + Nonce + MAC,
+	// round both numbers to the closest multiple of 32.
+	return make([]byte, 0, len(buffer)+64+96*len(keyciphers))
+}
+
+// NewMultiKeyCryptoEncoder creates a new MultiKeyCryptoEncoder.
+//
+// creator is a function capable of generating a random key and a BinaryEncoder to use
+// to encode the data.
+//
+// With settters, at least one keyholder must be specified.
+func NewMultiKeyCryptoEncoder(rng *rand.Rand, creator CryptoFactory, setters ...MultiKeyCryptoSetter) (*MultiKeyCryptoEncoder, error) {
+	mke := &MultiKeyCryptoEncoder{
+		rng:      rng,
+		allocate: DefaultAllocator,
+		creator:  creator,
+	}
+
+	for _, setter := range setters {
+		if err := setter(mke); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(mke.keyholder) <= 0 {
+		return nil, fmt.Errorf("no key holder specified - at least one keyholder is required")
+	}
+	return mke, nil
+}
+
+// Encode encrypts the data so that it can be decrypted by any one keyholder.
+//
+// Encode invokes the configured CryptoFactory to generate a random key and a BinaryEncoder
+// to encrypt the data. It then invokes each keyholder in turn to encrypt this random key
+// alongside the encrypted message.
+//
+// The returned byte array has the format:
+//   [varint: length of ciphertext][ciphertext]
+//   [varint: length of key encrypted with keyholder[0]][key encrypted with keyholder[0]]
+//   [varint: length of key encrypted with keyholder[1]][key encrypted with keyholder[1]]
+//   [...]
+func (mke *MultiKeyCryptoEncoder) Encode(data []byte) ([]byte, error) {
+	sc, key, err := mke.creator(mke.rng, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := mke.allocate(data, sc, mke.keyholder)
+	lenbuff := make([]byte, binary.MaxVarintLen64)
+	add := func(data []byte) {
+		n := binary.PutUvarint(lenbuff, uint64(len(data)))
+		result = append(result, lenbuff[:n]...)
+		result = append(result, data...)
+	}
+
+	cipherdata, err := sc.Encode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	add(cipherdata)
+	for _, kh := range mke.keyholder {
+		ek, err := kh.Encode(key)
+		if err != nil {
+			return nil, err
+		}
+		add(ek)
+	}
+
+	return result, nil
+}
+
+// Decode decrypts a message created with Encode.
+//
+// Given that the MultiKeyCryptoEncoder used to Decode the message is expected
+// to be initialized with a single key or a small subset of the keys used to
+// encode the message, Decode will simply try to decode each key with each
+// keyholder configured.
+//
+// If it finds one key that can be decoded successfully by one of its keyholders,
+// and this key can decrypt the data without errors, Decode() will return success
+// with the result of the operation.
+func (mke *MultiKeyCryptoEncoder) Decode(ctx context.Context, buffer []byte) (context.Context, []byte, error) {
+	cipherlen, uintlen := binary.Uvarint(buffer)
+	if uintlen <= 0 || cipherlen > math.MaxInt32 || cipherlen <= 0 || (uintlen+int(cipherlen)) > len(buffer) {
+		return ctx, nil, fmt.Errorf("ciphertext: buffer is too small, or not encoded correctly - %d %d", cipherlen, uintlen)
+	}
+
+	ciphertext := buffer[uintlen : uintlen+int(cipherlen)]
+	keybuffer := buffer[uintlen+int(cipherlen):]
+	var errors []error
+	for keyid := 0; len(keybuffer) > 0; keyid += 1 {
+		keylen, uintlen := binary.Uvarint(keybuffer)
+		if uintlen <= 0 || keylen > math.MaxInt32 || keylen <= 0 || (uintlen+int(keylen)) > len(keybuffer) {
+			return ctx, nil, fmt.Errorf("key[%d]: buffer is too small, or not encoded correctly", keyid)
+		}
+		currentkey := keybuffer[uintlen : uintlen+int(keylen)]
+		keybuffer = keybuffer[uintlen+int(keylen):]
+
+		var decodedkey []byte
+		var cleartext []byte
+		var err error
+		for cx, kh := range mke.keyholder {
+			ctx, decodedkey, err = kh.Decode(ctx, currentkey)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("key[%d], cipher[%d]: key cannot be decoded - %w", keyid, cx, err))
+				continue
+			}
+
+			sc, _, err := mke.creator(mke.rng, decodedkey)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("key[%d], cipher[%d]: key cannot be used - %w", keyid, cx, err))
+				continue
+			}
+
+			ctx, cleartext, err = sc.Decode(ctx, ciphertext)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("key[%d], cipher[%d]: key cannot decode ciphertext - %w", keyid, cx, err))
+				continue
+			}
+
+			return ctx, cleartext, nil
+		}
+
+	}
+	return ctx, nil, multierror.NewOr(errors, fmt.Errorf("no valid key could be found"))
+}

--- a/lib/token/multi_test.go
+++ b/lib/token/multi_test.go
@@ -1,0 +1,180 @@
+package token
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var flagIterations = flag.Int("iterations", 10000, "Corrupt iterations")
+
+// Use simple symmetric keyholders.
+func TestMultiSimple(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	// No KeyHolder at all is illegal.
+	mke, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator)
+	assert.Error(t, err)
+	assert.Nil(t, mke)
+
+	// Configure two keyholders. The data will be decodable with any one of the two.
+	k1, err := GenerateSymmetricKey(rng, 0)
+	assert.NoError(t, err)
+	kh1, err := NewSymmetricEncoder(rng, UseSymmetricKey(k1))
+	assert.NoError(t, err)
+	k2, err := GenerateSymmetricKey(rng, 0)
+	assert.NoError(t, err)
+	kh2, err := NewSymmetricEncoder(rng, UseSymmetricKey(k2))
+	assert.NoError(t, err)
+
+	mke, err = NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh1, kh2))
+	assert.NoError(t, err)
+	assert.NotNil(t, mke)
+
+	sentence := []byte("A country that does not know how to read and write is easy to deceive.")
+
+	encoded, err := mke.Encode(sentence)
+	assert.NoError(t, err)
+	assert.NotEqual(t, sentence, encoded)
+	assert.True(t, len(encoded) > len(sentence))
+
+	// Simple decrypt with the same multi key encoder. Should succeed.
+	_, decoded, err := mke.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	// Decrypt with a single key - see that's enough to decrypt the message.
+	// (keyholder recreated from scratch for extra safety)
+	kh3, err := NewSymmetricEncoder(rng, UseSymmetricKey(k1))
+	assert.NoError(t, err)
+	mkd3, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh3))
+	assert.NoError(t, err)
+
+	_, decoded, err = mkd3.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	kh4, err := NewSymmetricEncoder(rng, UseSymmetricKey(k2))
+	assert.NoError(t, err)
+	mkd4, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh4))
+	assert.NoError(t, err)
+
+	_, decoded, err = mkd4.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	// Decrypt with a set of keys, none of which is valid.
+	// (keyholder recreated from scratch for extra safety)
+	ki1, err := GenerateSymmetricKey(rng, 0)
+	assert.NoError(t, err)
+	ki2, err := GenerateSymmetricKey(rng, 0)
+	assert.NoError(t, err)
+
+	kih1, err := NewSymmetricEncoder(rng, UseSymmetricKey(ki1))
+	assert.NoError(t, err)
+	kih2, err := NewSymmetricEncoder(rng, UseSymmetricKey(ki2))
+	assert.NoError(t, err)
+
+	mki, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kih1, kih2))
+	assert.NoError(t, err)
+	assert.NotNil(t, mki)
+
+	_, decoded, err = mki.Decode(context.Background(), encoded)
+	assert.Error(t, err)
+
+	// Corrupt text randomly and see that deciphering fails.
+	// (but first, check that deciphering still works fine)
+	_, decoded, err = mkd3.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	_, decoded, err = mkd4.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	seed := time.Now().UnixNano()
+	t.Run(fmt.Sprintf("seed-%d", seed), func(t *testing.T) {
+		rng = rand.New(rand.NewSource(seed))
+		for i := 0; i < *flagIterations; i++ {
+			offset := rng.Intn(len(encoded))
+			bit := byte(1 << rng.Intn(8))
+
+			t.Run(fmt.Sprintf("%d-offset%d-bit%d", i, offset, bit), func(t *testing.T) {
+				newencoded := append([]byte{}, encoded...)
+				newencoded[offset] ^= bit
+
+				// Depending on the random bit we pick, we may be corrupting:
+				// - the first key - decrypting with the second key will succeed.
+				// - the second key - decrypting with the first key will succeed.
+				// - the text stored - decrypting with any key will succeed.
+				_, _, err3 := mkd3.Decode(context.Background(), newencoded)
+				_, _, err4 := mkd4.Decode(context.Background(), newencoded)
+				assert.True(t, err3 != nil || err4 != nil, "err3: %v, err4: %v", err3, err4)
+			})
+		}
+	})
+}
+
+// Use a mix of keyholders.
+func TestMultiMix(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	// Configure a symmetric encoder. Usable both to encrypt and decrypt.
+	k1, err := GenerateSymmetricKey(rng, 0)
+	assert.NoError(t, err)
+	kh1, err := NewSymmetricEncoder(rng, UseSymmetricKey(k1))
+	assert.NoError(t, err)
+
+	// Configure an asymmetric encoder. Can only be used to encrypt!
+	pub, priv, err := GenerateAsymmetricKeys(rng)
+	assert.NoError(t, err)
+	kh2, err := NewAsymmetricEncoder(rng, UsePublicKey(pub))
+	assert.NoError(t, err)
+
+	mke, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh1, kh2))
+	assert.NoError(t, err)
+	assert.NotNil(t, mke)
+
+	sentence := []byte("Learn what is to be taken seriously and laugh at the rest.")
+
+	encoded, err := mke.Encode(sentence)
+	assert.NoError(t, err)
+	assert.NotEqual(t, sentence, encoded)
+	assert.True(t, len(encoded) > len(sentence))
+
+	// Simple decrypt with the same multi key encoder should succeed,
+	// thanks to the symmetric key.
+	_, decoded, err := mke.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	// Verify the symmetric key.
+	mksym, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh1))
+	assert.NoError(t, err)
+	assert.NotNil(t, mksym)
+	_, decoded, err = mksym.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+
+	// Verify the asymmetric key (should fail, no private key).
+	mkasy, err := NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(kh2))
+	assert.NoError(t, err)
+	assert.NotNil(t, mkasy)
+	_, decoded, err = mkasy.Decode(context.Background(), encoded)
+	assert.Error(t, err)
+
+	// Prepare an asymmetric decipher with both private and public key.
+	khpriv, err := NewAsymmetricEncoder(rng, UsePublicKey(pub), UsePrivateKey(priv))
+	assert.NoError(t, err)
+	mkasy, err = NewMultiKeyCryptoEncoder(rng, SymmetricCreator, WithKeyHolder(khpriv))
+	assert.NoError(t, err)
+	assert.NotNil(t, mkasy)
+	_, decoded, err = mkasy.Decode(context.Background(), encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, sentence, decoded)
+}


### PR DESCRIPTION
Add support to generate tokens that can be decrypted by different
keys.

This is in preparation for future code, but it allows to generate tokens
meant for specific systems to consume them, while issuing a different
key to each such system.

It can also be used to implement schemes where data is stored with
an escrow key alongside a per-user/per-session key, or where data
is encrypted to be sent to different recipients.