### PR TITLE
gee: fix _confirm_default_no typo

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3007,7 +3007,7 @@ function gee__pr_submit() {
 
   # Presubmit check: Are presubmit checks passing?
   if ! gee__pr_check; then
-    if ! confirm_default_no \
+    if ! _confirm_default_no \
       "Presubmit checks did not succeed.  Proceed anyway? (y/N)  "; then
       _fatal "PR submission aborted."
     fi


### PR DESCRIPTION
Buried in my code, I accidentally called "confirm_default_no" instead of
"_confirm_default_no."

Further evidence that gee needs to be rewritten in golang.

PR generated by jonathan from branch gee_confirm_default_no.

Commits:
*  862196c gee: fix _confirm_default_no typo
*  b6b6e14 gee: add "config enable_meld" option (#350)
