### PR TITLE
Change faketree $UID to $(id -u)

### DIFF
--- a/faketree/faketree_test.sh
+++ b/faketree/faketree_test.sh
@@ -12,7 +12,7 @@ test "$?" == 125 || {
   fail "--help should return error status 125"
 }
 
-uid=$($ft -- sh -c 'echo $UID')
+uid=$($ft -- sh -c 'echo $(id -u)')
 test "$?" == 0 || {
   fail "simple shell command failed"
 }
@@ -20,7 +20,7 @@ test "$uid" == "$UID" || {
   fail "uid does not match expected uid - $uid"
 }
 
-uid=$($ft --root -- sh -c 'echo $UID')
+uid=$($ft --root -- sh -c 'echo $(id -u)')
 test "$?" == 0 || {
   fail "starting as root failed"
 }


### PR DESCRIPTION
$UID is a bash feature, not a feature of posix, so the test would fail while using dash. 

This succeeds using dash, changes the way to get user id. 