### PR TITLE
gee: remove \"git branch --show-current\" calls.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.12"
+readonly VERSION="0.2.13"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3741,7 +3741,7 @@ function gee_prompt_update_git_info() {
   fi
 
   local branch
-  read -r branch < <( git branch --show-current )
+  read -r branch < <( git rev-parse --abbrev-ref HEAD )
   GEE_PROMPT_BRANCH="${branch}"
 
   local mode=""


### PR DESCRIPTION
gee: remove \"git branch --show-current\" calls.

The hw-dev containers only support git version 2.17.1, which does not support
the `git branch --show-current` call.  To maintain backwards compatibility,
those calls have been replace with `git rev-parse  --abbrev-ref HEAD`.

Tested:
* installed patched gee in hw-dev container.
* reloaded gee's bash_setup functions.
* verified that git error messages are gone.

PR generated by jonathan from branch gee_backwards_compat.

