### PR TITLE
flextape: Return queue details in LicensesStatus

### DIFF
--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -161,6 +161,9 @@ message LicenseStats {
   // Flextape. This should be less than or equal to in_use_count.
   uint32 allocated_count = 5;
 
+  // Invocations that are currently allocated this license. These Invocation
+  // messages will not have the `licenses` field set - it is implied from being
+  // contained by this `LicenseStats`. This field is not inherently ordered.
   repeated Invocation allocated_invocations = 7;
 
   // Number of invocations queued for a license, as reported by the
@@ -168,6 +171,10 @@ message LicenseStats {
   // total_license_count.
   uint32 queued_count = 6;
 
+  // Invocations that are currently queued for this license. These Invocation
+  // messages will not have the `licenses` field set - it is implied from being
+  // contained by this `LicenseStats`. This field ordered from next invocation
+  // to be allocated to last invocation to be allocated.
   repeated Invocation queued_invocations = 8;
 }
 

--- a/flextape/proto/flextape.proto
+++ b/flextape/proto/flextape.proto
@@ -161,10 +161,14 @@ message LicenseStats {
   // Flextape. This should be less than or equal to in_use_count.
   uint32 allocated_count = 5;
 
+  repeated Invocation allocated_invocations = 7;
+
   // Number of invocations queued for a license, as reported by the
   // Flextape. If this number is >0, then allocated_count should equal
   // total_license_count.
   uint32 queued_count = 6;
+
+  repeated Invocation queued_invocations = 8;
 }
 
 message Invocation {

--- a/flextape/service/license.go
+++ b/flextape/service/license.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -141,6 +142,15 @@ func (l *license) GetStats() *fpb.LicenseStats {
 	if len(fields) != 2 {
 		fields = []string{"<UNKNOWN>", l.name}
 	}
+	allocated := []*fpb.Invocation{}
+	for _, inv := range l.allocations{
+		allocated = append(allocated, inv.ToProto())
+	}
+	sort.Slice(allocated, func(i, j int) bool { return allocated[i].Id < allocated[j].Id })
+	queued := []*fpb.Invocation{}
+	for _, inv := range l.queue{
+		queued = append(queued, inv.ToProto())
+	}
 	return &fpb.LicenseStats{
 		License: &fpb.License{
 			Vendor:  fields[0],
@@ -149,7 +159,9 @@ func (l *license) GetStats() *fpb.LicenseStats {
 		Timestamp:         timestamppb.New(timeNow()),
 		TotalLicenseCount: uint32(l.totalAvailable),
 		AllocatedCount:    uint32(len(l.allocations)),
+		AllocatedInvocations: allocated,
 		QueuedCount:       uint32(len(l.queue)),
+		QueuedInvocations: queued,
 	}
 }
 

--- a/flextape/service/license.go
+++ b/flextape/service/license.go
@@ -130,7 +130,7 @@ func (l *license) ExpireQueued(expiry time.Time) {
 func (l *license) GetQueued(invID string) (*invocation, uint32) {
 	for i, inv := range l.queue {
 		if inv.ID == invID {
-			return inv, uint32(i+1)
+			return inv, uint32(i + 1)
 		}
 	}
 	return nil, 0
@@ -143,12 +143,12 @@ func (l *license) GetStats() *fpb.LicenseStats {
 		fields = []string{"<UNKNOWN>", l.name}
 	}
 	allocated := []*fpb.Invocation{}
-	for _, inv := range l.allocations{
+	for _, inv := range l.allocations {
 		allocated = append(allocated, inv.ToProto())
 	}
 	sort.Slice(allocated, func(i, j int) bool { return allocated[i].Id < allocated[j].Id })
 	queued := []*fpb.Invocation{}
-	for _, inv := range l.queue{
+	for _, inv := range l.queue {
 		queued = append(queued, inv.ToProto())
 	}
 	return &fpb.LicenseStats{
@@ -156,12 +156,12 @@ func (l *license) GetStats() *fpb.LicenseStats {
 			Vendor:  fields[0],
 			Feature: fields[1],
 		},
-		Timestamp:         timestamppb.New(timeNow()),
-		TotalLicenseCount: uint32(l.totalAvailable),
-		AllocatedCount:    uint32(len(l.allocations)),
+		Timestamp:            timestamppb.New(timeNow()),
+		TotalLicenseCount:    uint32(l.totalAvailable),
+		AllocatedCount:       uint32(len(l.allocations)),
 		AllocatedInvocations: allocated,
-		QueuedCount:       uint32(len(l.queue)),
-		QueuedInvocations: queued,
+		QueuedCount:          uint32(len(l.queue)),
+		QueuedInvocations:    queued,
 	}
 }
 

--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -111,9 +111,9 @@ type invocation struct {
 
 func (i *invocation) ToProto() *fpb.Invocation {
 	return &fpb.Invocation{
-		Owner: i.Owner,
+		Owner:    i.Owner,
 		BuildTag: i.BuildTag,
-		Id: i.ID,
+		Id:       i.ID,
 	}
 }
 

--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -109,6 +109,14 @@ type invocation struct {
 	LastCheckin time.Time // Time the invocation last had its queue position/allocation refreshed.
 }
 
+func (i *invocation) ToProto() *fpb.Invocation {
+	return &fpb.Invocation{
+		Owner: i.Owner,
+		BuildTag: i.BuildTag,
+		Id: i.ID,
+	}
+}
+
 type state int
 
 const (

--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -64,7 +64,6 @@ func licensesFromConfig(config *fpb.Config) map[string]*license {
 			allocations:    map[string]*invocation{},
 		}
 	}
-	fmt.Printf("%+v\n", licenses)
 	return licenses
 }
 

--- a/flextape/service/service_test.go
+++ b/flextape/service/service_test.go
@@ -163,8 +163,8 @@ func TestAllocate(t *testing.T) {
 			want: &fpb.AllocateResponse{
 				ResponseType: &fpb.AllocateResponse_Queued{
 					Queued: &fpb.Queued{
-						InvocationId: "1",
-						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						InvocationId:  "1",
+						NextPollTime:  timestamppb.New(start.Add(5 * time.Second)),
 						QueuePosition: 1,
 					},
 				},
@@ -236,8 +236,8 @@ func TestAllocate(t *testing.T) {
 			want: &fpb.AllocateResponse{
 				ResponseType: &fpb.AllocateResponse_Queued{
 					Queued: &fpb.Queued{
-						InvocationId: "1",
-						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						InvocationId:  "1",
+						NextPollTime:  timestamppb.New(start.Add(5 * time.Second)),
 						QueuePosition: 1,
 					},
 				},
@@ -274,8 +274,8 @@ func TestAllocate(t *testing.T) {
 			want: &fpb.AllocateResponse{
 				ResponseType: &fpb.AllocateResponse_Queued{
 					Queued: &fpb.Queued{
-						InvocationId: "2",
-						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						InvocationId:  "2",
+						NextPollTime:  timestamppb.New(start.Add(5 * time.Second)),
 						QueuePosition: 2,
 					},
 				},
@@ -348,8 +348,8 @@ func TestAllocate(t *testing.T) {
 			want: &fpb.AllocateResponse{
 				ResponseType: &fpb.AllocateResponse_Queued{
 					Queued: &fpb.Queued{
-						InvocationId: "1",
-						NextPollTime: timestamppb.New(start.Add(5 * time.Second)),
+						InvocationId:  "1",
+						NextPollTime:  timestamppb.New(start.Add(5 * time.Second)),
 						QueuePosition: 1,
 					},
 				},
@@ -888,24 +888,24 @@ func TestLicensesStatus(t *testing.T) {
 						QueuedCount:       1,
 						AllocatedInvocations: []*fpb.Invocation{
 							&fpb.Invocation{
-								Id: "5",
-								Owner: "unit_test",
+								Id:       "5",
+								Owner:    "unit_test",
 								BuildTag: "tag_1",
 							},
 							&fpb.Invocation{
-								Id: "8",
-								Owner: "unit_test",
+								Id:       "8",
+								Owner:    "unit_test",
 								BuildTag: "tag_2",
 							},
 						},
 						QueuedInvocations: []*fpb.Invocation{
 							&fpb.Invocation{
-								Id: "9",
-								Owner: "unit_test",
+								Id:       "9",
+								Owner:    "unit_test",
 								BuildTag: "tag_3",
 							},
 						},
-						Timestamp:         timestamppb.New(start),
+						Timestamp: timestamppb.New(start),
 					},
 				},
 			},

--- a/flextape/service/service_test.go
+++ b/flextape/service/service_test.go
@@ -886,6 +886,25 @@ func TestLicensesStatus(t *testing.T) {
 						TotalLicenseCount: 2,
 						AllocatedCount:    2,
 						QueuedCount:       1,
+						AllocatedInvocations: []*fpb.Invocation{
+							&fpb.Invocation{
+								Id: "5",
+								Owner: "unit_test",
+								BuildTag: "tag_1",
+							},
+							&fpb.Invocation{
+								Id: "8",
+								Owner: "unit_test",
+								BuildTag: "tag_2",
+							},
+						},
+						QueuedInvocations: []*fpb.Invocation{
+							&fpb.Invocation{
+								Id: "9",
+								Owner: "unit_test",
+								BuildTag: "tag_3",
+							},
+						},
 						Timestamp:         timestamppb.New(start),
 					},
 				},


### PR DESCRIPTION
This change extends the LicensesStatus RPC to show details on each
invocaition that has been allocated, and each invocation that is queued.
This should help us answer questions about where particular builds are
queued if asked.

Tested: Unit tests, ran server plus clients with

```
for i in $(seq 1 10); do (LICENSE_SERVER_IMPL=flextape bazel-bin/manager/client/client_/client localhost 6433 xilinx vivado sleep 60 &); done
```

and then `LicensesStatus` with:

```
grpc_cli call localhost:6433 flextape.proto.Flextape.LicensesStatus ''
```

and verified that `allocated_invocations` and `queued_invocations` were
filled as expected.

Jira: INFRA-287