### PR TITLE
machinist/testing: fix e2e test.

### DIFF
--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -111,7 +111,7 @@ func TestJoinServerAndPoll(t *testing.T) {
 	assert.Equal(t, 2, len(allRecordsRes))
 	assert.Nil(t, s.Stop())
 	assert.Nil(t, lis.Close())
-	assert.Equal(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
+	assert.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
 	time.Sleep(20 * time.Millisecond)
 
 	//Test serialization


### PR DESCRIPTION
Background:
See https://console.cloud.google.com/cloud-build/builds/3e2fc550-dfef-498b-95cb-11921306d0b5;step=5?project=cloud-build-290921,
test fails every now and then with the message below**.

Running the test with --runs_per_test=100, shows about
60% failure rate. This is not surprising: DNS returns records in random
order by standard, test expects them in an exact order.

In this PR:
- change `Equal()` to `ElementsMatch()`.

After this change, test passes 100% of the times.

[**]

--- FAIL: TestJoinServerAndPoll (0.28s)
    machinist_e2e_test.go:114:
        	Error Trace:	machinist_e2e_test.go:114
        	Error:      	Not equal:
        	            	expected: []string{"10.0.0.4", "10.0.0.1"}
        	            	actual  : []string{"10.0.0.1", "10.0.0.4"}

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]string) (len=2) {
        	            	- (string) (len=8) "10.0.0.4",
        	            	- (string) (len=8) "10.0.0.1"
        	            	+ (string) (len=8) "10.0.0.1",
        	            	+ (string) (len=8) "10.0.0.4"
        	            	 }
        	Test:       	TestJoinServerAndPoll
FAIL