### PR TITLE
Changes to get Faketree to work as a test dependency

### DIFF
--- a/faketree/faketree_test.sh
+++ b/faketree/faketree_test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+foundft="$(find . -name "faketree" -type f -executable)"
 ft="./faketree/faketree_/faketree"
-
+if [ ! -f $ft ]; then
+  ft=$foundft
+fi
 function fail() {
   echo -- "$@" >&2
   exit 1
@@ -9,7 +12,7 @@ function fail() {
 
 $ft --help &>/dev/null
 test "$?" == 125 || {
-  fail "--help should return error status 125"
+  fail "--help should return error status 125 but it returned ${$?}"
 }
 
 uid=$($ft -- sh -c 'echo $(id -u)')

--- a/faketree/faketree_test.sh
+++ b/faketree/faketree_test.sh
@@ -12,7 +12,7 @@ test "$?" == 125 || {
   fail "--help should return error status 125"
 }
 
-uid=$($ft -- sh -c 'echo $UID')
+uid=$($ft -- sh -c 'echo $(id -u)')
 test "$?" == 0 || {
   fail "simple shell command failed"
 }
@@ -20,7 +20,7 @@ test "$uid" == "$UID" || {
   fail "uid does not match expected uid - $uid"
 }
 
-uid=$($ft --root -- sh -c 'echo $UID')
+uid=$($ft --root -- sh -c 'echo $(id -u)')
 test "$?" == 0 || {
   fail "starting as root failed"
 }


### PR DESCRIPTION
When testing with `@enkit//faketree/...` the location of the binary is actually located in `external/`

This just allows for a fallback to find the binary in case it isn't located as a first party test.

http://buddy.bazel.corp.enfabrica.net/invocation/023bed4d-e347-4067-bbbb-5487ff3f8c90