### PR TITLE
bazel: Add cloud_run rules

### DIFF
--- a/bazel/cloud_run/defs.bzl
+++ b/bazel/cloud_run/defs.bzl
@@ -1,0 +1,72 @@
+"""Cloud Run rules"""
+
+_ACCESS_MODES = [
+    "authenticated",
+    "public",
+]
+
+def _cloud_run_deploy_impl(ctx):
+    if ctx.attr.access not in _ACCESS_MODES:
+        fail("attribute `access` must be one of: {}".format(_ACCESS_MODES))
+    access_flag = "--allow-unauthenticated" if ctx.attr.access == "public" else "--no-allow-unauthenticated"
+
+    http2_flag = "--use-http2" if not ctx.attr.http2_downgrade else "--no-use-http2"
+
+    if ctx.attr.image_version.startswith("sha256:"):
+        image = "{}@{}".format(ctx.attr.image, ctx.attr.image_version)
+    else:
+        image = "{}:{}".format(ctx.attr.image, ctx.attr.image_version)
+
+    run_script = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
+    ctx.actions.write(
+        run_script,
+        """#!/bin/bash
+gcloud \\
+  --project={project} \\
+  run \\
+  deploy \\
+  {service_name} \\
+  --image {image} \\
+  --region {region} \\
+  {access} \\
+  {http2_mode}
+""".format(
+            project = ctx.attr.project,
+            service_name = ctx.attr.service,
+            image = image,
+            region = ctx.attr.region,
+            access = access_flag,
+            http2_mode = http2_flag,
+        ),
+        is_executable = True,
+    )
+    print("cloud_run_deploy!")
+    return DefaultInfo(executable = run_script)
+
+cloud_run_deploy = rule(
+    implementation = _cloud_run_deploy_impl,
+    attrs = {
+        "project": attr.string(
+            mandatory = True,
+        ),
+        "service": attr.string(
+            mandatory = True,
+        ),
+        "image": attr.string(
+            mandatory = True,
+        ),
+        "image_version": attr.string(
+            mandatory = True,
+        ),
+        "region": attr.string(
+            mandatory = True,
+        ),
+        "access": attr.string(
+            default = "authenticated",
+        ),
+        "http2_downgrade": attr.bool(
+            default = False,
+        ),
+    },
+    executable = True,
+)

--- a/bazel/cloud_run/defs.bzl
+++ b/bazel/cloud_run/defs.bzl
@@ -6,10 +6,7 @@ _ACCESS_MODES = [
 ]
 
 def _cloud_run_deploy_impl(ctx):
-    if ctx.attr.access not in _ACCESS_MODES:
-        fail("attribute `access` must be one of: {}".format(_ACCESS_MODES))
     access_flag = "--allow-unauthenticated" if ctx.attr.access == "public" else "--no-allow-unauthenticated"
-
     http2_flag = "--use-http2" if not ctx.attr.http2_downgrade else "--no-use-http2"
 
     if ctx.attr.image_version.startswith("sha256:"):
@@ -40,7 +37,6 @@ gcloud \\
         ),
         is_executable = True,
     )
