### PR TITLE
proxy: add support for --validate-only flag.

### DIFF
--- a/proxy/enproxy/enproxy.go
+++ b/proxy/enproxy/enproxy.go
@@ -248,8 +248,11 @@ func WithLogging(logger logger.Logger) Modifier {
 func FromFlags(flags *Flags) Modifier {
 	return func(op *Options) error {
 		var config Config
+		if len(flags.ConfigContent) <= 0 {
+			return kflags.NewUsageErrorf("Config file is empty, or no config file specified. Check the --config flag.")
+		}
 		if err := marshal.UnmarshalDefault(flags.ConfigName, flags.ConfigContent, marshal.Json, &config); err != nil {
-			return kflags.NewUsageError(err)
+			return kflags.NewUsageErrorf("Invalid configuration file '%s': %w", flags.ConfigName, err)
 		}
 
 		if flags.Oauth.AuthURL != "" && !flags.DisabledAuthentication {

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/enfabrica/enkit/proxy/enproxy"
 	"github.com/spf13/cobra"
 	"math/rand"
+	"fmt"
 	"os"
 )
 
@@ -30,12 +31,21 @@ func main() {
 	flags := enproxy.DefaultFlags()
 	flags.Register(set, "")
 
+	var validateOnly bool
+	set.BoolVar(&validateOnly, "validate-only", false,
+		"If this flag is set, no proxy is started. Instead, the config file and command line " +
+		"flags are validated, and a non-zero status returned if invalid")
+
 	root.RunE = func(cmd *cobra.Command, args []string) error {
 		ep, err := enproxy.New(rng, enproxy.WithLogging(base.Log), enproxy.FromFlags(flags))
 		if err != nil {
 			return err
 		}
 
+		if validateOnly {
+			fmt.Printf("Config file and flags: OK\n")
+			return nil
+		}
 		return ep.Run()
 	}
 


### PR DESCRIPTION
Background:
Up until this PR, the only way to validate a config file and set
of flags was to start a proxy server, which is extremely inconvenient,
as it requires taking down the old proxy and starting a new one,
and... only then you find out if there's a config error.

In this PR:
- added a simple --validate-only flag, which prevents starting the
  proxy, but still does as much of the config file validation as
  possible. Causes a non-zero exit status in case of error.

Additionally:
- improve the messages printed in case of configuration file errors.

Tested: right now, run the main manually with and without --validate-only, and some invalid flag combinations. I expect to add a sh_test or similar in an upcoming PR.