### PR TITLE
cloud build staging: Add initial Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__/
 .pytest_cache
 .idea/
 .ijwb/
+.terraform
+*.tfstate.backup

--- a/infra/cloudbuild_staging/.terraform.lock.hcl
+++ b/infra/cloudbuild_staging/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.5.0"
+  hashes = [
+    "h1:MWHx6G+emVNvPyxxLCpEEco5F7eoRzX9Tp9lbtO/PmI=",
+    "zh:0db8d3e7cc68ddd70a75c72334908b60a875062162c5e8a78bb9e7c0060def64",
+    "zh:2ed5ac0301e6382589353402b11aed8ded08bfad425016a508523e18e8766424",
+    "zh:3abcaf9439bc60b7666cfc257af8bbe555a90b9692972bc46e84b2d96189bf63",
+    "zh:4d9da72347c0bc8dd34fa40ae5c26c7c862dc633e7a5da89564f8fa29d950a49",
+    "zh:5d4d85fb7318df9572e273ee3808c009db7856165a3f1d684e635cec67e4b0ef",
+    "zh:5eac81865b2e1467e2f54e31f8766b098baee9d86e9eeda0f9608f9dbf1863b9",
+    "zh:68c5095136b810a3b80d8aa698252eea4f391500904e4717f5b735f60e04388b",
+    "zh:99c584e796068899cc217d8ecb2204684f851b091a4ab8442e0d9186074f54ca",
+    "zh:a64e291acdd8d61c456073c91abe6b578760ee4526258d416aa5daaa3ed651b3",
+    "zh:acb7844d2a9bac8213764d755fdaeb64e96b50bf11381a66e0300bc4b1aa8040",
+    "zh:f294fd86cfeeee4bef2de31afd7af608d1c7f3f9e35f74127c39b02f58addc4c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "4.5.0"
+  hashes = [
+    "h1:11A4fme9royApN02DkA/yd9iz/WkiQATetWbraiz6rY=",
+    "zh:06bd1685e81f8d12ac50a673910e662624653f891177d04bb20e13d0a6c468c6",
+    "zh:0ee25c4e64e624ed532d2222557c2f4d35856e532164ba8b07caac267c410006",
+    "zh:1fa1690e3a0b22ad440aec89e9425fe326d983fac426e8db0641eb520ccfa545",
+    "zh:39b3c0e19af917acf3c66bad158889ca1cc9be6634b859bfda38a6ffe0ff8e72",
+    "zh:733e81c039875ab192b4dbb51bbca95b288590351b722aecda5baf21b45c5488",
+    "zh:75afcc9253bb1a5931b06bc8f005f3bf9bc89cba74e4e0ea34aa7f0e5c6a8e5f",
+    "zh:9b0c9ef87ffc44b22010ddeedb88807f45205497e80ada17368d9f345ff9991c",
+    "zh:bb6db9848e3bab85974908e63454cdec92c06f9fa55197d4da11937ddeec35f8",
+    "zh:d2d344e851e79a23f708e633f6942a84eca0e2a8c9767d235416dff3c327b596",
+    "zh:d5dbcd8536525f9397fed019e2f283f6fb318defbdeacd8e6d7f8d855a25396b",
+    "zh:f0469e4d20b532fe959fc8668a7d13aeb22261a86f64986253d3ecb256e3aa1a",
+  ]
+}

