### PR TITLE
Refactor and Test MultiError  

### DIFF
--- a/lib/khttp/workpool/helpers_test.go
+++ b/lib/khttp/workpool/helpers_test.go
@@ -109,7 +109,7 @@ func TestRetry(t *testing.T) {
 	wg.Wait()
 
 	assert.NotNil(t, errs)
-	assert.Equal(t, "Multiple errors:\n  error attempt 1\n  error attempt 2\n  error attempt 3\n  error attempt 4\n  error attempt 5", errs.Error())
+	assert.Equal(t, "error attempt 1\n  error attempt 2\n  error attempt 3\n  error attempt 4\n  error attempt 5", errs.Error())
 	assert.Equal(t, 5, calls)
 	assert.Equal(t, 4, waits) // No wait after the last call, and before the first.
 }

--- a/lib/khttp/workpool/helpers_test.go
+++ b/lib/khttp/workpool/helpers_test.go
@@ -109,7 +109,7 @@ func TestRetry(t *testing.T) {
 	wg.Wait()
 
 	assert.NotNil(t, errs)
-	assert.Equal(t, "error attempt 1\n  error attempt 2\n  error attempt 3\n  error attempt 4\n  error attempt 5", errs.Error())
+	assert.Equal(t, "Multiple errors:\n  error attempt 1\n  error attempt 2\n  error attempt 3\n  error attempt 4\n  error attempt 5", errs.Error())
 	assert.Equal(t, 5, calls)
 	assert.Equal(t, 4, waits) // No wait after the last call, and before the first.
 }

--- a/lib/multierror/BUILD.bazel
+++ b/lib/multierror/BUILD.bazel
@@ -1,8 +1,17 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["multierror.go"],
     importpath = "github.com/enfabrica/enkit/lib/multierror",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["multierror_test.go"],
+    deps = [
+        ":go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/lib/multierror/multierror.go
+++ b/lib/multierror/multierror.go
@@ -87,5 +87,5 @@ func (multi MultiError) Error() string {
 		}
 		messages = append(messages, err.Error())
 	}
-	return strings.Join(messages, Separator)
+	return "Multiple errors:\n  " + strings.Join(messages, Separator)
 }

--- a/lib/multierror/multierror.go
+++ b/lib/multierror/multierror.go
@@ -17,7 +17,6 @@ type MultiError []error
 //		> errors.Is(err, &myTypedErr)
 //
 //
-// This is just a convenience wrapper to ensure that if there is no error,
 // if errs has len() == 0, or all errors are nil, nil is returned.
 // * Capture tracing from fmt.Errorf
 // 		> myTypedErr := errors.New("ssh agent failed to query keyring")
