### PR TITLE
gee: validate pr descriptions

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1665,6 +1665,29 @@ function _gh_pr_view() {
   _gh pr view --repo "${UPSTREAM}/${REPO}" "${FROM_BRANCH}"
 }
 
+function _check_pr_description() {
+  local PATH="$1"
+  local -a LINES
+  mapfile -t LINES <"${PATH}"
+  if [[ "${#LINES[@]}" -lt 3 ]]; then
+    _warn "The description must contain at least a title, a blank line, and a body."
+    return 1
+  fi
+  if [[ -z "${LINES[0]}" ]]; then
+    _warn "The first line of the description must be the title."
+    return 1
+  fi
+  if [[ -n "${LINES[1]}" ]]; then
+    _warn "The second line of the description must be blank."
+    return 1
+  fi
+  if [[ -z "${LINES[2]}" ]]; then
+    _warn "The third line must be the beginning of the longer description."
+    return 1
+  fi
+  return 0
+}
+
 ##########################################################################
 # init command
 ##########################################################################
@@ -2919,7 +2942,8 @@ EndOfPrTemplate
   # lines into single blank lines:
   sed -i '/^#/d;/\S/,/^\s*$/!d' "${BODYFILE}"
 
-  # TODO(jonathan): Check that the PR description contains at least two paragraphs.
+  # Check that the PR description looks valid
+  _check_pr_description "${BODYFILE}"
 
   # Parse metadata from PR description.
   local TITLE

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.10"
+readonly VERSION="0.2.11"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee.bats
+++ b/scripts/gee.bats
@@ -65,3 +65,19 @@ setup() {
   printf "got: %q\n" "$output" >&3
   assert_output $'bar\nbum\ncharlie\ndelta\necho'
 }
+
+@test "_check_pr_description checks" {
+  printf "this: is a good title\n\nthis is a body\nmore body\n" > /tmp/goodpr.1
+  printf "this: is a good title\nthis is a body\nmore body\n" > /tmp/badpr.1
+  printf "this: is a good title\n" > /tmp/badpr.2
+  printf "\nthis: is a good title\n\nfoobar\n" > /tmp/badpr.3
+  run _check_pr_description /tmp/goodpr.1
+  assert_success
+  run _check_pr_description /tmp/badpr.1
+  assert_failure
+  run _check_pr_description /tmp/badpr.2
+  assert_failure
+  run _check_pr_description /tmp/badpr.3
+  assert_failure
+}
+


### PR DESCRIPTION
Add _check_pr_description function to examine the user-provided PR description
and make sure that it is at least basically conformant with expectations: a one
line title, a blank line, and then one or more lines of body text.

PR generated by jonathan from branch gee_pr_description2.
Derived from branch gee_pr_description's PR #347.

Commits:
*  db3c4c0 gee: add _check_pr_description function
*  1d5c06a add test for _check_pr_description