--- a/infra/cloudbuild_staging/README.md
+++ b/infra/cloudbuild_staging/README.md
@@ -1,0 +1,103 @@
+# Terraform-controlled Cloud Build
+
+This directory contains an experimental Terraform setup for managing the
+`enfabrica-cloud-build-staging` project.
+
+## Getting Started
+
+### Initialization
+
+1. **Install Terraform** by following the [appropriate
+   instructions](https://www.terraform.io/downloads). TODO: Include `terraform`
+   into the dev container, or via bazel rules somehow.
+
+1. **Initialize Terraform modules**: Terraform implements functionality via
+   plugins that are downloaded in a one-time initialization step. Until this is
+   integrated into bazel rules, run the init step manually to populate the
+   `.terraform/` directory; these files should be `.gitignore`d and not checked
+   in.
+
+   ```
+   terraform -chdir=infra/cloudbuild_staging init
+   ```
+
+1. **gcloud login for applications**: Terraform attempts to pick up gcloud
+   credentials via its "application default credentials" mechanism, which
+   necessitates a special login command:
+
+   ```
+   gcloud auth application-default login
+   ```
+
+### Preview Changes
+
+`terraform` can be run in a mode that will show the changes made to the project
+before execution.
+
+1. Run:
+
+   ```
+   terraform -chdir=infra/cloudbuild_staging plan
+   ```
+
+### Execute Changes
+
+1. Run:
+
+   ```
+   terraform -chdir=infra/cloudbuild_staging apply
+
+   # Extra configuration due to https://github.com/hashicorp/terraform-provider-google/issues/9883
+   gcloud \
+     --project=enfabrica-cloud-build-staging \
+     beta \
+     builds \
+     triggers \
+     import \
+     --source=infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
+   ```
+
+## Portions not covered by Terraform
+
+### Project: Enable Billing
+
+Open the
+[billing](https://console.cloud.google.com/billing/linkedaccount?project=enfabrica-cloud-build-staging)
+page as a billing admin and configure billing for the project.
+
+### Cloud Build: Configure Github Repositories
+
+On the [Manage repositories
+page](https://console.cloud.google.com/cloud-build/repos?project=cloud-build-290921):
+click `CONNECT REPOSITORY` and follow the workflow.
+
+### Secret: Add Cloud Run user as secret viewer
+
+Context: [These instructions](https://cloud.google.com/build/docs/configuring-notifications/configure-smtp#configuring_email_notifications)
+
+Determine the compute service account user for the project, and then replace the
+`--member` flag below:
+
+```
+gcloud \
+  projects \
+  add-iam-policy-binding \
+  cloud-build-290921 \
+  --member=serviceAccount:757178422572-compute@developer.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor
+```
+
+TODO: This should be defined in Terraform as well, when the cloud-build project
+is managed using Terraform.
+
+### Enabling APIs
+
+Various GCP APIs need to be enabled before Terraform can successfully apply:
+
+* Cloud Build
+* Compute Engine
+* Cloud Scheduler
+* TODO: Add more
+
+This might be able to be added to Terraform with the [`google_project_service`
+resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service).

--- a/infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
+++ b/infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
@@ -1,0 +1,26 @@
+build:
+  options:
+    machineType: E2_HIGHCPU_8
+  steps:
+  - args:
+    - build
+    - //...
+    entrypoint: /usr/bin/bazelisk
+    env:
+    - BAZEL_PROFILE=cloudbuild
+    name: gcr.io/devops-284019/developer:stable
+  - args:
+    - test
+    - //...
+    entrypoint: /usr/bin/bazelisk
+    env:
+    - BAZEL_PROFILE=cloudbuild
+    name: gcr.io/devops-284019/developer:stable
+  timeout: 1200s
+createTime: '2021-12-22T17:00:24.852472140Z'
+id: 1b99a715-4526-4a8a-9667-e47f104e8f7d
+name: enkit-bazel-postsubmit
+sourceToBuild:
+  ref: refs/heads/master
+  repoType: GITHUB
+  uri: https://github.com/enfabrica/enkit

--- a/infra/cloudbuild_staging/enkit_postsubmit.tf
+++ b/infra/cloudbuild_staging/enkit_postsubmit.tf
@@ -1,0 +1,235 @@
+variable "project_id" {
+  type = string
+  default = "enfabrica-cloud-build-staging"
+}
+
+################################################################################
+# ONE-TIME SETUP
+# The following resources need to only be configured once for all builds.
+################################################################################
+
+# Grab a handle to the existing compute service account
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
+# Grab a handle to the existing cloud build service account
+resource "google_project_service_identity" "cloud_build" {
+  provider = google-beta
+  project = var.project_id
+  service = "cloudbuild.googleapis.com"
+}
+
+# Grab a handle to the existing pubsub service account
+resource "google_project_service_identity" "pubsub" {
+  provider = google-beta
+  project = var.project_id
+  service = "pubsub.googleapis.com"
+}
+
+# Create a service account that will be used to kick a Cloud Run instance from a
+# PubSub message
+resource "google_service_account" "cloud_run_pubsub_invoker" {
+  project = var.project_id
+  account_id = "cloud-run-pubsub-invoker"
+  display_name = "Cloud Run Pub/Sub Invoker"
+}
+
+# Create an AppEngine app in the desired location
+#
+# Cloud Scheduler requires an AppEngine app in the same region, due to a
+# limitation of the API: https://cloud.google.com/scheduler/docs/#supported_regions
+resource "google_app_engine_application" "app" {
+  project = var.project_id
+  location_id = "us-west1"
+}
+
+# Give the cloud build service account read access to devops project Docker
+# images
+resource "google_storage_bucket_iam_member" "service_account_docker_image_viewer" {
+  bucket = "artifacts.devops-284019.appspot.com"
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_project_service_identity.cloud_build.email}"
+}
+
+# Give the pubsub service account the ability to create service account tokens
+resource "google_project_iam_member" "pubsub_auth_token_creator" {
+  project = var.project_id
+  role = "roles/iam.serviceAccountTokenCreator"
+  member = "serviceAccount:${google_project_service_identity.pubsub.email}"
+}
+
+# Give the pubsub invoker service account the ability to trigger Cloud Run
+# instances
+resource "google_cloud_run_service_iam_binding" "cloud_run_pubsub_invoker_is_invoker" {
+  location = google_cloud_run_service.smtp_notifier.location
+  project = google_cloud_run_service.smtp_notifier.project
+  service = google_cloud_run_service.smtp_notifier.name
+  role = "roles/run.invoker"
+  members = [
+    "serviceAccount:${google_service_account.cloud_run_pubsub_invoker.email}",
+  ]
+}
+
+# Create a GCS bucket for SMTP notifier configs
+resource "google_storage_bucket" "configs" {
+  project = var.project_id
+  name = "enfabrica-cloud-build-staging-configs"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+# Give the compute service account read access to the bucket for SMTP notifier
+# configs
+resource "google_storage_bucket_iam_binding" "configs_bucket_binding" {
+  bucket = google_storage_bucket.configs.name
+  role = "roles/storage.objectViewer"
+  members = [
+    "serviceAccount:${data.google_compute_default_service_account.default.email}",
+  ]
+}
+
+# Create a pubsub topic for cloud build results
+resource "google_pubsub_topic" "cloud_builds" {
+  project = var.project_id
+  name = "cloud-builds"
+  message_retention_duration = "86400s" # 24h
+}
+
+################################################################################
+# PER-BUILD SETUP
+# The following resources need to be defined N times - one per build
+################################################################################
+
+# Create a Cloud Build build trigger for this build.
+#
+# TODO: We can't actually express in terraform what is needed to configure the
+# trigger properly until
+# https://github.com/hashicorp/terraform-provider-google/issues/9883 is
+# resolved. Until then, we'll have to emit the corresponding gcloud yaml and
+# import via the gcloud CLI:
+#
+# gcloud \
+#   --project=enfabrica-cloud-build-staging \
+#   beta \
+#   builds \
+#   triggers \
+#   import \
+#   --source=infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
+#
+# To generate this yaml:
+# 
+# 1. Run `terraform apply` to create a broken build trigger
+# 2. Run `gcloud --project=enfabrica-cloud-build-staging beta builds triggers describe <TRIGGER NAME>` > infra/cloudbuild_staging/TRIGGER_NAME.yml
+# 3. Modify the YAML to match the same structure as //infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
+resource "google_cloudbuild_trigger" "build-trigger" {
+  trigger_template {
+    branch_name = "master"
+    repo_name = "enfabrica/enkit"
+  }
+  
+  name = "enkit-bazel-postsubmit"
+  project = var.project_id
+  
+  build {
+    step {
+      name = "gcr.io/devops-284019/developer:stable"
+      entrypoint = "/usr/bin/bazelisk"
+      args = ["build", "//..."]
+      env = ["BAZEL_PROFILE=cloudbuild"]
+    }
+    step {
+      name = "gcr.io/devops-284019/developer:stable"
+      entrypoint = "/usr/bin/bazelisk"
+      args = ["test", "//..."]
+      env = ["BAZEL_PROFILE=cloudbuild"]
+    }
+    timeout = "1200s" # 20m
+    options {
+      machine_type = "E2_HIGHCPU_8"
+    }
+  }
+}
+
+# Create a Cloud Scheduler cron-based trigger for this build
+resource "google_cloud_scheduler_job" "job" {
+  name = "enkit-bazel-postsubmit-cron"
+  project = var.project_id
+  region = google_app_engine_application.app.location_id
+  schedule = "30 4 * * *" # 4:30AM
+  #time_zone = "America/Los_Angeles"
+  attempt_deadline = "15s"
+
+  http_target {
+    http_method = "POST"
+    body = base64encode("{\"branchName\": \"master\"}")
+    uri = "https://cloudbuild.googleapis.com/v1/projects/${var.project_id}/triggers/${google_cloudbuild_trigger.build-trigger.trigger_id}:run"
+    oauth_token {
+      scope = "https://www.googleapis.com/auth/cloud-platform"
+      service_account_email = data.google_compute_default_service_account.default.email
+    }
+  }
+}
+
+# Create a pubsub subscription to kick the correct SMTP notifier for this build
+resource "google_pubsub_subscription" "cloud_builds_smtp_notifier" {
+  name = "cloud_builds_smtp_notifier"
+  project = var.project_id
+  topic = google_pubsub_topic.cloud_builds.name
+  push_config {
+    push_endpoint = google_cloud_run_service.smtp_notifier.status[0].url
+    oidc_token {
+      service_account_email = google_service_account.cloud_run_pubsub_invoker.email
+    }
+  }
+}
+
+# Create an SMTP notifier config for this build
+resource "google_storage_bucket_object" "smtp_notifier_config" {
+  bucket = google_storage_bucket.configs.name
+  name = "smtp_notifier/${google_cloudbuild_trigger.build-trigger.name}.yml"
+  content = <<EOF
+apiVersion: cloud-build-notifiers/v1
+kind: SMTPNotifier
+metadata:
+  name: example-smtp-notifier
+spec:
+  notification:
+    filter: build.status in [Build.Status.FAILURE, Build.Status.TIMEOUT] && build.build_trigger_id == "${google_cloudbuild_trigger.build-trigger.trigger_id}"
+    delivery:
+      server: smtp.gmail.com
+      port: '587'
+      sender: bot@enfabrica.net
+      from: bot@enfabrica.net
+      recipients:
+        - scott@enfabrica.net
+      password:
+        secretRef: bot-password
+  secrets:
+  - name: bot-password
+    value: projects/496137108493/secrets/bot-gsuite-password/versions/1
+EOF
+  }
+
+# Create an SMTP notifier for this build
+resource "google_cloud_run_service" "smtp_notifier" {
+  name = "enkit-bazel-postsubmit-smtp-notifier"
+  project = var.project_id
+  location = "us-west1"
+
+  template {
+    spec {
+      containers {
+        image = "us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/smtp:latest"
+        env {
+          name = "CONFIG_PATH"
+          value = "gs://${google_storage_bucket_object.smtp_notifier_config.bucket}/${google_storage_bucket_object.smtp_notifier_config.name}"
+        }
+        env {
+          name = "PROJECT_ID"
+          value = var.project_id
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change adds a Terraform config that attempts to create the
following:

* a Cloud Build for the `enkit` repository
* a cron trigger in Cloud Scheduler for the aforementioned build
* an SMTP notifier that sends build failure notifications via Cloud Run

...in accordance with the manual setup steps described
[here](https://cloud.google.com/build/docs/configuring-notifications/configure-smtp)
and
[here](https://cloud.google.com/build/docs/automating-builds/create-scheduled-triggers).

Since this is our first official foray into Terraform, the directory
includes a README about how to install and use Terraform, as well as
manual setup steps for a new project that can't be done inside
Terraform.

This change commits the Terraform lock files as well as the recorded
state after `terraform apply` (so we can detect out-of-band changes).
Terraform temporary files (the .terraform directory, and the state
backup) are `.gitignore`d; therefore, users must run `terraform init`
commands before any `terraform apply` commands, as per the `README`.

The goal in this change is to create one "golden" config for a single build,
so that it becomes clear what needs to be parameterized when doing
config generation and scaling to N builds.

In future changes, the terraform commands are hopefully replaced with
bazel rules, and the terraform configs themselves hopefully replaced
with some sort of generation mechanism that exposes a cleaner interface.

Tested: Clicked "run now" on Cloud Scheduler trigger - Cloud Scheduler
successfully kicked Cloud Build, which failed and sent me a failure notification mail.

Jira: INFRA-296
Jira: INFRA-297