### PR TITLE
astore_download: Run download step locally

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -81,6 +81,18 @@ def _astore_download(ctx):
         command = command,
         tools = [ctx.executable._astore_client],
         outputs = [output],
+        execution_requirements = {
+            # We can't run these remotely since remote workers won't have
+            # credentials to fetch from astore.
+            # We should also avoid remotely caching since:
+            # * this means we need to give individuals permissions to remotely
+            #   cache local actions, which we currently don't do
+            # * we might spend lots of disk/network caching astore artifacts
+            #   remotely
+            "no-remote": "Don't run remotely or cache remotely",
+            "requires-network": "Downloads from astore",
+            "no-cache": "Not hermetic, since it doesn't refer to packages by hash",
+        },
     )
     return [DefaultInfo(files = depset([output]))]
 


### PR DESCRIPTION
This change tags actions in the `astore_download` rule as:

* `no-remote`, since remote workers don't have credentials that `enkit`
  looks for when fetching from astore
* `requires-network`, since the action requires the network
* `no-cache`, since `astore_download` doesn't necessarily lock the
  downloaded version of artifacts (arguably a second issue that should be
  addressed, and then the tag can be removed)

Tested: Dependent build in `internal` fails normally, but succeeds with
this change when run with:

```
BAZEL_PROFILE=buildbarn bazel build //developer:developer-image --override_repository=enkit=/home/bminor/dev/enkit
```

Jira: INFRA-170