### PR TITLE
flextape: Add Docker deployment script

### DIFF
--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PORT=8000
+
+docker run \
+  -d \
+  -t \
+  -p ${PORT}:${PORT} \
+  -e "PORT=${PORT}" \
+  --name=flextape \
+  --restart="always" \
+  "gcr.io/devops-284019/infra/flextape@sha256:ad2a1035790ff148ad434feee98b3cbb97c2406a48725c80a4d4217078d4213e"


### PR DESCRIPTION
This change contains a script with the Docker command used to bring up
Flextape on build-00. This script can get deleted once flextape is
migrated to the cluster.

Tested: Ran this command on build-00; flextape is currently running.

Jira: INFRA-252