-    print("cloud_run_deploy!")
     return DefaultInfo(executable = run_script)
 
 cloud_run_deploy = rule(
@@ -48,24 +44,32 @@ cloud_run_deploy = rule(
     attrs = {
         "project": attr.string(
             mandatory = True,
+            doc = "gcloud project to which to deploy Cloud Run service",
         ),
         "service": attr.string(
             mandatory = True,
+            doc = "Name of service to deploy",
         ),
         "image": attr.string(
             mandatory = True,
+            doc = "Repository and image path to Docker image to deploy",
         ),
         "image_version": attr.string(
             mandatory = True,
+            doc = "Image tag or hash to deploy. If a hash, must start with `sha256:`",
         ),
         "region": attr.string(
             mandatory = True,
+            doc = "Region to which to deploy Cloud Run service",
         ),
         "access": attr.string(
             default = "authenticated",
+            values = _ACCESS_MODES,
+            doc = "Defines who can access the service. If set to `public`, anyone can issue gRPC/HTTP requests.",
         ),
         "http2_downgrade": attr.bool(
             default = False,
+            doc = "If true, service will only support HTTP2. If false, gcloud will downgrade HTTP2 to HTTP1.1 in the load balancer before the service.",
         ),
     },
     executable = True,

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("//bazel/cloud_run:defs.bzl", "cloud_run_deploy")
 
 go_library(
     name = "go_default_library",
@@ -12,8 +13,6 @@ go_library(
         "//lib/server:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//codes:go_default_library",
-        "@org_golang_google_grpc//status:go_default_library",
     ],
 )
 
@@ -48,4 +47,14 @@ container_push(
     repository = "devops-284019/infra/bestie",
     # TODO: Change this tag to "live"
     tag = "testing",
+)
+
+cloud_run_deploy(
+    name = "bestie_cloud_run_deploy",
+    access = "public",
+    image = "gcr.io/devops-284019/infra/bestie",
+    image_version = "testing",
+    project = "bestie-builds",
+    region = "us-west1",
+    service = "bestie",
 )

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -29,5 +29,5 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	server.Run(mux, grpcs)
+	server.CloudRun(mux, grpcs)
 }

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
     importpath = "github.com/enfabrica/enkit/flextape/server",
+    visibility = ["//visibility:private"],
     deps = [
         "//flextape/proto:go_default_library",
         "//flextape/service:go_default_library",
@@ -19,6 +20,7 @@ go_library(
 go_binary(
     name = "flextape",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )
 
 pkg_tar(
@@ -36,13 +38,13 @@ pkg_tar(
 container_image(
     name = "flextape_image",
     base = "@golang_base//image",
-    tars = [
-        ":flextape_tar",
-        ":flextape_config_tar",
-    ],
     cmd = [
         "/enfabrica/bin/flextape",
         "--service_config=/enfabrica/config/flextape_config.textproto",
+    ],
+    tars = [
+        ":flextape_tar",
+        ":flextape_config_tar",
     ],
 )
 
@@ -52,7 +54,7 @@ container_push(
     image = ":flextape_image",
     registry = "gcr.io",
     repository = "devops-284019/infra/flextape",
+    stamp = True,
     # TODO: Change this tag to "live"
     tag = "testing",
-    stamp = True,
 )

--- a/lib/server/BUILD.bazel
+++ b/lib/server/BUILD.bazel
@@ -10,5 +10,7 @@ go_library(
         "@com_github_soheilhy_cmux//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",
+        "@org_golang_x_net//http2:go_default_library",
+        "@org_golang_x_net//http2/h2c:go_default_library",
     ],
 )

--- a/lib/server/run.go
+++ b/lib/server/run.go
@@ -78,6 +78,9 @@ func Run(mux *http.ServeMux, grpcs *grpc.Server) {
 // ✗ grpc-web via websockets
 // ✗ HTTP 1.1
 // ✔ HTTP 2.0
+//
+// TODO(INFRA-211): Merge with above Run() function if possible, and add tests
+// that verify the protocol compatibility table above either way.
 func CloudRun(mux http.Handler, grpcs *grpc.Server) {
 	if mux == nil {
 		mux = http.NewServeMux()

--- a/lib/server/run.go
+++ b/lib/server/run.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -15,6 +17,13 @@ import (
 // Run runs the specified HTTP handlers and/or gRPC server on a port specified
 // by the `PORT` environment variable. If no HTTP mux or gRPC server is provided
 // (is nil), one with default routes/services will be started, respectively.
+//
+// Run() starts a server supporting the following protocols:
+//
+// ✔ grpc
+// ✔ grpc-web via websockets
+// ✔ HTTP 1.1
+// ✗ HTTP 2.0 (hijacked by grpc support)
 func Run(mux *http.ServeMux, grpcs *grpc.Server) {
 	if mux == nil {
 		mux = http.NewServeMux()
@@ -55,4 +64,58 @@ func Run(mux *http.ServeMux, grpcs *grpc.Server) {
 	if err := cml.Serve(); err != nil {
 		log.Fatalf("Serve failed with error: %s", err)
 	}
+}
+
+// CloudRun starts an HTTP and gRPC server handling requests for all on the same
+// port, determined by the env var $PORT. If no HTTP mux or gRPC server is
+// provided (is nil), one with default routes/services will be started,
+// respectively.
+//
+// CloudRun() is a helper for servers that run in Google Cloud run, and thus
+// starts a server that supports the following protocols:
+//
+// ✔ grpc
+// ✗ grpc-web via websockets
+// ✗ HTTP 1.1
+// ✔ HTTP 2.0
+func CloudRun(mux http.Handler, grpcs *grpc.Server) {
+	if mux == nil {
+		mux = http.NewServeMux()
+	}
+	if grpcs == nil {
+		grpcs = grpc.NewServer()
+	}
+	reflection.Register(grpcs)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "6433"
+	}
+
+	log.Printf("Opening port %s - will be available at http://127.0.0.1:%s/", port, port)
+	listener, err := net.Listen("tcp", net.JoinHostPort("", port))
+	if err != nil {
+		log.Fatalf("failed to listen: %s", err)
+	}
+
+	mux = grpcHTTP2Mux(mux, grpcs)
+
+	http2s := &http2.Server{}
+	https := &http.Server{
+		Handler: h2c.NewHandler(mux, http2s),
+	}
+
+	if err := https.Serve(listener); err != nil {
+		log.Fatalf("Serve failed with error: %s", err)
+	}
+}
+
+func grpcHTTP2Mux(h http.Handler, grpc http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && r.Header.Get("content-type") == "application/grpc" {
+			grpc.ServeHTTP(w, r)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
This change adds rules to deploy a Docker image to Cloud Run, and
provides an example deployment for bestie.

This change also adds a new common server factory function, since
the current factory doesn't seem to allow normal HTTP2 requests to succeed.
This new server sets up gRPC and HTTP2 but not grpc-web, which is
currently not needed. Ideally they should be coalesced into one method,
which we may be able to do once we understand the nuances of the
various protocols.

Tested:

```
# Built and deployed image
bazel run //bestie/server:bestie_image_push && bazel run //bestie/server:bestie_cloud_run_deploy

# Test grpc request
grpcurl -d '{"name": "scott"}'  bestie-24mnsxopwq-uw.a.run.app:443 bestie.proto.Greeter/Greet
# which returns
{
  "greeting": "Hello, scott!"
}

# Test HTTP2 request
curl --http2-prior-knowledge https://bestie-24mnsxopwq-uw.a.run.app/metrics
# which returns Prometheus metrics page
```

Jira: INFRA-191