### PR TITLE
lib/token: use config/marshal from TypeEncoder

### DIFF
--- a/lib/config/marshal/BUILD.bazel
+++ b/lib/config/marshal/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -14,4 +14,14 @@ go_library(
         "@com_github_pelletier_go_toml//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "marshal_test.go",
+        "select_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/lib/config/marshal/marshal.go
+++ b/lib/config/marshal/marshal.go
@@ -1,6 +1,8 @@
 package marshal
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"github.com/pelletier/go-toml"
 	"gopkg.in/yaml.v2"
@@ -40,4 +42,25 @@ func (j *YamlEncoder) Unmarshal(data []byte, value interface{}) error {
 }
 func (j *YamlEncoder) Extension() string {
 	return "yaml"
+}
+
+type GobEncoder struct{}
+
+func (g *GobEncoder) Marshal(value interface{}) ([]byte, error) {
+	buffer := bytes.Buffer{}
+	enc := gob.NewEncoder(&buffer)
+	if err := enc.Encode(value); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+func (j *GobEncoder) Unmarshal(data []byte, value interface{}) error {
+	enc := gob.NewDecoder(bytes.NewReader(data))
+	if err := enc.Decode(value); err != nil {
+		return err
+	}
+	return nil
+}
+func (j *GobEncoder) Extension() string {
+	return "gob"
 }

--- a/lib/config/marshal/marshal_test.go
+++ b/lib/config/marshal/marshal_test.go
@@ -1,0 +1,30 @@
+package marshal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestType struct {
+	Name, Surname string
+	Year          int
+}
+
+func TestGobMarshal(t *testing.T) {
+	data := TestType{
+		Name:    "Friedrich",
+		Surname: "Nietzsche",
+		Year:    1844,
+	}
+
+	result, err := Gob.Marshal(data)
+	assert.NoError(t, err)
+	assert.True(t, len(result) > 0)
+
+	var comparison TestType
+	err = Gob.Unmarshal(result, &comparison)
+	assert.NoError(t, err)
+
+	assert.Equal(t, data, comparison)
+}

--- a/lib/config/marshal/select.go
+++ b/lib/config/marshal/select.go
@@ -18,12 +18,15 @@ var Yaml = &YamlEncoder{}
 // Use marshal.Json to encode/decode from Json format.
 var Json = &JsonEncoder{}
 
+// Use marshal.Gob to encode/decode from Gob format.
+var Gob = &GobEncoder{}
+
 // Set of known encoders/decoders, in preference order.
 var Known = []FileMarshaller{
-	Toml, Json, Yaml,
+	Toml, Json, Yaml, Gob,
 }
 
-// Represents a sorted list of marshallers. Lowest indes is the most preferred marshaller.
+// Represents a sorted list of marshallers. Lowest index is the most preferred marshaller.
 type FileMarshallers []FileMarshaller
 
 // ByExtension returns the first FileMarshaller based on the extension of the path provided.

--- a/lib/config/marshal/select_test.go
+++ b/lib/config/marshal/select_test.go
@@ -1,0 +1,32 @@
+package marshal
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalFile(t *testing.T) {
+	data := TestType{
+		Name:    "Friedrich",
+		Surname: "Nietzsche",
+		Year:    1844,
+	}
+	dir, err := ioutil.TempDir("", "test-marshal")
+	assert.NoError(t, err)
+
+	// litmus test: an unknown extension should cause error.
+	err = MarshalFile(filepath.Join(dir, "test.whatever"), data)
+	assert.Error(t, err)
+
+	err = MarshalFile(filepath.Join(dir, "test.gob"), data)
+	assert.NoError(t, err)
+
+	var readback TestType
+	err = UnmarshalFile(filepath.Join(dir, "test.gob"), &readback)
+	assert.NoError(t, err)
+
+	assert.Equal(t, data, readback)
+}

--- a/lib/token/BUILD.bazel
+++ b/lib/token/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/enfabrica/enkit/lib/token",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/config/marshal:go_default_library",
         "//lib/multierror:go_default_library",
         "@org_golang_x_crypto//nacl/box:go_default_library",
         "@org_golang_x_crypto//nacl/sign:go_default_library",

--- a/lib/token/token_test.go
+++ b/lib/token/token_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"context"
+	"github.com/enfabrica/enkit/lib/config/marshal"
 	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
@@ -26,4 +27,32 @@ func TestTypeEncoder(t *testing.T) {
 	_, err = te.Decode(context.Background(), data1, &result)
 	assert.Nil(t, err)
 	assert.Equal(t, "this is a string", result)
+}
+
+func TestTypeEncoderMarshal(t *testing.T) {
+	be := NewBase64UrlEncoder()
+	assert.NotNil(t, be)
+
+	tgob := NewTypeEncoder(be)
+	assert.NotNil(t, tgob)
+
+	tyaml := NewTypeEncoder(be, WithMarshaller(marshal.Yaml))
+	assert.NotNil(t, tyaml)
+
+	data := "When morality comes up against profit, it is seldom that profit loses."
+
+	result1, err := tgob.Encode(data)
+	assert.Nil(t, err)
+	result2, err := tgob.Encode(data)
+	assert.Nil(t, err)
+	result3, err := tyaml.Encode(data)
+
+	// This is just to verify that there is no entropy accidentally added.
+	assert.Equal(t, result1, result2)
+	assert.NotEqual(t, result1, result3)
+
+	var decoded string
+	_, err = tyaml.Decode(context.Background(), result3, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, decoded)
 }


### PR DESCRIPTION
Before this change:
TypeEncoder in lib/token would always use gob encoding, and could
use gob encoding only. While we had support for arbitrary marshallers
in lib/config/marshal, gob was not usable.

In this PR:
- add support for gob encoding in config/marshal, so gob is
  treated just like any other format supported.
- change token.TypeEncoder to use config/marshal. Specifically:
  - it now users marshal.Marshal/marshal.Unmarshal instead of
    hardcoding gob support.
  - it now provides a setter so an arbitrary marshaller can be
    selected.

Additionally:
- add initial tests for config/marshal. Goal for now is to just
  cover the added functionality.
- add tests in token_test.go to cover marshalling/marshalling with
  an arbitrary marshaller passed to type encoder.

Tested: all unit tests in lib/token and lib/config pass.

Note that there is no API change in this PR: all changes are within
the internal implementation of the config/marshal and token/ library.