### PR TITLE
proxy/nss/confparse: address problem found by unittest.

### DIFF
--- a/proxy/nss/confparse/confparse.c
+++ b/proxy/nss/confparse/confparse.c
@@ -604,7 +604,12 @@ error_code_e parse_quoted_string(parse_context_t *ctx, char **dest)
 
 	/* Code here can assume that the input is correct. */
 	*dest = malloc(ctx->cursor - start - escapes);
-	for (char *cursor = *dest; start < ctx->cursor - 1; ++start) {
+	for (char *cursor = *dest; ; ++start) {
+		if (start >= ctx->cursor - 1) {
+			*cursor = '\0';
+			break;
+		}
+
 		if (*start == '\\') {
 			*cursor++ = *++start;
 		} else {


### PR DESCRIPTION
Background:
Strings need to end with a \0. Function to unescape strings
did malloc(), but did not add \0 at the end.

This caused confparse_test ParseQuotedString.All to fail at times.
Probably, some good % of the times malloc() was returning zeroed
memory out of pure luck.

In this PR:
- correctly terminate the string before returning it.