### PR TITLE
enfuse: Fuse over Websockets!

### DIFF
--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -1,13 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "postsubmit_proto",
     srcs = ["postsubmit.proto"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "postsubmit_go_proto",
     importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
     proto = ":postsubmit_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":postsubmit_go_proto"],
+    importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
+    visibility = ["//visibility:public"],
 )

--- a/proxy/enfuse/BUILD.bazel
+++ b/proxy/enfuse/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lib/logger:go_default_library",
+        "//lib/multierror:go_default_library",
         "//lib/srand:go_default_library",
         "//proxy/enfuse/rpc:go_default_library",
         "@com_github_google_uuid//:go_default_library",

--- a/proxy/enfuse/client.go
+++ b/proxy/enfuse/client.go
@@ -14,7 +14,7 @@ var (
 )
 
 func NewClient(config *ConnectConfig) (*FuseClient, error) {
-	conn, err := grpc.Dial(net.JoinHostPort(config.Url, strconv.Itoa(config.Port)), grpc.WithInsecure())
+	conn, err := grpc.Dial(net.JoinHostPort(config.Url, strconv.Itoa(config.Port)), config.GrpcDialOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -39,4 +39,3 @@ type FuseClient struct {
 func (f *FuseClient) Root() (fs.Node, error) {
 	return &Dir{Dir: "", Client: f.ConnClient}, nil
 }
-

--- a/proxy/enfuse/config.go
+++ b/proxy/enfuse/config.go
@@ -1,14 +1,16 @@
 package enfuse
 
 import (
+	"google.golang.org/grpc"
 	"net"
 )
 
 type ConnectConfig struct {
-		Port int
-		Url  string
-		L    net.Listener
-	}
+	Port         int
+	Url          string
+	L            net.Listener
+	GrpcDialOpts []grpc.DialOption
+}
 
 type ConnectMod func(c *ConnectConfig)
 
@@ -31,6 +33,11 @@ var (
 	WithConnectConfig = func(c1 *ConnectConfig) ConnectMod {
 		return func(c *ConnectConfig) {
 			*c = *c1
+		}
+	}
+	WithGrpcDialOpts = func(opts ...grpc.DialOption) ConnectMod {
+		return func(c *ConnectConfig) {
+			c.GrpcDialOpts = opts
 		}
 	}
 )

--- a/proxy/enfuse/e2e_test.go
+++ b/proxy/enfuse/e2e_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestManyClientsUsingBasicPeering(t *testing.T) {
 	relayServer := testserver.NewWebSocketBasicClientServer(t)
-	defer relayServer.Close()
 	sharingPeerWssConn, _, err := websocket.DefaultDialer.Dial(strings.ReplaceAll(relayServer.URL+"/server", "http", "ws"), nil)
 	assert.NoError(t, err)
 
@@ -71,7 +70,6 @@ func generateConsumingPeerShim(t *testing.T, relayServer *httptest.Server) *enfu
 
 func TestSingleClientUsingBasicPeering(t *testing.T) {
 	relayServer := testserver.NewWebSocketBasicClientServer(t)
-	defer relayServer.Close()
 	sharingPeerWssConn, _, err := websocket.DefaultDialer.Dial(strings.ReplaceAll(relayServer.URL+"/server", "http", "ws"), nil)
 	assert.NoError(t, err)
 

--- a/proxy/enfuse/e2e_test.go
+++ b/proxy/enfuse/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"bazil.org/fuse/fs/fstestutil"
 	"fmt"
 	"github.com/enfabrica/enkit/lib/knetwork"
-	"github.com/enfabrica/enkit/lib/srand"
 	"github.com/enfabrica/enkit/proxy/enfuse"
 	fusepb "github.com/enfabrica/enkit/proxy/enfuse/rpc"
 	"github.com/enfabrica/enkit/proxy/enfuse/testserver"
@@ -177,9 +176,8 @@ func CreateSeededTmpDir(t *testing.T, num int) (string, []TmpFile) {
 }
 
 func createTmpFile(t *testing.T, tmpDirName string) TmpFile {
-	rng := rand.New(srand.Source)
 	cwd := tmpDirName
-	for i := 0; i < rng.Intn(5); i++ {
+	for i := 0; i < rand.Intn(5); i++ {
 		name, err := os.MkdirTemp(cwd, "*")
 		assert.NoError(t, err)
 		cwd = name
@@ -187,9 +185,9 @@ func createTmpFile(t *testing.T, tmpDirName string) TmpFile {
 	f, err := os.CreateTemp(cwd, "*.txt")
 	assert.Nil(t, err)
 	filename := f.Name()
-	sizeOfFile := 1024 * 1024 * (rng.Intn(2) + 1) // size of the file is greater than rpc data.
+	sizeOfFile := 1024 * 1024 * (rand.Intn(2) + 1) // size of the file is greater than rpc data.
 	content := make([]byte, sizeOfFile)
-	i, err := rng.Read(content)
+	i, err := rand.Read(content)
 	assert.NoError(t, err)
 	assert.Equal(t, sizeOfFile, i)
 	_, err = f.Write(content)

--- a/proxy/enfuse/files.go
+++ b/proxy/enfuse/files.go
@@ -80,15 +80,11 @@ func (f *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 func (f *Dir) fetchData() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if time.Since(f.LastFetch) < 5*time.Second {
-		return nil
-	}
 	r, err := f.Client.FileInfo(context.Background(), &fusepb.FileInfoRequest{Dir: f.Dir})
 	if err != nil {
 		return err
 	}
 	f.Data = r.Files
-	f.LastFetch = time.Now()
 	return nil
 }
 

--- a/proxy/enfuse/socket.go
+++ b/proxy/enfuse/socket.go
@@ -2,7 +2,6 @@ package enfuse
 
 import (
 	"context"
-	"fmt"
 	"github.com/enfabrica/enkit/lib/logger"
 	"github.com/enfabrica/enkit/lib/multierror"
 	"github.com/gorilla/websocket"
@@ -146,8 +145,6 @@ func (w *WebsocketTCPShim) handleReadToWebsocket(c net.Conn, uid []byte) {
 	for {
 		if _, err := io.Copy(socketShim, c); err != nil {
 			w.l.Errorf("err copying for client %w", err)
-		} else {
-			fmt.Println("exiting io.Copy in handleReadToWebsocket")
 		}
 	}
 }

--- a/proxy/enfuse/testserver/basic.go
+++ b/proxy/enfuse/testserver/basic.go
@@ -42,11 +42,11 @@ func NewWebSocketBasicClientServer(t *testing.T) *httptest.Server {
 			m, t, err := webConn.ReadMessage()
 			if err != nil {
 				fmt.Println(err.Error())
-				continue
+				return
 			}
 			if err := pool.WriteWebsocketServer(m, t, webConn); err != nil {
 				fmt.Println("error in write to server", err.Error())
-				continue
+				return
 			}
 		}
 	})

--- a/proxy/enfuse/testserver/hello.go
+++ b/proxy/enfuse/testserver/hello.go
@@ -26,7 +26,9 @@ func NewWebsocketCounterServer(t *testing.T, onMessage func(input []byte)) *http
 		}
 		for {
 			_, data, err := webConn.ReadMessage()
-			assert.NoError(t, err)
+			if err != nil { /* we discard errors here because as of right now there is no way to disconnect gracefully https://github.com/gorilla/websocket/issues/448 */
+				return
+			}
 			onMessage(data)
 		}
 	})

--- a/proxy/enfuse/testserver/hello.go
+++ b/proxy/enfuse/testserver/hello.go
@@ -4,6 +4,7 @@
 package testserver
 
 import (
+	"bytes"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"net"
@@ -47,6 +48,7 @@ func handleNewHelloNetConn(t *testing.T, c net.Conn) {
 	for {
 		buf := make([]byte, 1024)
 		_, err := c.Read(buf)
+		buf = bytes.Trim(buf, "\x00")
 		assert.NoError(t, err)
 		retBytes := append([]byte("hello "), buf...)
 		_, err = c.Write(retBytes)

--- a/proxy/enfuse/websocket_test.go
+++ b/proxy/enfuse/websocket_test.go
@@ -40,7 +40,6 @@ func TestWritesToServer(t *testing.T) {
 		recvMessages = append(recvMessages, string(input))
 		mu.Unlock()
 	})
-	defer s.Close()
 
 	url := strings.Replace(s.URL, "http", "ws", -1)
 	serverConn, _, err := websocket.DefaultDialer.Dial(url, nil)
@@ -63,6 +62,7 @@ func TestWritesToServer(t *testing.T) {
 	mu.Lock()
 	assert.ElementsMatch(t, messages, recvMessages)
 	mu.Unlock()
+	s.Close()
 }
 
 


### PR DESCRIPTION
This PR does the following:
- Tests running a FUSE filesystem over websockets.
- SocketShim now implements net.Conn
- Establishes the convention of how to use the tcp-to-websocket model (more documentation and refactoring later)
- Makes it so that the test server's no longer write back []byte with NULL characters appended.
- Add GrpcDialOpts to the connect configuration 
- Removes the Toy Caching from the FuseClient, wasn't really necessary