### PR TITLE
lib/khttp/server.go: allow to start a server without flags.

### DIFF
--- a/lib/khttp/server.go
+++ b/lib/khttp/server.go
@@ -23,10 +23,13 @@ type Flags struct {
 	Cache string
 }
 
+const DefaultPort = 9999
+var DefaultCache = configdir.LocalCache("enkit-certs")
+
 func DefaultFlags() *Flags {
 	return &Flags{
-		HttpPort: 9999,
-		Cache:    configdir.LocalCache("enkit-certs"),
+		HttpPort: DefaultPort,
+		Cache: DefaultCache,
 	}
 }
 
@@ -45,6 +48,13 @@ type Server struct {
 	HttpAddress  string
 	HttpsAddress string
 	CacheDir     string
+}
+
+func DefaultServer() *Server {
+	return &Server{
+		HttpAddress: fmt.Sprintf(":%d", DefaultPort),
+		CacheDir:    DefaultCache,
+	}
 }
 
 func FromFlags(flags *Flags) (*Server, error) {


### PR DESCRIPTION
(in preparation for next PR)

Before this PR: pretty much the only way to start the server
was via defining flags, and creating the object via flags.

In this PR: break down the initialization so it's easy to
create the object without flags.