### PR TITLE
lib/khttp/krequest: allow to override the host header.

### DIFF
--- a/lib/khttp/krequest/request.go
+++ b/lib/khttp/krequest/request.go
@@ -70,6 +70,17 @@ func SetHeader(key, value string) Modifier {
 	}
 }
 
+// SetHost overrides the host header in the request.
+//
+// This is useful, for example, when the name to lookup in DNS is
+// different than the name the server is expecting to receive.
+func SetHost(host string) Modifier {
+	return func(r *http.Request) error {
+		r.Host = host
+		return nil
+	}
+}
+
 // SetRawHeaders sets a set of values for a specific header, with no canonicalization.
 //
 // This is the same as SetHeader, except that the name of the header is not


### PR DESCRIPTION
(this is in preparation for follow up PRs)

Background:
When fetching a resource via HTTP, the client needs to know the
IP of the server, and the "name of the server" that will be used
in the "Host:" header to retrieve the server.

Typically, both the IP and Host header are computed from the URL
to retrieve. Eg, "get http://www.google.com/" will resolve www.google.com
to an IP, and add a Host header containing "www.google.com".

The golang libraries default to the same behavior: compute the
Host and IP from the URL to retrieve.

This is a problem in testing, when connecting to a reverse
proxy, or set of load balanced backends, eg, when the IP resolution
does not match the host that needs to be retrieved.

In this PR:
- add the ability to override the host independent of
  the URL to be retrieved.