### PR TITLE
proxy/: refactor for modularity and testing.

### DIFF
--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -8,15 +8,10 @@ go_library(
     deps = [
         ":credentials",
         "//lib/client:go_default_library",
-        "//lib/config/marshal:go_default_library",
-        "//lib/kflags:go_default_library",
         "//lib/kflags/kcobra:go_default_library",
-        "//lib/khttp:go_default_library",
-        "//lib/oauth:go_default_library",
         "//lib/srand:go_default_library",
+        "//proxy/enproxy:go_default_library",
         "//proxy/httpp:go_default_library",
-        "//proxy/nasshp:go_default_library",
-        "//proxy/utils:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/proxy/enproxy/BUILD.bazel
+++ b/proxy/enproxy/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["enproxy.go"],
+    importpath = "github.com/enfabrica/enkit/proxy/enproxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/config/marshal:go_default_library",
+        "//lib/kflags:go_default_library",
+        "//lib/khttp:go_default_library",
+        "//lib/logger:go_default_library",
+        "//lib/oauth:go_default_library",
+        "//proxy/httpp:go_default_library",
+        "//proxy/nasshp:go_default_library",
+        "//proxy/utils:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["enproxy_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//lib/khttp/krequest:go_default_library",
+        "//lib/khttp/ktest:go_default_library",
+        "//lib/khttp/protocol:go_default_library",
+        "//lib/knetwork/echo:go_default_library",
+        "//lib/logger:go_default_library",
+        "//lib/oauth:go_default_library",
+        "//lib/token:go_default_library",
+        "//proxy/httpp:go_default_library",
+        "//proxy/nasshp:go_default_library",
+        "//proxy/ptunnel:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)

--- a/proxy/enproxy/enproxy.go
+++ b/proxy/enproxy/enproxy.go
@@ -1,0 +1,353 @@
+// Package enproxy provides a complete proxy implementation with support
+// for HTTP, HTTP/2, and NASSH, with OAUTH authentication, all in a simple
+// API to use.
+//
+// This package glues together the default go net/http/httputil ReverseProxy
+// packaged in proxy/httpp and the SSH over HTTPs implementation in proxy/nasshp
+// together witha frontend server implemented using net/http, packaged in
+// lib/khttp.
+//
+// The simplest use of this library is via flags:
+//
+//    import (
+//        // Secure random numbers.
+//        "github.com/enfabrica/enkit/lib/srand"
+//        "github.com/enfabrica/enkit/lib/kflags"
+//        "flag"
+//    )
+//
+//    flags := enproxy.DefaultFlags()
+//    flags.Register(&kflags.GoFlagSet{FlagSet: flag.CommandLine})
+//
+//    // Parse flags after registering them!!
+//    flag.Parse()
+//
+//    rng := rand.New(srand.Source)
+//    proxy, err := enproxy.New(rng, enproxy.FromFlags(flags))
+//    if err != nil {
+//      ...
+//    }
+//
+//    proxy.Run()
+//
+// You can, of course, create a proxy manually with the desired options.
+// In that case, you want to use `WithConfig` and other `With.*` modifiers
+// to set all the desired options.
+//
+package enproxy
+
+import (
+	"github.com/enfabrica/enkit/lib/config/marshal"
+	"github.com/enfabrica/enkit/lib/kflags"
+	"github.com/enfabrica/enkit/lib/khttp"
+	"github.com/enfabrica/enkit/lib/logger"
+	"github.com/enfabrica/enkit/lib/oauth"
+	"github.com/enfabrica/enkit/proxy/httpp"
+	"github.com/enfabrica/enkit/proxy/nasshp"
+	"github.com/enfabrica/enkit/proxy/utils"
+	"log"
+	"math/rand"
+	"net/http"
+)
+
+// Config is the content of the proxy configuration file.
+type Config struct {
+	// Which URLs to map to which other URLs.
+	Mapping []httpp.Mapping
+	// Extra domains for which to obtain a certificate.
+	Domains []string
+	// List of allowed tunnels.
+	Tunnels []string
+}
+
+// Warnings represents a list of warnings.
+type Warnings []string
+
+// Add adds a new warning.
+func (w *Warnings) Add(warning string) {
+	(*w) = append(*w, warning)
+}
+
+// Print prints the list of warnings.
+//
+// For example:
+//   warnings.Print(log.Printf)
+// or:
+//   warnings.Print(klogger.Warnf)
+func (w *Warnings) Print(printer logger.Printer) {
+	for _, warn := range *w {
+		printer("%s", warn)
+	}
+}
+
+// Parse verifies and indexes a loaded Config.
+//
+// Returns the parsed whitelist of tunnels allowed, followed by a list of warnings.
+func (config *Config) Parse() (utils.PatternList, Warnings, error) {
+	var warn Warnings
+
+	if len(config.Mapping) <= 0 {
+		return nil, warn, kflags.NewUsageErrorf("config file: has no Mapping(s) defined")
+	}
+	if len(config.Tunnels) <= 0 {
+		warn.Add("config file: empty whitelist for tunnels - no tunnel will be allowed!")
+	}
+	wl, err := utils.NewPatternList(config.Tunnels)
+	if err != nil {
+		return nil, warn, kflags.NewUsageErrorf("config file: illegal patterns specified in tunnels: %s", err)
+	}
+
+	return wl, warn, nil
+}
+
+// Flags represents command line flags necessary to define a proxy.
+type Flags struct {
+	Http  *khttp.Flags
+	Oauth *oauth.RedirectorFlags
+	Nassh *nasshp.Flags
+
+	ConfigContent          []byte
+	ConfigName             string
+	DisabledAuthentication bool
+}
+
+// DefaultFlags returns the default flags.
+//
+// The default is generally a valid, working, one except for mandatory
+// configuration parameters.
+func DefaultFlags() *Flags {
+	fl := &Flags{
+		Http:  khttp.DefaultFlags(),
+		Oauth: oauth.DefaultRedirectorFlags(),
+		Nassh: nasshp.DefaultFlags(),
+	}
+	return fl
+}
+
+// Register register the flags necessary to configure enproxy.
+func (fl *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
+	fl.Http.Register(set, prefix)
+	fl.Oauth.Register(set, prefix)
+	fl.Nassh.Register(set, prefix)
+
+	set.ByteFileVar(&fl.ConfigContent, "config", fl.ConfigName, "Default config file location.", kflags.WithFilename(&fl.ConfigName))
+	set.BoolVar(&fl.DisabledAuthentication, "without-authentication", false, "allow tunneling even without authentication")
+
+	return fl
+}
+
+// Starter is a function capable of starting a web server.
+//
+// Requires providing a logger, an http.Handler (typically some form of mux), and
+// a list of domains for which an https certificate is necessary.
+type Starter func(log logger.Printer, handler http.Handler, domains ...string) error
+
+type Options struct {
+	log     logger.Logger
+	starter Starter
+
+	config Config
+
+	pmods []httpp.Modifier
+	nmods []nasshp.Modifier
+
+	authenticate               oauth.Authenticate
+	withoutNasshAuthentication bool
+}
+
+type Modifier func(opt *Options) error
+type Modifiers []Modifier
+
+func (mods Modifiers) Apply(o *Options) error {
+	for _, m := range mods {
+		if err := m(o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func WithConfig(config Config) Modifier {
+	return func(op *Options) error {
+		op.config = config
+		return nil
+	}
+}
+
+func WithDisabledNasshAuthentication(disabled bool) Modifier {
+	return func(op *Options) error {
+		op.withoutNasshAuthentication = disabled
+		return nil
+	}
+}
+
+func WithAuthenticator(auth oauth.Authenticate) Modifier {
+	return func(op *Options) error {
+		op.authenticate = auth
+		return nil
+	}
+}
+
+func WithHttpStarter(starter Starter) Modifier {
+	return func(op *Options) error {
+		op.starter = starter
+		return nil
+	}
+}
+
+func WithHttpFlags(flags *khttp.Flags) Modifier {
+	return func(op *Options) error {
+		server, err := khttp.FromFlags(flags)
+		if err != nil {
+			return err
+		}
+
+		return WithHttpStarter(server.Run)(op)
+	}
+}
+
+func WithProxyMods(pmods ...httpp.Modifier) Modifier {
+	return func(op *Options) error {
+		op.pmods = append(op.pmods, pmods...)
+		return nil
+	}
+}
+
+func WithNasshpMods(nmods ...nasshp.Modifier) Modifier {
+	return func(op *Options) error {
+		op.nmods = append(op.nmods, nmods...)
+		return nil
+	}
+}
+
+func WithOauthRedirector(rflags *oauth.RedirectorFlags) Modifier {
+	return func(op *Options) error {
+		redirector, err := oauth.NewRedirector(oauth.WithRedirectorFlags(rflags))
+		if err != nil {
+			return err
+		}
+		if err := WithAuthenticator(redirector.Authenticate)(op); err != nil {
+			return err
+		}
+
+		pmods := []httpp.Modifier{
+			httpp.WithStripCookie([]string{redirector.CredentialsCookieName()}),
+		}
+		return WithProxyMods(pmods...)(op)
+	}
+
+}
+
+func WithLogging(logger logger.Logger) Modifier {
+	return func(op *Options) error {
+		op.log = logger
+		return nil
+	}
+}
+
+func FromFlags(flags *Flags) Modifier {
+	return func(op *Options) error {
+		var config Config
+		if err := marshal.UnmarshalDefault(flags.ConfigName, flags.ConfigContent, marshal.Json, &config); err != nil {
+			return kflags.NewUsageError(err)
+		}
+
+		if flags.Oauth.AuthURL != "" && !flags.DisabledAuthentication {
+			if err := WithOauthRedirector(flags.Oauth)(op); err != nil {
+				return err
+			}
+		}
+
+		if err := WithNasshpMods(nasshp.FromFlags(flags.Nassh))(op); err != nil {
+			return err
+		}
+
+		if err := WithHttpFlags(flags.Http)(op); err != nil {
+			return err
+		}
+
+		return WithConfig(config)(op)
+	}
+}
+
+type Enproxy struct {
+	log logger.Logger
+
+	mux     http.Handler
+	domains []string
+	starter Starter
+}
+
+func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
+	op := &Options{
+		log:     &logger.DefaultLogger{Printer: log.Printf},
+		starter: khttp.DefaultServer().Run,
+	}
+	if err := Modifiers(mods).Apply(op); err != nil {
+		return nil, err
+	}
+
+	wl, warns, err := op.config.Parse()
+	if err != nil {
+		return nil, err
+	}
+	warns.Print(op.log.Warnf)
+
+	pmods := []httpp.Modifier{httpp.WithLogging(op.log), httpp.WithAuthenticator(op.authenticate)}
+	hproxy, err := httpp.New(op.config.Mapping, append(pmods, op.pmods...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	dispatcher := http.Handler(hproxy)
+	if op.authenticate == nil && !op.withoutNasshAuthentication {
+		op.log.Warnf("ssh gateway disabled as no authentication was configured")
+	} else {
+		authenticate := op.authenticate
+		if op.withoutNasshAuthentication {
+			op.log.Errorf("Watch out! The proxy is being started without authentication! SSH tunneling will rely entirely on a filmsy whitelist")
+			authenticate = nil
+		}
+
+		nasshp, err := nasshp.New(rng, authenticate, append([]nasshp.Modifier{nasshp.WithFilter(wl.Allow), nasshp.WithLogging(op.log)}, op.nmods...)...)
+		if err != nil {
+			return nil, err
+		}
+
+		// Why is a new mux created? Why not re-use the mux in hproxy? Why the funky logic below with empty host names?
+		//
+		// The httpp package uses the muxie mux by default. This mux can match directly on host name, and is generally
+		// great. Except it mangles the http request objects in such a way that gorilla/websocket fails to upgrade the
+		// connection.
+		//
+		// To work around that issue, we use two muxes:
+		// - one that dispatches based on host name, very simple, does not mangle the http request.
+		//   The goal of this mux is to route connection requests to either the ssh handler, or http proxy handler.
+		// - muxie, used by the proxy, to route all other requests.
+		//
+		// To support the two being configured on the same domain, or default domain, the muxie mux is configured
+		// as a fallback to the ssh mux.
+		mux := http.NewServeMux()
+		nasshp.Register(mux.HandleFunc)
+		mux.Handle("/", hproxy)
+
+		hosts := []khttp.HostDispatch{
+			{Host: nasshp.RelayHost(), Handler: mux},
+		}
+		if nasshp.RelayHost() != "" {
+			hosts = append(hosts, khttp.HostDispatch{Handler: hproxy})
+		}
+
+		handler, err := khttp.NewHostDispatcher(hosts)
+		if err != nil {
+			return nil, err
+		}
+		dispatcher = handler
+	}
+
+	return &Enproxy{log: op.log, mux: dispatcher, domains: append(op.config.Domains, hproxy.Domains...), starter: op.starter}, nil
+}
+
+func (ep *Enproxy) Run() error {
+	return ep.starter(ep.log.Infof, &khttp.Dumper{Real: ep.mux, Log: log.Printf}, ep.domains...)
+}

--- a/proxy/enproxy/enproxy_test.go
+++ b/proxy/enproxy/enproxy_test.go
@@ -1,0 +1,287 @@
+package enproxy
+
+import (
+	"bufio"
+	"github.com/enfabrica/enkit/lib/khttp/krequest"
+	"github.com/enfabrica/enkit/lib/khttp/ktest"
+	"github.com/enfabrica/enkit/lib/khttp/protocol"
+	"github.com/enfabrica/enkit/lib/knetwork/echo"
+	"github.com/enfabrica/enkit/lib/logger"
+	"github.com/enfabrica/enkit/lib/oauth"
+	"github.com/enfabrica/enkit/lib/token"
+	"github.com/enfabrica/enkit/proxy/httpp"
+	"github.com/enfabrica/enkit/proxy/nasshp"
+	"github.com/enfabrica/enkit/proxy/ptunnel"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Deny returns an authenticator that either denies a request, or returns a constant cookie.
+// Every request received is logged in log.
+func Deny(cookie *oauth.CredentialsCookie, urls []string, log *[]string) oauth.Authenticate {
+	return func(w http.ResponseWriter, r *http.Request, rurl *url.URL) (*oauth.CredentialsCookie, error) {
+		uri := *r.URL
+		if uri.Host == "" {
+			uri.Host = r.Host
+		}
+		suri := uri.String()
+
+		if log != nil {
+			(*log) = append(*log, suri)
+		}
+
+		for _, block := range urls {
+			if strings.HasPrefix(suri, block) {
+				http.Error(w, "Not authorized", http.StatusUnauthorized)
+				return nil, nil
+			}
+		}
+
+		return cookie, nil
+	}
+}
+
+// Server creates a Starter capable of binding an unused port and start an http server on it.
+func Server(url *string) Starter {
+	return func(log logger.Printer, handler http.Handler, domains ...string) error {
+		var err error
+		*url, err = ktest.Start(handler)
+		return err
+	}
+}
+
+func TestInvalidConfig(t *testing.T) {
+	var url string
+	rng := rand.New(rand.NewSource(1))
+
+	// Config file without any mappings.
+	ep, err := New(rng, WithHttpStarter(Server(&url)))
+	assert.Regexp(t, "config file.*has no Mapping.*defined", err)
+	assert.Nil(t, ep)
+
+	config := Config{
+		Mapping: []httpp.Mapping{
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test.lan",
+					Path: "/",
+				},
+				To: "toast.lan"},
+		},
+	}
+
+	// One mapping is provided, now authentication is required.
+	ep, err = New(rng, WithHttpStarter(Server(&url)), WithConfig(config))
+	assert.Regexp(t, "error in mapping entry 0", err)
+	assert.Nil(t, ep)
+
+	// Valid, but there is no tunnel configuration nor authentication, it should spew a few warnings.
+	accumulator := logger.NewAccumulator()
+	config.Mapping[0].Auth = httpp.MappingPublic
+	ep, err = New(rng, WithHttpStarter(Server(&url)), WithConfig(config), WithLogging(accumulator))
+	assert.NoError(t, err)
+	assert.NotNil(t, ep)
+
+	events := accumulator.Retrieve()
+	assert.True(t, len(events) >= 5, "%v", events)
+}
+
+func TestSimpleHTTP(t *testing.T) {
+	// Create a few http servers to use as backends.
+	s1, err := ktest.Start(http.HandlerFunc(ktest.StringHandler("s1")))
+	assert.Nil(t, err)
+	s2, err := ktest.Start(http.HandlerFunc(ktest.StringHandler("s2")))
+	assert.Nil(t, err)
+	s3, err := ktest.Start(http.HandlerFunc(ktest.StringHandler("s3")))
+	assert.Nil(t, err)
+	s4, err := ktest.Start(http.HandlerFunc(ktest.StringHandler("s4")))
+	assert.Nil(t, err)
+
+	// Frontend proxy config.
+	config := Config{
+		Mapping: []httpp.Mapping{
+			// A single file path on this host.
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test1.lan",
+					Path: "/glad",
+				},
+				Auth: httpp.MappingPublic,
+				To:   s1,
+			},
+
+			// Multiple overlapping paths on test2.
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test2.lan",
+					Path: "/",
+				},
+				Auth: httpp.MappingPublic,
+				To:   s2,
+			},
+
+			// ... this one is private (but a directory).
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test2.lan",
+					Path: "/oppose/",
+				},
+				To: s3,
+			},
+
+			// ... this one is also private - but access will be denied.
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test2.lan",
+					Path: "/deny/",
+				},
+				To: s3,
+			},
+
+			// ... this one is a prefix of /oppose and public.
+			httpp.Mapping{
+				From: httpp.HostPath{
+					Host: "test2.lan",
+					Path: "/opp/",
+				},
+				Auth: httpp.MappingPublic,
+				To:   s4,
+			},
+
+			// No wildcard match for now.
+		},
+
+		// Allow any tunnel.
+		Tunnels: []string{"*"},
+	}
+
+	cookie := &oauth.CredentialsCookie{
+		Identity: oauth.Identity{
+			Id:           "id",
+			Username:     "username",
+			Organization: "organization",
+		},
+	}
+
+	var fe string
+	rng := rand.New(rand.NewSource(1))
+
+	accessLog := []string{}
+	accumulator := logger.NewAccumulator()
+	ep, err := New(rng, WithHttpStarter(Server(&fe)), WithConfig(config),
+		WithLogging(accumulator), WithAuthenticator(Deny(cookie, []string{"//test2.lan/deny"}, &accessLog)),
+		WithNasshpMods(nasshp.WithSymmetricOptions(token.WithGeneratedSymmetricKey(0))))
+	assert.NoError(t, err)
+	assert.NotNil(t, ep)
+
+	ep.Run()
+
+	var herr *protocol.HTTPError
+	body := ""
+
+	// The root fe for test1.lan is not mapped anywhere, should return an error.
+	err = protocol.Get(fe, protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test1.lan")))
+	assert.ErrorAs(t, err, &herr)
+	assert.Equal(t, http.StatusNotFound, herr.Resp.StatusCode)
+
+	// /glad for test1.lan is mapped to s1, let's check that.
+	err = protocol.Get(fe+"glad", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test1.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s1", body)
+	// /glad should be an exact match, so /gladder should not match.
+	err = protocol.Get(fe+"gladder", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test1.lan")))
+	assert.ErrorAs(t, err, &herr)
+	assert.Equal(t, http.StatusNotFound, herr.Resp.StatusCode)
+	// /glad/glod should also not work, as /glad was not configured as a path prefix (not /glad/).
+	err = protocol.Get(fe+"glad/glod", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test1.lan")))
+	assert.ErrorAs(t, err, &herr)
+	assert.Equal(t, http.StatusNotFound, herr.Resp.StatusCode)
+
+	// Let's try a single request to test2.lan root.
+	err = protocol.Get(fe, protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s2", body)
+	// test2.lan maps all prefixes to s2, as it has a default path. Let's test it.
+	err = protocol.Get(fe+"darwin/was/right", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s2", body)
+
+	// Before making any private request, let's ensure no private request was made so far.
+	assert.Equal(t, 0, len(accessLog))
+
+	// Private request, should be allowed, but checked with the authenticator.
+	// Note that this verifies both that the map works correctly, and that authentication is enforced.
+	err = protocol.Get(fe+"oppose", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s3", body)
+	assert.Equal(t, "//test2.lan/oppose", accessLog[len(accessLog)-1])
+	// Same for subdirectories.
+	err = protocol.Get(fe+"oppose/censorship", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s3", body)
+	assert.Equal(t, "//test2.lan/oppose/censorship", accessLog[len(accessLog)-1])
+
+	// Let's see what happens if the authentication layer denies a request.
+	err = protocol.Get(fe+"deny/oppression", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.ErrorAs(t, err, &herr)
+	assert.Equal(t, http.StatusUnauthorized, herr.Resp.StatusCode)
+	assert.Equal(t, "//test2.lan/deny/oppression", accessLog[len(accessLog)-1])
+
+	// /opp is a prefix of /oppose, but should still work as expected.
+	err = protocol.Get(fe+"opp", protocol.Read(protocol.String(&body)), protocol.WithRequestOptions(krequest.SetHost("test2.lan")))
+	assert.NoError(t, err)
+	assert.Equal(t, "s4", body)
+
+	// Start an echo server to use as a tunnel backend.
+	e, err := echo.New("127.0.0.1:0")
+	assert.NoError(t, err)
+	assert.NotNil(t, e)
+
+	echoaddress, err := e.Address()
+	assert.NoError(t, err)
+
+	defer e.Close()
+	go e.Run()
+
+	proxy, err := url.Parse(fe)
+	assert.NoError(t, err)
+
+	// Try a tunnel connection.
+	pool := nasshp.NewBufferPool(8192)
+	tlog := logger.NewAccumulator()
+	tunnel, err := ptunnel.NewTunnel(pool, ptunnel.WithLogger(tlog))
+	assert.NoError(t, err)
+	assert.NotNil(t, tunnel)
+
+	defer tunnel.Close()
+	go tunnel.KeepConnected(proxy, echoaddress.IP.String(), uint16(echoaddress.Port))
+
+	send, write := io.Pipe()
+	go tunnel.Send(send)
+
+	read, receive := io.Pipe()
+	go tunnel.Receive(receive)
+
+	quote := "You never change things by fighting the existing reality. To change something, build a new model that makes the existing model obsolete.\n"
+	l, err := write.Write([]byte(quote))
+	assert.NoError(t, err)
+	assert.Equal(t, len(quote), l)
+
+	rback, err := bufio.NewReader(read).ReadString('\n')
+	assert.NoError(t, err)
+	assert.Equal(t, quote, rback)
+
+	assert.Nil(t, tlog.Retrieve())
+
+	// This is for defense in depth: check that the test actually connected to the echo server VIA THE PROXY.
+	// We do so by verifying that there is a log entry reporting the connection.
+	// TODO: once we have better metrics and introspection, do something smarter.
+	events := accumulator.Retrieve()
+	assert.True(t, len(events) > 1)
+	assert.Regexp(t, "- connects "+echoaddress.String(), events[len(events)-1].Message)
+}

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -2,31 +2,14 @@ package main
 
 import (
 	"github.com/enfabrica/enkit/lib/client"
-	"github.com/enfabrica/enkit/lib/config/marshal"
-	"github.com/enfabrica/enkit/lib/kflags"
 	"github.com/enfabrica/enkit/lib/kflags/kcobra"
-	"github.com/enfabrica/enkit/lib/khttp"
-	"github.com/enfabrica/enkit/lib/oauth"
 	"github.com/enfabrica/enkit/lib/srand"
 	"github.com/enfabrica/enkit/proxy/credentials"
-	"github.com/enfabrica/enkit/proxy/httpp"
-	"github.com/enfabrica/enkit/proxy/nasshp"
-	"github.com/enfabrica/enkit/proxy/utils"
+	"github.com/enfabrica/enkit/proxy/enproxy"
 	"github.com/spf13/cobra"
-	"log"
 	"math/rand"
-	"net/http"
 	"os"
 )
-
-type Config struct {
-	// Which URLs to map to which other URLs.
-	Mapping []httpp.Mapping
-	// Extra domains for which to obtain a certificate.
-	Domains []string
-	// List of allowed tunnels.
-	Tunnels []string
-}
 
 func main() {
 	root := &cobra.Command{
@@ -35,118 +18,25 @@ func main() {
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Example: `  $ proxy -c ./mappings.toml
+		Example: `  $ enproxy -c ./mappings.toml
 	To start a proxy mapping the urls defined in mappings.toml.`,
 	}
 
 	set, populator, runner := kcobra.Runner(root, os.Args)
 
-	base := client.DefaultBaseFlags(root.Name(), "enkit")
+	rng := rand.New(srand.Source)
+	base := client.DefaultBaseFlags(root.Name(), "enproxy")
 
-	hflags := khttp.DefaultFlags()
-	hflags.Register(set, "")
-
-	rflags := oauth.DefaultRedirectorFlags()
-	rflags.Register(set, "")
-
-	nflags := nasshp.DefaultFlags()
-	nflags.Register(set, "")
-
-	configbytes := []byte{}
-	configname := ""
-	withoutAuthentication := false
-	set.BoolVar(&withoutAuthentication, "without-authentication", false,
-		"allow tunneling even without authentication")
-	set.ByteFileVar(&configbytes, "config", configname, "Default config file location.", kflags.WithFilename(&configname))
+	flags := enproxy.DefaultFlags()
+	flags.Register(set, "")
 
 	root.RunE = func(cmd *cobra.Command, args []string) error {
-		var config Config
-		if err := marshal.UnmarshalDefault(configname, configbytes, marshal.Json, &config); err != nil {
-			return kflags.NewUsageError(err)
-		}
-		if len(config.Mapping) <= 0 {
-			return kflags.NewUsageErrorf("invalid config: it has no mappings")
-		}
-		if len(config.Tunnels) <= 0 {
-			base.Log.Warnf("watch out, your config has no whitelisted tunnel - no tunnel will be allowed!")
-		}
-		wl, err := utils.NewPatternList(config.Tunnels)
-		if err != nil {
-			return kflags.NewUsageErrorf("invalid patterns specified in tunnels: %s", err)
-		}
-
-		mods := []httpp.Modifier{httpp.WithLogging(base.Log)}
-		var authenticate oauth.Authenticate
-		if rflags.AuthURL != "" && !withoutAuthentication {
-			redirector, err := oauth.NewRedirector(oauth.WithRedirectorFlags(rflags))
-			if err != nil {
-				return err
-			}
-			authenticate = redirector.Authenticate
-			mods = append(mods, httpp.WithStripCookie([]string{
-				redirector.CredentialsCookieName(),
-			}))
-			mods = append(mods, httpp.WithAuthenticator(authenticate))
-		}
-
-		hproxy, err := httpp.New(config.Mapping, mods...)
+		ep, err := enproxy.New(rng, enproxy.WithLogging(base.Log), enproxy.FromFlags(flags))
 		if err != nil {
 			return err
 		}
 
-		dispatcher := http.Handler(hproxy)
-		if authenticate == nil && !withoutAuthentication {
-			base.Log.Warnf("ssh gateway disabled as no authentication was configured")
-		} else {
-			if withoutAuthentication {
-				base.Log.Errorf("Watch out! The proxy is being started without authentication! Relying entirely on a filmsy whitelist")
-				authenticate = nil
-			}
-
-			rng := rand.New(srand.Source)
-			nasshp, err := nasshp.New(rng, authenticate, nasshp.WithFilter(wl.Allow), nasshp.FromFlags(nflags), nasshp.WithLogging(base.Log))
-			if err != nil {
-				return err
-			}
-
-			// Why is a new mux created? Why not re-use the mux in hproxy? Why the funky logic below with empty host names?
-			//
-			// The httpp package uses the muxie mux by default. This mux can match directly on host name, and is generally
-			// great. Except it mangles the http request objects in such a way that gorilla/websocket fails to upgrade the
-			// connection.
-			//
-			// To work around that issue, we use two muxes:
-			// - one that dispatches based on host name, very simple, does not mangle the http request.
-			//   The goal of this mux is to route connection requests to either the ssh handler, or http proxy handler.
-			// - muxie, used by the proxy, to route all other requests.
-			//
-			// To support the two being configured on the same domain, or default domain, the muxie mux is configured
-			// as a fallback to the ssh mux.
-
-			mux := http.NewServeMux()
-			nasshp.Register(mux.HandleFunc)
-			mux.Handle("/", hproxy)
-
-			hosts := []khttp.HostDispatch{
-				{Host: nflags.RelayHost, Handler: mux},
-			}
-			if nflags.RelayHost != "" {
-				hosts = append(hosts, khttp.HostDispatch{Handler: hproxy})
-			}
-
-			handler, err := khttp.NewHostDispatcher(hosts)
-			if err != nil {
-				return err
-			}
-			dispatcher = handler
-		}
-
-		server, err := khttp.FromFlags(hflags)
-		if err != nil {
-			return err
-		}
-
-		return server.Run(base.Log.Infof, &khttp.Dumper{Real: dispatcher, Log: log.Printf}, append(config.Domains, hproxy.Domains...)...)
+		return ep.Run()
 	}
 
 	base.LoadFlagAssets(populator, credentials.Data)

--- a/proxy/nasshp/nassh.go
+++ b/proxy/nasshp/nassh.go
@@ -43,6 +43,10 @@ type NasshProxy struct {
 	connections sync.Map
 }
 
+func (np *NasshProxy) RelayHost() string {
+	return np.relayHost
+}
+
 type options struct {
 	bufferSize       int
 	symmetricSetters []token.SymmetricSetter
@@ -148,7 +152,7 @@ func FromFlags(fl *Flags) Modifier {
 		if len(fl.SymmetricKey) == 0 {
 			key, err := token.GenerateSymmetricKey(o.rng, 0)
 			if err != nil {
-				return fmt.Errorf("the world is about to end, even random nubmer generators are failing - %w", err)
+				return fmt.Errorf("the world is about to end, even random number generators are failing - %w", err)
 			}
 			fl.SymmetricKey = key
 		}
@@ -183,6 +187,14 @@ func WithTimeouts(timeouts *Timeouts) Modifier {
 	}
 }
 
+// New creates a new instance of a nasshp tunnel protocol.
+//
+// rng MUST be a secure random number generator, use github.com/enfabrica/lib/srand
+// in case of doubt to create one.
+// authenticator is optional, can be left to nil to disable authentication.
+//
+// mods MUST either contain FromFlags, to initialize all the nassh parameters from
+// command line flags, or it MUST provide a symmetric key with nasshp.WithSymmetricOptions.
 func New(rng *rand.Rand, authenticator oauth.Authenticate, mods ...Modifier) (*NasshProxy, error) {
 	o := &options{rng: rng, bufferSize: 8192}
 	np := &NasshProxy{
@@ -207,7 +219,7 @@ func New(rng *rand.Rand, authenticator oauth.Authenticate, mods ...Modifier) (*N
 	if np.encoder == nil {
 		be, err := token.NewSymmetricEncoder(rng, o.symmetricSetters...)
 		if err != nil {
-			return nil, fmt.Errorf("error setting up symmetric encryption: %w", err)
+			return nil, fmt.Errorf("nassh - error setting up symmetric encryption: %w", err)
 		}
 
 		ue := token.NewBase64UrlEncoder()


### PR DESCRIPTION
The enkit proxy creates a MUX that is able to dispatch to an
http proxy, or to the nassh tunnel handling (which happens to
use websockets and GET/POST requests via HTTP).

Creation of this MUX was performed directly from main, together
with a bunch of flags/configuration parsing.

Among other things, this made testing harder.

In this PR:
- break out code out of main() into a dedicated object, under
  enproxy/. This object follows the common conventions in the
  enkit/ repo, allowing direct initialization via flags or via
  simple modifiers/functors.
- add unit test covering the basic functionality of the proxy
  as well as ability to establish tunnels.

Note that this PR is still in preparation for follow up PRs:
THERE WERE NO BEHAVIORAL CHANGES IN THIS PR. Tried to minimize
code changes as much as possible, outside those changes necessary
to break the code out.

Follow up PRs will change a few behavioral things. Specifically:
- add functionality to only test the config file
  (without loading the proxy)
- metrics for prometheus
- a few cleanups (eg, use a single mux).

But this break down is a precursor to those changes.