### PR TITLE
flextape client: Move to separate binary

### DIFF
--- a/flextape/client/BUILD.bazel
+++ b/flextape/client/BUILD.bazel
@@ -4,7 +4,11 @@ go_library(
     name = "go_default_library",
     srcs = ["client.go"],
     importpath = "github.com/enfabrica/enkit/flextape/client",
-    visibility = ["//manager/client:__pkg__"],
+    visibility = [
+        "//flextape/client/flextape_client:__pkg__",
+        # TODO(scott): Drop this when deleting the code
+        "//manager/client:__pkg__",
+    ],
     deps = ["//flextape/proto:go_default_library"],
 )
 

--- a/flextape/client/flextape_client/BUILD.bazel
+++ b/flextape/client/flextape_client/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/flextape/client/flextape_client",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//flextape/client:go_default_library",
+        "//flextape/proto:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "flextape_client",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/flextape/client/flextape_client/main.go
+++ b/flextape/client/flextape_client/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"time"
+
+	"github.com/enfabrica/enkit/flextape/client"
+	fpb "github.com/enfabrica/enkit/flextape/proto"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+var (
+	timeout = flag.Duration("timeout", 7200*time.Second, "Max time waiting in license queue")
+)
+
+func main() {
+	// This argument handling is a bit unorthodox, but must be compatible with the
+	// commandline issued by bazel rules.
+	host, port := os.Args[1], os.Args[2]
+	flag.Parse()
+	vendor, feature, cmd, args := os.Args[3], os.Args[4], os.Args[5], os.Args[6:]
+
+	user, err := user.Current()
+	if err != nil {
+		log.Fatalf("Failed to get username: %s \n", err)
+	}
+
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Connection failed: %s \n", err)
+	}
+	defer conn.Close()
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		log.Fatalf("failed to generate job ID: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	// TODO(INFRA-418): Insert signal handling here
+
+	c := client.New(fpb.NewFlextapeClient(conn), user.Username, vendor, feature, id.String())
+	err = c.Guard(ctx, cmd, args...)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -1,13 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "postsubmit_proto",
     srcs = ["postsubmit.proto"],
+    visibility = ["//visibility:private"],
 )
 
 go_proto_library(
     name = "postsubmit_go_proto",
     importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
     proto = ":postsubmit_proto",
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":postsubmit_go_proto"],
+    importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
+    visibility = ["//visibility:private"],
 )

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -46,11 +46,14 @@ go_library(
 )
 
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
 container_image(
     name = "enproxy-base",
     base = "@go_image_base//image",
+    env = {
+        "HOME": "/cache",
+    },
 
     # enproxy needs to cache certificates in a directory so they survive
     # across restarts.
@@ -60,10 +63,10 @@ container_image(
     # up in a restart loop of the proxy without the cache, we'd quickly
     # exhaust this limit, and won't be able to get new certificates until
     # the rate limit grants more quota.
-    volumes = ["/cache", "/config"],
-    env = {
-      "HOME": "/cache",
-    },
+    volumes = [
+        "/cache",
+        "/config",
+    ],
 )
 
 go_image(


### PR DESCRIPTION
The original license manager client has two code paths: one that talks
to the old server, and one that talks to the new server. The old server
is no longer in use.

This change copies the code path that talks to the new server into a new
binary under //flextape/client/flextape_client. This will allow us to
delete the entire //manager subtree in a future change.

This change prepares us to add signal handling required for INFRA-418
more cleanly.

Jira: INFRA-418