### PR TITLE
flextape: Add cadence licenses

### DIFF
--- a/flextape/server/flextape_config.textproto
+++ b/flextape/server/flextape_config.textproto
@@ -177,3 +177,35 @@ license_configs {
   }
   quantity: 3
 }
+
+license_configs {
+  license {
+    vendor: "cadence"
+    feature: "Affirma_sim_analysis_env"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "cadence"
+    feature: "COSLITE_ACCESS"
+  }
+  quantity: 1
+}
+
+license_configs {
+  license {
+    vendor: "cadence"
+    feature: "Integrated_Metrics_Center"
+  }
+  quantity: 3
+}
+
+license_configs {
+  license {
+    vendor: "cadence"
+    feature: "Xcelium_Single_Core"
+  }
+  quantity: 3
+}

--- a/flextape/server/flextape_config.textproto
+++ b/flextape/server/flextape_config.textproto
@@ -178,6 +178,18 @@ license_configs {
   quantity: 3
 }
 
+# TODO(INFRA-164): This is a bogus license for backwards-compatibility with the
+# old annotations, which name the bogus feature "xcelium" instead of an actual
+# feature managed by the flexlm server. Once all rules name features below, we
+# should drop this license entry.
+license_configs {
+  license {
+    vendor: "cadence"
+    feature: "xcelium"
+  }
+  quantity: 3
+}
+
 license_configs {
   license {
     vendor: "cadence"


### PR DESCRIPTION
This change adds cadence licenses for all features that expire in March
2022. Licenses for features that expire soon are skipped.

Jira: INFRA-274