### PR TITLE
scripts/gee: add title to merge-commit message, allow edits.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3110,14 +3110,27 @@ function gee__pr_submit() {
   mapfile -t FILES < <( "${GIT}" diff --name-only "${MERGEBASE}"..HEAD )
   _info "PR contains ${#COMMITS[@]} commits, changing ${#FILES[@]} files."
 
-  # Extract the first comment as the commit message.
+  # Extract the title and first comment as the commit message.
   local BODYFILE
   BODYFILE="$(mktemp -t pr.message.XXXXXX.txt)"
-  gh pr view | sed -n '/^--/,$p' | tail +2 >"${BODYFILE}"
-  _info "Commit message will be:"
-  cat "${BODYFILE}"
+  TEMPFILE="$(mktemp -t pr.temp.XXXXXX.txt)"
+  gh pr view > "${TEMPFILE}"
+  grep "^title:" "${TEMPFILE}" | sed 's/title:\s*//' >"${BODYFILE}"
+  echo "" >> "${BODYFILE}"
+  sed -n '/^--/,$p' "${TEMPFILE}" | tail +2 >> "${BODYFILE}"
+  rm "${TEMPFILE}"
 
-  _confirm_or_exit "About to merge.  Confirm? (y/N)  "
+  declare -g RESP=""
+  while /bin/true; do
+    _info "Commit message will be:"
+    cat "${BODYFILE}"
+    _choose_one "About to merge.  Confirm? [y]es,[e]dit,[N]o  " "n"
+    case "${RESP}" in
+      [eE]*) vim "${BODYFILE}"; ;;
+      [nN]*) _fatal  "Aborted."; ;;
+      [yY]*) break; ;;
+    esac
+  done
 
   local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
   if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -3114,7 +3114,7 @@ function gee__pr_submit() {
   local BODYFILE
   BODYFILE="$(mktemp -t pr.message.XXXXXX.txt)"
   TEMPFILE="$(mktemp -t pr.temp.XXXXXX.txt)"
-  gh pr view > "${TEMPFILE}"
+  "${GH}" pr view > "${TEMPFILE}"
   grep "^title:" "${TEMPFILE}" | sed 's/title:\s*//' >"${BODYFILE}"
   echo "" >> "${BODYFILE}"
   sed -n '/^--/,$p' "${TEMPFILE}" | tail +2 >> "${BODYFILE}"
@@ -3126,7 +3126,7 @@ function gee__pr_submit() {
     cat "${BODYFILE}"
     _choose_one "About to merge.  Confirm? [y]es,[e]dit,[N]o  " "n"
     case "${RESP}" in
-      [eE]*) vim "${BODYFILE}"; ;;
+      [eE]*) "${EDITOR:-vim}" "${BODYFILE}"; ;;
       [nN]*) _fatal  "Aborted."; ;;
       [yY]*) break; ;;
     esac

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.13"
+readonly VERSION="0.2.14"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3124,7 +3124,7 @@ function gee__pr_submit() {
   while /bin/true; do
     _info "Commit message will be:"
     cat "${BODYFILE}"
-    _choose_one "About to merge.  Confirm? [y]es,[e]dit,[N]o  " "n"
+    _choose_one "About to merge.  Confirm? [y]es,[e]dit,[N]o  " "yeN" "n"
     case "${RESP}" in
       [eE]*) "${EDITOR:-vim}" "${BODYFILE}"; ;;
       [nN]*) _fatal  "Aborted."; ;;


### PR DESCRIPTION
scripts/gee: add title to merge-commit message, allow edits.

I accidentally omitted the PR title from the squash-merge commit message.
This PR fixes the automatic production of the commit message to include the
PR title as the first line.

I also added an option for the user to edit the commit message at the
last moment before submitting, just in case.

Tested:
- Passes shellcheck.
- Using this version of the tool to submit.

PR generated by jonathan from branch gee_pr_description3.

