### PR TITLE
enproxy: add rules to release docker image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,6 +45,13 @@ load(
 
 container_repositories()
 
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
+
+_go_image_repos()
+
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -44,3 +44,46 @@ go_library(
     importpath = "github.com/enfabrica/enkit/proxy/credentials",
     visibility = ["//visibility:public"],
 )
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+
+container_image(
+    name = "enproxy-base",
+    base = "@go_image_base//image",
+
+    # enproxy needs to cache certificates in a directory so they survive
+    # across restarts.
+    #
+    # This cache is extremely important: "let's encrypt" limits the number
+    # of certificates it issues for a domain in a given week. If we end
+    # up in a restart loop of the proxy without the cache, we'd quickly
+    # exhaust this limit, and won't be able to get new certificates until
+    # the rate limit grants more quota.
+    volumes = ["/cache", "/config"],
+    env = {
+      "HOME": "/cache",
+    },
+)
+
+go_image(
+    name = "enproxy-image",
+    base = ":enproxy-base",
+    binary = ":enproxy",
+    visibility = ["//visibility:public"],
+)
+
+# To release a new version of enproxy, run:
+#   bazelisk run :upload-enproxy-image
+#
+# WARNING: before doing so, make sure you have set all the desired
+# defaults as per instructions in the credentials/ directory.
+container_push(
+    name = "upload-enproxy-image",
+    format = "Docker",
+    image = ":enproxy-image",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/enproxy",
+    tag = "latest",
+    visibility = ["//visibility:public"],
+)

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -70,7 +70,7 @@ go_image(
     name = "enproxy-image",
     base = ":enproxy-base",
     binary = ":enproxy",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 # To release a new version of enproxy, run:


### PR DESCRIPTION
This PR adds a few rules to build a distroless container with enproxy,
and to upload it to gcr.

I realized today that while I had used this rule multiple times in
the past, I had never merged it in.