### PR TITLE
kunit: Use an ephemeral tmp path as the UML directory

### DIFF
--- a/bazel/linux/run_um_kunit_tests.template
+++ b/bazel/linux/run_um_kunit_tests.template
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 MODULE=$(dirname $(realpath {module}))
 TMPOUTPUT=$TEST_TMPDIR/.output
-{kernel} ubd0={rootfs} hostfs=$MODULE uml_dir=$TEST_TMPDIR | tee $TMPOUTPUT
+
+# The Bazel TEST_TMPDIR path tends to get long depending on the project
+# structure and the current working directory at the time of test invocation.
+# This overflows UNIX_PATH_MAX that UML sees when firing up. To prevent this,
+# create a temporary directory and link it under the Bazel tree so it gets
+# cleaned up properly after the test.
+UML_DIR=$(mktemp -u)
+ln -s ${TEST_TMPDIR} ${UML_DIR}
+
+{kernel} ubd0={rootfs} hostfs=$MODULE uml_dir=${UML_DIR} | tee $TMPOUTPUT
 {parser} parse < $TMPOUTPUT


### PR DESCRIPTION
As noted in the comment, this prevents a path string overflow. Without
this change, the mconsole initialization fails:

```
printk: console [stderr0] disabled
umid_file_name : buffer too short
```

And it succeeds with it:

```
printk: console [stderr0] disabled
mconsole (version 2) initialized on /tmp/tmp.tOCqXFlP01/zbnwLP/mconsole
```

Signed-off-by: Raghu Raja <raghu@enfabrica.net>