### PR TITLE
flextape: Update image version

### DIFF
--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:ad2a1035790ff148ad434feee98b3cbb97c2406a48725c80a4d4217078d4213e"
+  "gcr.io/devops-284019/infra/flextape@sha256:122c6fba315ebb13bf3fc43c536be08e53a5e9e4d79128eebe2f64fdc22ffea4"


### PR DESCRIPTION
Tested: Deployed to build-00

Metrics for cadence shown in https://monitoring.corp.enfabrica.net/d/uRCWqp27z/flextape?orgId=1:
![image](https://user-images.githubusercontent.com/8988434/145630454-d092aa9f-fd9b-46e5-84a3-b0e342438e81.png)


Jira: INFRA-274