@@ -42,7 +41,6 @@ func Wrap(err ...error) error {
 
 // NewOr creates a MultiError from a list of errors, or returns the fallback error.
 //
-// Just like New, but gurantees that an error is returned. If the list of errors is
 // empty, it will return the supplied error instead.
 func NewOr(errs []error, fallback error) error {
 	if len(errs) == 0 {
@@ -63,27 +61,23 @@ func (multi MultiError) Unwrap() error {
 	if len(multi) == 0 {
 		return nil
 	}
-	return multi[0]
+	return multi[1:]
 }
 
 // As for MultiError returns the first error that can be considered As the specified target.
 func (multi MultiError) As(target interface{}) bool {
-	for _, err := range multi {
-		if errors.As(err, target) {
-			return true
-		}
+	if len(multi) == 0 {
+		return false
 	}
-	return false
+	return errors.As(multi[0], target)
 }
 
 // Is for MultiError returns true if any of the errors listed can be considered of the target type.
 func (multi MultiError) Is(target error) bool {
-	for _, err := range multi {
-		if errors.Is(err, target) {
-			return true
-		}
+	if len(multi) == 0 {
+		return false
 	}
-	return false
+	return errors.Is(multi[0], target)
 }
 
 func (multi MultiError) Error() string {

--- a/lib/multierror/multierror.go
+++ b/lib/multierror/multierror.go
@@ -10,6 +10,7 @@ const Separator = "\n  "
 type MultiError []error
 
 // New creates a MultiError from a list of errors.
+// if errs has len() == 0, or all errors are nil, nil is returned.
 // It has two primary intended uses:
 // * Capture maybe returns of ACID-style transactions or stack tracing.
 // 		> myTypedErr := errors.New("my specific query failed in transaction")
@@ -17,7 +18,6 @@ type MultiError []error
 //		> errors.Is(err, &myTypedErr)
 //
 //
-// if errs has len() == 0, or all errors are nil, nil is returned.
 // * Capture tracing from fmt.Errorf
 // 		> myTypedErr := errors.New("ssh agent failed to query keyring")
 //		> return multierror.Wrap(myTypedErr, fmt.Errorf("mw raw log %v", realAgentErr))
@@ -40,7 +40,6 @@ func Wrap(err ...error) error {
 }
 
 // NewOr creates a MultiError from a list of errors, or returns the fallback error.
-//
 // empty, it will return the supplied error instead.
 func NewOr(errs []error, fallback error) error {
 	if len(errs) == 0 {

--- a/lib/multierror/multierror.go
+++ b/lib/multierror/multierror.go
@@ -5,18 +5,9 @@ import (
 	"strings"
 )
 
-const Seperator = "\n "
+const Separator = "\n  "
 
-type MultiError struct {
-	err1 error
-	err2 error
-}
-
-var (
-	_ error                           = &MultiError{}
-	_ interface{ Unwrap() error }     = &MultiError{}
-	_ interface{ Is(err error) bool } = &MultiError{}
-)
+type MultiError []error
 
 // New creates a MultiError from a list of errors.
 // It has two primary intended uses:
@@ -26,6 +17,8 @@ var (
 //		> errors.Is(err, &myTypedErr)
 //
 //
+// This is just a convenience wrapper to ensure that if there is no error,
+// if errs has len() == 0, or all errors are nil, nil is returned.
 // * Capture tracing from fmt.Errorf
 // 		> myTypedErr := errors.New("ssh agent failed to query keyring")
 //		> return multierror.Wrap(myTypedErr, fmt.Errorf("mw raw log %v", realAgentErr))
@@ -35,18 +28,16 @@ func New(errs []error) error {
 	if len(errs) == 0 {
 		return nil
 	}
-	l := len(errs)
-	if l >= 2 {
-		return &MultiError{err1: errs[0], err2: New(errs[1:])}
-	}
-	if l == 1 {
-		return &MultiError{err1: errs[0], err2: nil}
+	for _, err := range errs {
+		if err != nil {
+			return MultiError(errs)
+		}
 	}
 	return nil
 }
 
-func Wrap(ers ...error) error {
-	return New(ers)
+func Wrap(err ...error) error {
+	return New(err)
 }
 
 // NewOr creates a MultiError from a list of errors, or returns the fallback error.
@@ -57,40 +48,51 @@ func NewOr(errs []error, fallback error) error {
 	if len(errs) == 0 {
 		return fallback
 	}
-	return New(errs)
+	for _, err := range errs {
+		if err != nil {
+			return MultiError(errs)
+		}
+	}
+	return fallback
 }
 
 // Unwrap for MultiError always returns nil, as there is no reasonable way to implement it.
 //
 // Use As and Is methods, or loop over the list directly to access the underlying errors.
-func (multi *MultiError) Unwrap() error {
-	return multi.err2
+func (multi MultiError) Unwrap() error {
+	if len(multi) == 0 {
+		return nil
+	}
+	return multi[0]
 }
 
 // As for MultiError returns the first error that can be considered As the specified target.
 func (multi MultiError) As(target interface{}) bool {
-	if errors.As(multi.err1, target) {
-		return true
+	for _, err := range multi {
+		if errors.As(err, target) {
+			return true
+		}
 	}
-	return errors.As(multi.err2, target)
+	return false
 }
 
 // Is for MultiError returns true if any of the errors listed can be considered of the target type.
 func (multi MultiError) Is(target error) bool {
-	if errors.Is(multi.err1, target) {
-		return true
+	for _, err := range multi {
+		if errors.Is(err, target) {
+			return true
+		}
 	}
-	return errors.Is(multi.err2, target)
+	return false
 }
 
-// Error unwraps a MultError recursively
-func (multi *MultiError) Error() string {
+func (multi MultiError) Error() string {
 	var messages []string
-	if multi.err1 != nil {
-		messages = append(messages, multi.err1.Error())
+	for _, err := range multi {
+		if err == nil {
+			continue
+		}
+		messages = append(messages, err.Error())
 	}
-	if multi.err2 != nil {
-		messages = append(messages, multi.err2.Error())
-	}
-	return strings.Join(messages, Seperator)
+	return strings.Join(messages, Separator)
 }

--- a/lib/multierror/multierror_test.go
+++ b/lib/multierror/multierror_test.go
@@ -37,8 +37,8 @@ func (exist doesNotExist) Error() string {
 
 func TestSanityIsError(t *testing.T) {
 	err := multierror.Wrap(OneErr, ThreeErr, FourErr)
-	assertErrIsAllSubErr(t, err, ThreeErr, FourErr)
-	assertErrIsNotAllSubErr(t, err, TwoErr, FiveErr, SevenErr)
+	assertErrIsSubErr(t, err, ThreeErr, FourErr)
+	assertErrIsNotSubErr(t, err, TwoErr, FiveErr, SevenErr)
 	assertErrContainsAllSubStrings(t, err, ThreeErr, FourErr, OneErr)
 }
 
@@ -70,8 +70,8 @@ func TestSingleNestedMultiErr(t *testing.T) {
 	tErr := &nameError{"TestSingleNestedMultiErr"}
 	subErr := multierror.Wrap(OneErr, FourErr, SevenErr, tErr)
 	err := multierror.Wrap(OneErr, ThreeErr, subErr)
-	assertErrIsAllSubErr(t, err, OneErr, ThreeErr, FourErr, SevenErr)
-	assertErrIsNotAllSubErr(t, err, TwoErr, SixErr)
+	assertErrIsSubErr(t, err, OneErr, ThreeErr, FourErr, SevenErr)
+	assertErrIsNotSubErr(t, err, TwoErr, SixErr)
 	assertErrContainsAllSubStrings(t, err, OneErr, ThreeErr, OneErr, FourErr, SevenErr, tErr)
 	var testNameErr *nameError
 	assert.True(t, errors.As(err, &testNameErr))
@@ -84,13 +84,13 @@ func assertErrContainsAllSubStrings(t *testing.T, primary error, rest ...error) 
 	}
 }
 
-func assertErrIsAllSubErr(t *testing.T, primary error, rest ...error) {
+func assertErrIsSubErr(t *testing.T, primary error, rest ...error) {
 	for _, err := range rest {
 		assert.True(t, errors.Is(primary, err))
 	}
 }
 
-func assertErrIsNotAllSubErr(t *testing.T, primary error, rest ...error) {
+func assertErrIsNotSubErr(t *testing.T, primary error, rest ...error) {
 	for _, err := range rest {
 		assert.False(t, errors.Is(primary, err))
 	}

--- a/lib/multierror/multierror_test.go
+++ b/lib/multierror/multierror_test.go
@@ -27,14 +27,19 @@ func (e nameError) Error() string {
 	return fmt.Sprintf("checkEven: Given number %s is not an even number", e.name)
 }
 
+type doesNotExist struct {
+	Num int
+}
+
+func (exist doesNotExist) Error() string {
+	return "does not exist"
+}
+
 func TestSanityIsError(t *testing.T) {
 	err := multierror.Wrap(OneErr, ThreeErr, FourErr)
-	assert.True(t, errors.Is(err, OneErr))
-	assert.False(t, errors.Is(err, TwoErr))
-	assert.True(t, errors.Is(err, ThreeErr))
-	assert.True(t, errors.Is(err, FourErr))
-	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), FourErr.Error()}
-	assert.Equal(t, strings.Join(realErrStrings, multierror.Separator), err.Error())
+	assertErrIsAllSubErr(t, err, ThreeErr, FourErr)
+	assertErrIsNotAllSubErr(t, err, TwoErr, FiveErr, SevenErr)
+	assertErrContainsAllSubStrings(t, err, ThreeErr, FourErr, OneErr)
 }
 
 func TestSanityAsError(t *testing.T) {
@@ -45,6 +50,8 @@ func TestSanityAsError(t *testing.T) {
 	var tErr1 *nameError
 	assert.True(t, errors.As(err, &tErr1))
 	assert.Equal(t, tErr1.Error(), tErr.Error())
+	var doesNotExistErr *doesNotExist
+	assert.False(t, errors.As(err, &doesNotExistErr))
 }
 
 func TestManyNestedMultiErr(t *testing.T) {
@@ -61,16 +68,30 @@ func TestManyNestedMultiErr(t *testing.T) {
 
 func TestSingleNestedMultiErr(t *testing.T) {
 	tErr := &nameError{"TestSingleNestedMultiErr"}
-	err := multierror.Wrap(OneErr, FourErr, SevenErr, tErr)
-	newErr := multierror.Wrap(OneErr, ThreeErr, err)
-	assert.True(t, errors.Is(newErr, OneErr))
-	assert.False(t, errors.Is(newErr, TwoErr))
-	assert.True(t, errors.Is(newErr, ThreeErr))
-	assert.True(t, errors.Is(newErr, FourErr))
-	assert.True(t, errors.Is(newErr, SevenErr))
-	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), OneErr.Error(), FourErr.Error(), SevenErr.Error(), tErr.Error()}
-	assert.Equal(t, strings.Join(realErrStrings, multierror.Separator), newErr.Error())
+	subErr := multierror.Wrap(OneErr, FourErr, SevenErr, tErr)
+	err := multierror.Wrap(OneErr, ThreeErr, subErr)
+	assertErrIsAllSubErr(t, err, OneErr, ThreeErr, FourErr, SevenErr)
+	assertErrIsNotAllSubErr(t, err, TwoErr, SixErr)
+	assertErrContainsAllSubStrings(t, err, OneErr, ThreeErr, OneErr, FourErr, SevenErr, tErr)
 	var testNameErr *nameError
-	assert.True(t, errors.As(newErr, &testNameErr))
+	assert.True(t, errors.As(err, &testNameErr))
 	assert.Equal(t, testNameErr.Error(), tErr.Error())
+}
+
+func assertErrContainsAllSubStrings(t *testing.T, primary error, rest ...error) {
+	for _, err := range rest {
+		assert.True(t, strings.Contains(primary.Error(), err.Error()))
+	}
+}
+
+func assertErrIsAllSubErr(t *testing.T, primary error, rest ...error) {
+	for _, err := range rest {
+		assert.True(t, errors.Is(primary, err))
+	}
+}
+
+func assertErrIsNotAllSubErr(t *testing.T, primary error, rest ...error) {
+	for _, err := range rest {
+		assert.False(t, errors.Is(primary, err))
+	}
 }

--- a/lib/multierror/multierror_test.go
+++ b/lib/multierror/multierror_test.go
@@ -1,0 +1,76 @@
+package multierror_test
+
+import (
+	"errors"
+	"fmt"
+	"github.com/enfabrica/enkit/lib/multierror"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+var (
+	OneErr   = errors.New("err one")
+	TwoErr   = errors.New("err two")
+	ThreeErr = errors.New("err three")
+	FourErr  = errors.New("err four")
+	FiveErr  = errors.New("err four")
+	SixErr   = errors.New("err four")
+	SevenErr = errors.New("err four")
+)
+
+type nameError struct {
+	name string
+}
+
+func (e nameError) Error() string {
+	return fmt.Sprintf("checkEven: Given number %s is not an even number", e.name)
+}
+
+func TestSanityIsError(t *testing.T) {
+	err := multierror.Wrap(OneErr, ThreeErr, FourErr)
+	assert.True(t, errors.Is(err, OneErr))
+	assert.False(t, errors.Is(err, TwoErr))
+	assert.True(t, errors.Is(err, ThreeErr))
+	assert.True(t, errors.Is(err, FourErr))
+	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), FourErr.Error()}
+	assert.Equal(t, strings.Join(realErrStrings, multierror.Seperator), err.Error())
+}
+
+func TestSanityAsError(t *testing.T) {
+	tErr := &nameError{
+		name: "test 1",
+	}
+	err := multierror.Wrap(tErr)
+	var tErr1 *nameError
+	assert.True(t, errors.As(err, &tErr1))
+	assert.Equal(t, tErr1.Error(), tErr.Error())
+}
+
+func TestManyNestedMultiErr(t *testing.T) {
+	tErr := &nameError{name: "nested many"}
+	m := multierror.Wrap(OneErr, tErr)
+	for i := 0; i < 1000; i++ {
+		m = multierror.Wrap(ThreeErr, FourErr, m)
+	}
+	var testNameErr *nameError
+	assert.True(t, errors.As(m, &testNameErr))
+	assert.Equal(t, testNameErr.Error(), tErr.Error())
+	assert.True(t, errors.Is(m, OneErr))
+}
+
+func TestSingleNestedMultiErr(t *testing.T) {
+	tErr := &nameError{"TestSingleNestedMultiErr"}
+	err := multierror.Wrap(OneErr, FourErr, SevenErr, tErr)
+	newErr := multierror.Wrap(OneErr, ThreeErr, err)
+	assert.True(t, errors.Is(newErr, OneErr))
+	assert.False(t, errors.Is(newErr, TwoErr))
+	assert.True(t, errors.Is(newErr, ThreeErr))
+	assert.True(t, errors.Is(newErr, FourErr))
+	assert.True(t, errors.Is(newErr, SevenErr))
+	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), OneErr.Error(), FourErr.Error(), SevenErr.Error(), tErr.Error()}
+	assert.Equal(t, strings.Join(realErrStrings, multierror.Seperator), newErr.Error())
+	var testNameErr *nameError
+	assert.True(t, errors.As(newErr, &testNameErr))
+	assert.Equal(t, testNameErr.Error(), tErr.Error())
+}

--- a/lib/multierror/multierror_test.go
+++ b/lib/multierror/multierror_test.go
@@ -34,7 +34,7 @@ func TestSanityIsError(t *testing.T) {
 	assert.True(t, errors.Is(err, ThreeErr))
 	assert.True(t, errors.Is(err, FourErr))
 	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), FourErr.Error()}
-	assert.Equal(t, strings.Join(realErrStrings, multierror.Seperator), err.Error())
+	assert.Equal(t, strings.Join(realErrStrings, multierror.Separator), err.Error())
 }
 
 func TestSanityAsError(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSingleNestedMultiErr(t *testing.T) {
 	assert.True(t, errors.Is(newErr, FourErr))
 	assert.True(t, errors.Is(newErr, SevenErr))
 	realErrStrings := []string{OneErr.Error(), ThreeErr.Error(), OneErr.Error(), FourErr.Error(), SevenErr.Error(), tErr.Error()}
-	assert.Equal(t, strings.Join(realErrStrings, multierror.Seperator), newErr.Error())
+	assert.Equal(t, strings.Join(realErrStrings, multierror.Separator), newErr.Error())
 	var testNameErr *nameError
 	assert.True(t, errors.As(newErr, &testNameErr))
 	assert.Equal(t, testNameErr.Error(), tErr.Error())

--- a/lib/multierror/multierror_test.go
+++ b/lib/multierror/multierror_test.go
@@ -42,6 +42,17 @@ func TestSanityIsError(t *testing.T) {
 	assertErrContainsAllSubStrings(t, err, ThreeErr, FourErr, OneErr)
 }
 
+func TestFmtError(t *testing.T) {
+	errs := []error{
+		fmt.Errorf("outer caused by %w", fmt.Errorf("inner caused by %w", OneErr)),
+		fmt.Errorf("outer caused by %w", fmt.Errorf("inner caused by %w", TwoErr)),
+	}
+	err := multierror.New(errs)
+	assert.True(t, errors.Is(err, OneErr))
+	assert.True(t, errors.Is(err, TwoErr))
+	assert.False(t, errors.Is(err, ThreeErr))
+}
+
 func TestSanityAsError(t *testing.T) {
 	tErr := &nameError{
 		name: "test 1",


### PR DESCRIPTION
Current issues with MultiError:

Not tested and according to the source code: 

https://cs.opensource.google/go/go/+/refs/tags/go1.17.4:src/errors/wrap.go;l=90

The Unwrap() function is supposed to be the equivalent of a list.pop(). This is not how multierror currently functions.

Right now, it essentially calls errors.As recursively, and for {} loops all get executed in a single pass recursively. 
With these changes, it follows the intended behaviour. 

Does the following things:

- Tests MultiError
- Updates the docs to specify why the library exists
- Changes Unwrap() to return an error
- Adds in a spread creator
- Cleans up the receiver names to be less generic (linting) 

