### PR TITLE
flextape client: Kill wrapped process on SIGINT/SIGTERM

### DIFF
--- a/flextape/client/client.go
+++ b/flextape/client/client.go
@@ -67,6 +67,11 @@ func (c *LicenseClient) Guard(ctx context.Context, cmd string, args ...string) e
 		cancel()
 		// Wait for command to fail/be killed
 		<-jobResult
+		// If the error received was nil, probably the context got cancelled, so
+		// report that as the error instead.
+		if err == nil {
+			err = ctx.Err()
+		}
 		return fmt.Errorf("lost license and killed job: %w", err)
 	case err := <-jobResult:
 		// Command has finished, either with success or error


### PR DESCRIPTION
This change listens for SIGINT/SIGTERM and kills the child process
before exiting by cancelling the appropriate context.

Before this change, issuing a signal via e.g. `kill` would kill the
`flextape_client` process, but not the process that it was wrapping.
This makes manual cleanup on worker nodes more tedious than it needs to
be.

This change allows us to reliably kill both processes by issuing a
single SIGINT/SIGTERM.

Tested:
* Started local flextape server
* Started client wrapping a `sleep 60` command: `bazel run
  //flextape/client/flextape_client -- localhost 6433 xilinx vivado
  sleep 60`
* Looked for both the sleep and the flextape_client invocation: `watch
  'ps -ax | rg "sleep|bazel"'
* Sent a SIGINT to the `flextape_client` invocation: `kill -2 <pid>`
* Confirmed that `sleep 60` was also terminated
* Saw appropriate log output from `flextape_client` on stderr

Jira: INFRA-418