### PR TITLE
INFRA-351 change lib/server types accepted

### DIFF
--- a/lib/server/run.go
+++ b/lib/server/run.go
@@ -21,7 +21,7 @@ import (
 // ✔ grpc-web via websockets
 // ✔ HTTP 1.1
 // ✗ HTTP 2.0 (hijacked by grpc support)
-func Run(mux *http.ServeMux, grpcs *grpc.Server) {
+func Run(mux http.Handler, grpcs *grpc.Server) {
 	if mux == nil {
 		mux = http.NewServeMux()
 	}


### PR DESCRIPTION
- Problem: lib/server doesn't accept http.Handler, but the concrete type that implements it.
- Solution change it from the concerte http.ServeMux to the interface http.Handler

Tested: bazelisk test //..., no changes all tests are the same. bazelisk build //test/... works now.