### PR TITLE
Machinist Bug Fixes

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -689,8 +689,8 @@ def go_repositories():
     go_repository(
         name = "com_github_golang_protobuf",
         importpath = "github.com/golang/protobuf",
-        sum = "h1:jAbXjIeW2ZSW2AwFxlGTDoc2CjI2XujLkV3ArsZFCvc=",
-        version = "v1.5.1",
+        sum = "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=",
+        version = "v1.5.2",
     )
     go_repository(
         name = "com_github_golang_snappy",
@@ -2296,8 +2296,8 @@ def go_repositories():
     go_repository(
         name = "org_golang_google_protobuf",
         importpath = "google.golang.org/protobuf",
-        sum = "h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=",
-        version = "v1.26.0",
+        sum = "h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=",
+        version = "v1.27.1",
     )
     go_repository(
         name = "org_golang_x_crypto",
@@ -2380,15 +2380,15 @@ def go_repositories():
     )
     go_repository(
         name = "org_golang_x_tools",
-        importpath = "golang.org/x/tools",
-        sum = "h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=",
-        version = "v0.1.0",
         # gazelle spits out ugly warnings for this repo unless certain dirs are
         # omitted: https://github.com/bazelbuild/bazel-gazelle/issues/610
         build_extra_args = [
             "-exclude=**/testdata",
             "-exclude=go/packages/packagestest",
         ],
+        importpath = "golang.org/x/tools",
+        sum = "h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=",
+        version = "v0.1.0",
     )
     go_repository(
         name = "org_golang_x_xerrors",

--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,58 @@
 module github.com/enfabrica/enkit
 
-go 1.14
+go 1.17
+
+require (
+	cloud.google.com/go/datastore v1.1.0
+	cloud.google.com/go/storage v1.10.0
+	github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e
+	github.com/cheggaaa/pb/v3 v3.0.5
+	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/cybozu-go/aptutil v1.4.2-0.20200413001041-3f82d8384481
+	github.com/docker/docker v20.10.3+incompatible
+	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/color v1.10.0
+	github.com/go-git/go-git/v5 v5.1.0
+	github.com/golang/protobuf v1.5.2
+	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.4.2
+	github.com/improbable-eng/grpc-web v0.13.0
+	github.com/kataras/muxie v1.1.1
+	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
+	github.com/mitchellh/mapstructure v1.3.3
+	github.com/pelletier/go-toml v1.8.1
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
+	github.com/prometheus/client_golang v1.11.0
+	github.com/soheilhy/cmux v0.1.4
+	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
+	github.com/tchap/zapext v1.0.0
+	github.com/ulikunitz/xz v0.5.8
+	github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7
+	go.uber.org/zap v1.16.0
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
+	google.golang.org/api v0.30.0
+	google.golang.org/grpc v1.37.0
+	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect
-	cloud.google.com/go/datastore v1.1.0
-	cloud.google.com/go/storage v1.10.0
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 // indirect
-	github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e
-	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/containerd/containerd v1.4.3 // indirect
-	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/cybozu-go/aptutil v1.4.2-0.20200413001041-3f82d8384481
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v20.10.3+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/dustin/go-humanize v1.0.0
-	github.com/fatih/color v1.10.0
 	github.com/fullstorydev/grpcurl v1.8.5 // indirect
-	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-lintpack/lintpack v0.5.2 // indirect
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 // indirect
-	github.com/golang/protobuf v1.5.1
 	github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6 // indirect
 	github.com/golangci/go-tools v0.0.0-20190318055746-e32c54105b7c // indirect
 	github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3 // indirect
@@ -34,51 +62,26 @@ require (
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
-	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/uuid v1.3.0
-	github.com/gorilla/websocket v1.4.2
-	github.com/improbable-eng/grpc-web v0.13.0
-	github.com/kataras/muxie v1.1.1
-	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/klauspost/cpuid v1.2.0 // indirect
 	github.com/miekg/dns v1.1.41 // indirect
-	github.com/mitchellh/mapstructure v1.3.3
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pelletier/go-toml v1.8.1
-	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
 	github.com/prashantv/gostub v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.0 // indirect
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 // indirect
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
-	github.com/soheilhy/cmux v0.1.4
-	github.com/spf13/cobra v1.1.3
-	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.7.0
-	github.com/tchap/zapext v1.0.0
 	github.com/ugorji/go v1.1.4 // indirect
-	github.com/ulikunitz/xz v0.5.8
-	github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7
 	github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77 // indirect
 	go.uber.org/goleak v1.1.10 // indirect
-	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
-	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
-	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 // indirect
-	google.golang.org/api v0.30.0
-	google.golang.org/grpc v1.37.0
-	google.golang.org/protobuf v1.26.0
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 	sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enfabrica/enkit
 
-go 1.17
+go 1.16
 
 require (
 	cloud.google.com/go/datastore v1.1.0

--- a/machinist/example/deployment/docker-compose.yml
+++ b/machinist/example/deployment/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "--dns-port=4455"
       - "--bind-net=0.0.0.0"
       - "--port=4456"
-      - "--domains=hello.loca"
+      - "--domains=changeme.local"
     ports:
       - "4455:4455"
       - "4456:4456"

--- a/machinist/example/deployment/docker-compose.yml
+++ b/machinist/example/deployment/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  controlplane:
+    image: gcr.io/devops-284019/infra/machinist/controlplane:latest
+    command:
+      - "--state=/enfabrica/dns.state.json"
+      - "--dns-port=4455"
+      - "--bind-net=0.0.0.0"
+      - "--port=4456"
+      - "--domains=hello.loca"
+    ports:
+      - "4455:4455"
+      - "4456:4456"
+    volumes:
+      - "/enfabrica:/enfabrica"

--- a/machinist/mserver/BUILD.bazel
+++ b/machinist/mserver/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
         "@com_github_miekg_dns//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )
 

--- a/machinist/mserver/command.go
+++ b/machinist/mserver/command.go
@@ -33,9 +33,12 @@ func NewCommand(bf *client.BaseFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			mController, err := NewController(
+				WithStateFile(cpf.StateFile),
 				WithKDnsFlags(
 					kdns.WithTCPListener(dnsListener),
+					kdns.WithPort(cpf.DnsPort),
 					kdns.WithDomains(cpf.Domains),
 				),
 			)
@@ -61,6 +64,6 @@ func NewCommand(bf *client.BaseFlags) *cobra.Command {
 	c.PersistentFlags().IntVar(&cpf.DnsPort, "dns-port", 5353, "the udp port that the dns will be served on, also note it will also allocate the tcp socket on it as well")
 	c.PersistentFlags().StringSliceVar(&cpf.Domains, "domains", []string{}, "domains that the master ControlPlane will be serving")
 	c.PersistentFlags().StringVar(&cpf.BindNet, "bind-net", "127.0.0.1", "the address to bind the grpc listener to")
-	c.PersistentFlags().StringVar(&cpf.StateFile, "state", "./state.json", "file to write and load state to")
+	c.PersistentFlags().StringVar(&cpf.StateFile, "state", "", "file to write and load state to")
 	return c
 }

--- a/machinist/polling/BUILD.bazel
+++ b/machinist/polling/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "@org_uber_go_atomic//:go_default_library",
     ],
 )

--- a/machinist/polling/register.go
+++ b/machinist/polling/register.go
@@ -29,9 +29,9 @@ func SendRegisterRequests(ctx context.Context, client machinist_rpc.ControllerCl
 			_, err := pollStream.Recv()
 			s, ok := status.FromError(err)
 			if ok {
-				l.Errorf("unable to send register request: %s %s", s.Code(), s.Message())
+				l.Errorf("unable to send register request: %+v", s)
 			} else {
-				l.Errorf("unable to send request, unknown err: %v", err)
+				l.Errorf("unable to send request, unknown err: %w", err)
 			}
 			p, err := client.Poll(ctx)
 			if err != nil {

--- a/machinist/polling/register.go
+++ b/machinist/polling/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/enfabrica/enkit/machinist/config"
 	machinist_rpc "github.com/enfabrica/enkit/machinist/rpc/machinist"
+	"google.golang.org/grpc/status"
 	"time"
 )
 
@@ -25,12 +26,18 @@ func SendRegisterRequests(ctx context.Context, client machinist_rpc.ControllerCl
 	}
 	for {
 		if err := pollStream.Send(registerRequest); err != nil {
-			l.Errorf("unable to send request: %w", err)
+			_, err := pollStream.Recv()
+			s, ok := status.FromError(err)
+			if ok {
+				l.Errorf("unable to send register request: %s %s", s.Code(), s.Message())
+			} else {
+				l.Errorf("unable to send request, unknown err: %v", err)
+			}
 			p, err := client.Poll(ctx)
 			if err != nil {
 				l.Errorf("error %w reconnecting, trying again", err)
 				registerFailCounter.Inc()
-			}else {
+			} else {
 				l.Infof("Successfully reconnected")
 				pollStream = p
 			}

--- a/machinist/state/controlplane.go
+++ b/machinist/state/controlplane.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"fmt"
 	"github.com/enfabrica/enkit/lib/config/marshal"
 	"net"
 	"os"
@@ -23,12 +22,16 @@ type MachineController struct {
 func AddMachine(mc *MachineController, m *Machine) error {
 	mc.Lock()
 	defer mc.Unlock()
-	for _, mm := range mc.Machines {
-		if mm.Name == m.Name {
-			return fmt.Errorf("machinist: named machine %s already exists", m.Name)
+	modifiedInPlace := false
+	for i := range mc.Machines {
+		if mc.Machines[i].Name == m.Name {
+			mc.Machines[i] = m
+			modifiedInPlace = true
 		}
 	}
-	mc.Machines = append(mc.Machines, m)
+	if !modifiedInPlace {
+		mc.Machines = append(mc.Machines, m)
+	}
 	return nil
 }
 

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -111,7 +111,7 @@ func TestJoinServerAndPoll(t *testing.T) {
 	assert.Equal(t, 2, len(allRecordsRes))
 	assert.Nil(t, s.Stop())
 	assert.Nil(t, lis.Close())
-	assert.Equal(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
+	assert.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
 	time.Sleep(20 * time.Millisecond)
 
 	//Test serialization


### PR DESCRIPTION
These are just a collection of bug fixes for machinist that needed to get done for NC/MTV
Problems:
- settting the state file and dns port did nothing to the internal application
- machines would error out if they had the same name instead of updating in place (people wanted this changed)

Solutions:
- state.AddMachine no longer errors if the machine is the same name, updates in place instead
- updates our go.mod and updates the golang-protobuf library a minor version (Note, not protobuf, but the go library bindings)
- Puts the DNS port and the state files from the CLI to the running 
- Fixes a flakey e2e test. 
- Removes random print statements