### PR TITLE
gee: ignore "apt update" errors

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -993,7 +993,8 @@ function _install_tools() {
       | sudo /usr/bin/apt-key --keyring "${KRFILE}" add -
     echo "deb [arch=amd64 signed-by=${KRFILE}] https://cli.github.com/packages stable main" \
       | sudo /usr/bin/tee /etc/apt/sources.list.d/githubcli-archive.list
-    sudo /usr/bin/apt update && sudo /usr/bin/apt install gh
+    sudo /usr/bin/apt update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt install gh
     if [ ! -x ${GH} ]; then
       _fatal "Could not install gh."
     fi
@@ -1001,7 +1002,8 @@ function _install_tools() {
 
   if [ ! -x "${JQ}" ]; then
     _info "Installing missing tool: jq"
-    sudo /usr/bin/apt update && sudo /usr/bin/apt install jq
+    sudo /usr/bin/apt update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt install jq
     if [ ! -x "${JQ}" ]; then
       _fatal "Could not install jq."
     fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -993,8 +993,8 @@ function _install_tools() {
       | sudo /usr/bin/apt-key --keyring "${KRFILE}" add -
     echo "deb [arch=amd64 signed-by=${KRFILE}] https://cli.github.com/packages stable main" \
       | sudo /usr/bin/tee /etc/apt/sources.list.d/githubcli-archive.list
-    sudo /usr/bin/apt update || /bin/true  # ignore errors associated with stale repos.
-    sudo /usr/bin/apt install gh
+    sudo /usr/bin/apt-get update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt-get install gh
     if [ ! -x ${GH} ]; then
       _fatal "Could not install gh."
     fi
@@ -1002,8 +1002,8 @@ function _install_tools() {
 
   if [ ! -x "${JQ}" ]; then
     _info "Installing missing tool: jq"
-    sudo /usr/bin/apt update || /bin/true  # ignore errors associated with stale repos.
-    sudo /usr/bin/apt install jq
+    sudo /usr/bin/apt-get update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt-get install jq
     if [ ! -x "${JQ}" ]; then
       _fatal "Could not install jq."
     fi


### PR DESCRIPTION
gee: ignore "apt update" errors

Some of our installations have stale/broken links to certain launchpad
repos ( https://enfabrica.atlassian.net/browse/INFRA-383 ).  This causes
"sudo apt update" to fail with exit code 100, which then causes gee to
fail when trying to install missing tools.  gee now works around this
issue by ignoring all exit codes from "apt update."

Tested:
Ran "gee repair" on hw-dev-00, which has a broken repo configured.

PR generated by jonathan from branch gee_workaround_apt.

