### PR TITLE
lib/config/directory: minor bugfix - leaking file descriptor.

### DIFF
--- a/lib/config/directory/homedir.go
+++ b/lib/config/directory/homedir.go
@@ -88,6 +88,7 @@ func (hd *Directory) Write(name string, data []byte) error {
 	if err != nil {
 		return err
 	}
+	tmp.Close()
 
 	if err := ioutil.WriteFile(tmp.Name(), data, 0660); err != nil {
 		os.Remove(tmp.Name())


### PR DESCRIPTION
This PR fixes a minor file descriptor leak homedir Write, where
a tempfile is created, but the corresponding file object is never
closed.

This is generally not impacting, as configs are read/written to
at startup only.

But the config store API effectively provides a key value store,
and this could be used outside initial configuration handling.

Tested: unit tests pass before and after. No real test to detect leaks at this point.