### PR TITLE
gee: ensure the number of failed checks is always numeric.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2924,7 +2924,7 @@ function gee__pr_check() {
     else
       _info "${CHECKS[@]}"
       # something went wrong.  Is a test pending, or did we get a failure?
-      CHECK_COUNTS=()
+      CHECK_COUNTS=( [fail]=0 )
       local LINE
       for LINE in "${CHECKS[@]}"; do
         local -a FIELDS=()


### PR DESCRIPTION
This PR fixes a corner case where gee was setting the CHECKS_FAILED counter to
a null string instead of zero when "gh pr checks" would fail but no actual
checks failed.

This would occur when running in a branch with a closed PR (the PR has no
changes, and so "gh pr checks" fails as the pr is uncheckable, but no actual
check fails).

PR generated by jonathan from branch gee_errors.

Commits:
*  574dd20 gee: ensure the number of failed checks is always numeric.
