### PR TITLE
flextape: Update to pull in LicensesStatus improvements

### DIFF
--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -55,6 +55,5 @@ container_push(
     registry = "gcr.io",
     repository = "devops-284019/infra/flextape",
     stamp = True,
-    # TODO: Change this tag to "live"
-    tag = "testing",
+    tag = "latest",
 )

--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:122c6fba315ebb13bf3fc43c536be08e53a5e9e4d79128eebe2f64fdc22ffea4"
+  "gcr.io/devops-284019/infra/flextape@sha256:cdb12098e1f673f36ee4a82ae48f92f276e9fa18068b1080e0cb887e68a64636"


### PR DESCRIPTION
This change bumps the flextape image hash used, and changes the default
tag used when pushing images from "testing" to "latest".

Tested: Currently running on `build-00`

Jira: INFRA-287