### PR TITLE
gee pr_submit: fix bug that caused gee to fail to rebase child branches.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.11"
+readonly VERSION="0.2.12"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3188,7 +3188,7 @@ function gee__pr_submit() {
   KIDS+=( "${!UNIQUE_KIDS[@]}" )  # get keys of UNIQUE_KIDS
 
   # 1d. Bail early if there are no kids.
-  if [[ "${#K2[@]}" -eq 0 ]]; then
+  if [[ "${#KIDS[@]}" -eq 0 ]]; then
     # Our job is done here.
     return 0
   fi


### PR DESCRIPTION
gee pr_submit: fix bug that caused gee to fail to rebase child branches.

A previous PR reworked the way that gee detects the child branches of a branch
that has been submitted, and rebases them using "rebase --onto" to avoid
unnecessary merge conflicts.  Unfortunately, I introduced a bug causing
gee to check the wrong variable when looking for the list of child branches.

Further evidence of the need for a golang rewrite, but we've already had
plenty of that.

Tested:
Submitted a PR with children and made sure the children got rebased.

PR generated by jonathan from branch gee_whats_up_with_pr_submit.

