### PR TITLE
lib/knetwork/echo: small and naive echo server for testing.

### DIFF
--- a/lib/knetwork/echo/BUILD.bazel
+++ b/lib/knetwork/echo/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["echo.go"],
+    testonly = True,
     importpath = "github.com/enfabrica/enkit/lib/knetwork/echo",
     visibility = ["//visibility:public"],
 )

--- a/lib/knetwork/echo/BUILD.bazel
+++ b/lib/knetwork/echo/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["echo.go"],
+    importpath = "github.com/enfabrica/enkit/lib/knetwork/echo",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["echo_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+)

--- a/lib/knetwork/echo/echo.go
+++ b/lib/knetwork/echo/echo.go
@@ -9,6 +9,8 @@
 //
 // This is most useful for testing code that requires a TCP endpoint on
 // the other end.
+//
+// +build !release
 package echo
 
 import (

--- a/lib/knetwork/echo/echo.go
+++ b/lib/knetwork/echo/echo.go
@@ -1,0 +1,66 @@
+// Package echo implements a naive echo server.
+//
+// The echo server opens a port of choice, it spawns a goroutine for every
+// incoming connection, and echos back any data written into it.
+//
+// This is a textbook, naive, implementation of an echo server: no timeouts,
+// no limiting of incoming connections, no facilities to terminate the
+// clients as well as the listening socket on stop.
+//
+// This is most useful for testing code that requires a TCP endpoint on
+// the other end.
+package echo
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+type Echo struct {
+	listener net.Listener
+}
+
+func New(address string) (*Echo, error) {
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Echo{listener: l}, nil
+}
+
+func (e *Echo) Close() error {
+	return e.listener.Close()
+}
+
+func (e *Echo) Address() (*net.TCPAddr, error) {
+	if e.listener == nil {
+		return nil, fmt.Errorf("invalid listener: must be initialized with New()")
+	}
+
+	addr := e.listener.Addr()
+
+	taddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		return nil, fmt.Errorf("internal error: could not convert address to TCPAddr")
+	}
+
+	return taddr, nil
+}
+
+func (e *Echo) Run() error {
+	for {
+		conn, err := e.listener.Accept()
+		if err != nil {
+			return err
+		}
+
+		go e.handleConnection(conn)
+	}
+}
+
+func (e *Echo) handleConnection(conn net.Conn) {
+	defer conn.Close()
+	io.Copy(conn, conn)
+}

--- a/lib/knetwork/echo/echo.go
+++ b/lib/knetwork/echo/echo.go
@@ -1,3 +1,5 @@
+// +build !release
+//
 // Package echo implements a naive echo server.
 //
 // The echo server opens a port of choice, it spawns a goroutine for every
@@ -9,8 +11,6 @@
 //
 // This is most useful for testing code that requires a TCP endpoint on
 // the other end.
-//
-// +build !release
 package echo
 
 import (

--- a/lib/knetwork/echo/echo_test.go
+++ b/lib/knetwork/echo/echo_test.go
@@ -1,0 +1,50 @@
+package echo
+
+import (
+	"bufio"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net"
+	"testing"
+)
+
+func TestEcho(t *testing.T) {
+	e, err := New("127.0.0.1:0")
+	assert.NoError(t, err)
+	assert.NotNil(t, e)
+
+	address, err := e.Address()
+	assert.NoError(t, err)
+	go e.Run()
+	defer e.Close()
+
+	c, err := net.Dial("tcp", address.String())
+	defer c.Close()
+	assert.NoError(t, err)
+
+	// This code is technically incorrect: there is no guarantee
+	// that "statement" will fit in a TCP buffer.
+	//
+	// If the TCP buffer is too small, the WriteString() may block until
+	// some bytes have been consumed by the ReadString(), which will never
+	// happen and cause a deadlock, as the reader and writer are in the
+	// same thread.
+	//
+	// This is however extremely unlikely (impossible?) to happen in
+	// practice as linux defaults to a minimum buffer of a page size
+	// 4kb, and (1) the sentence is significantly smaller than that,
+	// and (2) this is over loopback, with larger buffers and no loss.
+	//
+	// There's also a significant gain in simplicity by not using
+	// multiple goroutines here.
+	statement := "behold of the underminer!\n"
+	for i := 0; i < 100; i++ {
+		l, err := io.WriteString(c, statement)
+		assert.NoError(t, err)
+		assert.Equal(t, len(statement), l)
+
+		rback, err := bufio.NewReader(c).ReadString('\n')
+		assert.NoError(t, err)
+		assert.Equal(t, rback, statement)
+	}
+}


### PR DESCRIPTION
Background:
Verifying that tunnels work as expected requires having a TCP endpoint
we can write to, and read from. This is a common enough pattern that
it's worth having a simple object to use that implements this feature.

This PR:
- implements a very naive TCP echo server. What's written to it gets
  written back.
- over features, I chose simplicity. There's very little code here.
  This also means the implementation is very naive: for example, on
  Close(), it terminates only the listening socket. All other sockets
  will terminate when the client disconnects. Also, no timeouts are
  implemented.