### PR TITLE
flextape: Add server-side HTML UI

### DIFF
--- a/flextape/client/client_test.go
+++ b/flextape/client/client_test.go
@@ -16,9 +16,9 @@ import (
 type fakeClient struct {
 	allocateCallCount int
 	allocateResponses []*fpb.AllocateResponse
-	refreshCallCount int
-	refreshResponses []*fpb.RefreshResponse
-	refreshCancel func()
+	refreshCallCount  int
+	refreshResponses  []*fpb.RefreshResponse
+	refreshCancel     func()
 }
 
 func (c *fakeClient) Allocate(context.Context, *fpb.AllocateRequest, ...grpc.CallOption) (*fpb.AllocateResponse, error) {
@@ -171,17 +171,17 @@ func TestLicenseClientRefresh(t *testing.T) {
 			wantCallCount: 3,
 		},
 		{
-			desc: "propagates error",
+			desc:          "propagates error",
 			wantCallCount: 1,
-			wantErr: "Refresh() failure",
+			wantErr:       "Refresh() failure",
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func (t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			fake := &fakeClient{
 				refreshResponses: tc.refreshResponses,
-				refreshCancel: cancel,
+				refreshCancel:    cancel,
 			}
 			client := &LicenseClient{
 				client: fake,

--- a/flextape/frontend/BUILD.bazel
+++ b/flextape/frontend/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["frontend.go"],
+    importpath = "github.com/enfabrica/enkit/flextape/frontend",
+    visibility = ["//flextape/server:__pkg__"],
+    deps = [
+        "//flextape/proto:go_default_library",
+        "//flextape/service:go_default_library",
+    ],
+)

--- a/flextape/frontend/frontend.go
+++ b/flextape/frontend/frontend.go
@@ -4,21 +4,21 @@
 package frontend
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"bytes"
+	"html/template"
 	"io"
 	"net/http"
-	"html/template"
 
-	"github.com/enfabrica/enkit/flextape/service"
 	fpb "github.com/enfabrica/enkit/flextape/proto"
+	"github.com/enfabrica/enkit/flextape/service"
 )
 
 // Frontend is an HTTP handler for Flextape server-side generated pages.
 type Frontend struct {
 	tmpl *template.Template
-	svc *service.Service
+	svc  *service.Service
 }
 
 // New returns a Frontend that serves templates based on state from the supplied
@@ -26,7 +26,7 @@ type Frontend struct {
 func New(tmpl *template.Template, svc *service.Service) *Frontend {
 	return &Frontend{
 		tmpl: tmpl,
-		svc: svc,
+		svc:  svc,
 	}
 }
 
@@ -54,9 +54,9 @@ func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // said error is non-nil. Returns true if an error was written.
 func checkErr(w http.ResponseWriter, err error) bool {
 	if err != nil {
-	w.WriteHeader(500)
-	fmt.Fprintf(w, "%v\n", err)
-	return true
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "%v\n", err)
+		return true
 	}
 	return false
 }

--- a/flextape/frontend/frontend.go
+++ b/flextape/frontend/frontend.go
@@ -5,7 +5,6 @@ package frontend
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -32,8 +31,7 @@ func New(tmpl *template.Template, svc *service.Service) *Frontend {
 
 // ServeHTTP serves the template for the queue page.
 func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := context.TODO()
-	res, err := f.svc.LicensesStatus(ctx, &fpb.LicensesStatusRequest{})
+	res, err := f.svc.LicensesStatus(r.Context(), &fpb.LicensesStatusRequest{})
 	if checkErr(w, err) {
 		return
 	}

--- a/flextape/frontend/frontend.go
+++ b/flextape/frontend/frontend.go
@@ -1,0 +1,62 @@
+// Package frontend provides some server-side generated HTML for viewing
+// Flextape state. This package is temporary; functionality should be moved to a
+// client-side React UI that calls the backend service directly.
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"bytes"
+	"io"
+	"net/http"
+	"html/template"
+
+	"github.com/enfabrica/enkit/flextape/service"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
+)
+
+// Frontend is an HTTP handler for Flextape server-side generated pages.
+type Frontend struct {
+	tmpl *template.Template
+	svc *service.Service
+}
+
+// New returns a Frontend that serves templates based on state from the supplied
+// service.
+func New(tmpl *template.Template, svc *service.Service) *Frontend {
+	return &Frontend{
+		tmpl: tmpl,
+		svc: svc,
+	}
+}
+
+// ServeHTTP serves the template for the queue page.
+func (f *Frontend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := context.TODO()
+	res, err := f.svc.LicensesStatus(ctx, &fpb.LicensesStatusRequest{})
+	if checkErr(w, err) {
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	err = f.tmpl.Execute(buf, res)
+	if checkErr(w, err) {
+		return
+	}
+	_, err = io.Copy(w, buf)
+	if err != nil {
+		// TODO: do something
+		return
+	}
+}
+
+// checkErr writes an error code and the supplied error to the ResponseWriter if
+// said error is non-nil. Returns true if an error was written.
+func checkErr(w http.ResponseWriter, err error) bool {
+	if err != nil {
+	w.WriteHeader(500)
+	fmt.Fprintf(w, "%v\n", err)
+	return true
+	}
+	return false
+}

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -5,9 +5,11 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    embedsrcs = glob(["templates/*.tmpl"]),
     importpath = "github.com/enfabrica/enkit/flextape/server",
     visibility = ["//visibility:private"],
     deps = [
+        "//flextape/frontend:go_default_library",
         "//flextape/proto:go_default_library",
         "//flextape/service:go_default_library",
         "//lib/server:go_default_library",

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"embed"
 	"flag"
 	"fmt"
+	"html/template"
 	"io/ioutil"
 	"log"
 	"net/http"
 
 	fpb "github.com/enfabrica/enkit/flextape/proto"
 	"github.com/enfabrica/enkit/flextape/service"
+	"github.com/enfabrica/enkit/flextape/frontend"
 	"github.com/enfabrica/enkit/lib/server"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -17,6 +20,8 @@ import (
 )
 
 var (
+	//go:embed templates/*
+	templates embed.FS
 	serviceConfig = flag.String("service_config", "", "Path to service configuration textproto")
 )
 
@@ -55,12 +60,18 @@ func main() {
 	config, err := loadConfig(*serviceConfig)
 	exitIf(err)
 
+	template, err := template.ParseFS(templates, "**/*.tmpl")
+	exitIf(err)
+
 	grpcs := grpc.NewServer()
 	s := service.New(config)
 	fpb.RegisterFlextapeServer(grpcs, s)
 
+	fe := frontend.New(template, s)
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/queue", fe)
 
 	server.Run(mux, grpcs)
 }

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/enfabrica/enkit/flextape/frontend"
 	fpb "github.com/enfabrica/enkit/flextape/proto"
 	"github.com/enfabrica/enkit/flextape/service"
-	"github.com/enfabrica/enkit/flextape/frontend"
 	"github.com/enfabrica/enkit/lib/server"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -21,7 +21,7 @@ import (
 
 var (
 	//go:embed templates/*
-	templates embed.FS
+	templates     embed.FS
 	serviceConfig = flag.String("service_config", "", "Path to service configuration textproto")
 )
 

--- a/flextape/server/templates/queue.go.tmpl
+++ b/flextape/server/templates/queue.go.tmpl
@@ -72,39 +72,32 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
-        <!-- Keep collapsed state on refresh -->
         <script>
-         $(document).ready(function () {
-            // When a group is shown, save it as the active accordion group
-            $("#licenses_accordion").on('shown.bs.collapse', function () {
-                var active = $("#licenses_accordion .show").attr('id');
-                window.localStorage.setItem('activeAccordionGroup', active);
-            });
-            $("#licenses_accordion").on('hidden.bs.collapse', function () {
-                window.localStorage.removeItem('activeAccordionGroup');
-            });
-            var last = window.localStorage.getItem('activeAccordionGroup');
-            if (last != null) {
-                // Remove default collapse settings
-                $("#accordion .panel-collapse").removeClass('show');
-                // Show the account_last visible group
-                $("#" + last).addClass("show");
-            }
+        // Keep scroll position on refresh
+        document.addEventListener("DOMContentLoaded", function(event) { 
             var scrollpos = localStorage.getItem('scrollpos');
             if (scrollpos) window.scrollTo(0, scrollpos);
         });
-        </script>
-
-        <!-- Keep scroll position on refresh -->
-        <script>
-            document.addEventListener("DOMContentLoaded", function(event) { 
-                var scrollpos = localStorage.getItem('scrollpos');
-                if (scrollpos) window.scrollTo(0, scrollpos);
-            });
-
-            window.onbeforeunload = function(e) {
-                localStorage.setItem('scrollpos', window.scrollY);
-            };
+        // Keep collapsed state on refresh
+        $(document).ready(function () {
+           // When a group is shown, save it as the active accordion group
+           $("#licenses_accordion").on('shown.bs.collapse', function () {
+               var active = $("#licenses_accordion .show").attr('id');
+               window.localStorage.setItem('activeAccordionGroup', active);
+           });
+           $("#licenses_accordion").on('hidden.bs.collapse', function () {
+               window.localStorage.removeItem('activeAccordionGroup');
+           });
+           var last = window.localStorage.getItem('activeAccordionGroup');
+           if (last != null) {
+               // Remove default collapse settings
+               $("#accordion .panel-collapse").removeClass('show');
+               // Show the account_last visible group
+               $("#" + last).addClass("show");
+           }
+           var scrollpos = localStorage.getItem('scrollpos');
+           if (scrollpos) window.scrollTo(0, scrollpos);
+        });
         </script>
     </body>
 </html>

--- a/flextape/server/templates/queue.go.tmpl
+++ b/flextape/server/templates/queue.go.tmpl
@@ -1,0 +1,110 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    </head>
+    <body>
+        <h1 class="display-3">Flextape Queues</h1>
+        <div class="accordion" id="licenses_accordion">
+        {{range .GetLicenseStats}}
+            <div class="card">
+                <div class="card-header" id="heading-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}">
+                    <h2 class="mb-0">
+                        <button
+                            class="btn btn-link collapsed"
+                            type="button"
+                            data-toggle="collapse"
+                            data-target="#collapse-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}"
+                            aria-expanded="false"
+                            aria-controls="collapse-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}">
+                            {{.GetLicense.GetVendor}}::{{.GetLicense.GetFeature}}
+                        </button>
+                        <button
+                            class="btn btn-link collapsed float-right"
+                            type="button"
+                            data-toggle="collapse"
+                            data-target="#collapse-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}"
+                            aria-expanded="false"
+                            aria-controls="collapse-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}">
+                            {{len .GetAllocatedInvocations}} reserved; {{len .GetQueuedInvocations}} in queue
+                        </button>
+                    </h2>
+                </div>
+                <div
+                    id="collapse-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}"
+                    class="collapse"
+                    aria-labelledby="heading-{{.GetLicense.GetVendor}}_{{.GetLicense.GetFeature}}"
+                    data-parent="#licenses_accordion">
+                    <div class="card-body">
+                        <h3>Reservations</h3>
+                        <table class="table thead-light">
+                            <tr>
+                                <th>Command ID</th>
+                                <th>User</th>
+                            </tr>
+                            {{range .GetAllocatedInvocations}}
+                            <tr>
+                                <td>{{.GetId}}</td>
+                                <td>{{.GetOwner}}</td>
+                            </tr>
+                            {{end}}
+                        </table>
+                        <h3>Queue</h3>
+                        <table class="table thead-light">
+                            <tr>
+                                <th>Command ID</th>
+                                <th>User</th>
+                            </tr>
+                            {{range .GetQueuedInvocations}}
+                            <tr>
+                                <td>{{.GetId}}</td>
+                                <td>{{.GetOwner}}</td>
+                            </tr>
+                            {{end}}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {{end}}
+        </div>
+
+        <!-- Required for bootstrap -->
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+
+        <!-- Keep collapsed state on refresh -->
+        <script>
+         $(document).ready(function () {
+            // When a group is shown, save it as the active accordion group
+            $("#licenses_accordion").on('shown.bs.collapse', function () {
+                var active = $("#licenses_accordion .show").attr('id');
+                window.localStorage.setItem('activeAccordionGroup', active);
+            });
+            $("#licenses_accordion").on('hidden.bs.collapse', function () {
+                window.localStorage.removeItem('activeAccordionGroup');
+            });
+            var last = window.localStorage.getItem('activeAccordionGroup');
+            if (last != null) {
+                // Remove default collapse settings
+                $("#accordion .panel-collapse").removeClass('show');
+                // Show the account_last visible group
+                $("#" + last).addClass("show");
+            }
+            var scrollpos = localStorage.getItem('scrollpos');
+            if (scrollpos) window.scrollTo(0, scrollpos);
+        });
+        </script>
+
+        <!-- Keep scroll position on refresh -->
+        <script>
+            document.addEventListener("DOMContentLoaded", function(event) { 
+                var scrollpos = localStorage.getItem('scrollpos');
+                if (scrollpos) window.scrollTo(0, scrollpos);
+            });
+
+            window.onbeforeunload = function(e) {
+                localStorage.setItem('scrollpos', window.scrollY);
+            };
+        </script>
+    </body>
+</html>

--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -355,5 +356,19 @@ func (s *Service) LicensesStatus(ctx context.Context, req *fpb.LicensesStatusReq
 	for _, lic := range s.licenses {
 		res.LicenseStats = append(res.LicenseStats, lic.GetStats())
 	}
+	// Sort by vendor, then feature, with two groups: first group has either
+	// allocations or queued invocations, second group has neither.
+	sort.Slice(res.LicenseStats, func(i, j int) bool {
+		aHasEntries := res.LicenseStats[i].GetAllocatedCount() > 0 || res.LicenseStats[i].GetQueuedCount() > 0
+		bHasEntries := res.LicenseStats[j].GetAllocatedCount() > 0 || res.LicenseStats[j].GetQueuedCount() > 0
+		if aHasEntries != bHasEntries {
+			return aHasEntries
+		}
+		licA, licB := res.LicenseStats[i].GetLicense(), res.LicenseStats[j].GetLicense()
+		if licA.GetVendor() == licB.GetVendor() {
+			return licA.GetFeature() < licB.GetFeature()
+		}
+		return licA.GetVendor() < licB.GetVendor()
+	})
 	return res, nil
 }


### PR DESCRIPTION
This change adds a `/queue` route to flextape that returns a page
showing:

* Each license + feature configured
* Current allocations for each, including command ID and owning user
* Current queued invocations for each, including command ID and owning
  user

The page uses Bootstrap from a CDN for formatting and hiding all but a
single selected license/feature combo's details.

Features with no reservations or queued invocations are sorted to the
bottom. The page remembers which panel is uncollapsed and the scroll
position on refresh.

Tested: Ran flextape locally, added load wrapping some `sleep` commands,
and observed `localhost:6433/queue`:
![image](https://user-images.githubusercontent.com/8988434/146456300-eca2e389-6dc5-4b7c-aa7c-bdf8ffceb753.png)


Jira: INFRA-288