### PR TITLE
proxy: mux cleanup and bug fix.

### DIFF
--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//lib/kflags/kcobra:go_default_library",
         "//lib/srand:go_default_library",
         "//proxy/enproxy:go_default_library",
-        "//proxy/httpp:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/proxy/amux/BUILD.bazel
+++ b/proxy/amux/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mux.go"],
+    importpath = "github.com/enfabrica/enkit/proxy/amux",
+    visibility = ["//visibility:public"],
+)

--- a/proxy/amux/amuxie/BUILD.bazel
+++ b/proxy/amux/amuxie/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["amuxie.go"],
+    importpath = "github.com/enfabrica/enkit/proxy/amux/amuxie",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proxy/amux:go_default_library",
+        "@com_github_kataras_muxie//:go_default_library",
+    ],
+)

--- a/proxy/amux/amuxie/amuxie.go
+++ b/proxy/amux/amuxie/amuxie.go
@@ -1,0 +1,64 @@
+// Interface adapter to make a "muxie" (from https://github.com/kataras/muxie) comformant
+// to the "github.com/enfabrica/enkit/proxy/amux" interface.
+package amuxie
+
+import (
+	"github.com/enfabrica/enkit/proxy/amux"
+	"github.com/kataras/muxie"
+	"net/http"
+)
+
+type Mux struct {
+	*muxie.Mux
+}
+
+func New() *Mux {
+	return &Mux{Mux: muxie.NewMux()}
+}
+
+func (m *Mux) Host(host string) amux.Mux {
+	h := muxie.NewMux()
+	m.HandleRequest(muxie.Host(host), h)
+
+	return &Mux{h}
+}
+
+func (m *Mux) Handle(path string, handler http.Handler) {
+	m.Mux.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// To manage the "upgrade" header to turn HTTP requests into
+		// WebSockets, the ResponseWriter must implement the Hijacker interface
+		// (https://pkg.go.dev/net/http#Hijacker).
+		//
+		// This is normally implemented by type casting the ResponseWriter
+		// into a Hijacker. If the cast succeeds, the WebSocket upgrade is
+		// performed. If the cast fails, the upgrade fails.
+		//
+		// The muxie library passes a muxie.Writer as a ResponseWriter,
+		// (https://pkg.go.dev/github.com/kataras/muxie#Writer), which is
+		// declared as a struct embedding a ResponseWriter interface.
+		//
+		// This causes the type casting to Hijacker to ALWAYS fail, no matter
+		// what the underlying implementation of the ResponseWriter is: the
+		// muxie.Writer struct itself does not implement any other interface,
+		// even if the embedded ResponseWriter does.
+		//
+		// The code here replaces the muxie.Writer with the original
+		// embedded ResponseWriter, so typecasting can succeed.
+		//
+		// To better understand the problem, you can look at the demo here
+		// showcasing the casting constraints: https://go.dev/play/p/WQJDMVhjKZY
+		//
+		// A loop is used for defense in depth, as different implementations
+		// of middlewares could cause more than one layer of encapsulation.
+		for {
+			mw, ok := w.(*muxie.Writer)
+			if !ok {
+				break
+			}
+
+			w = mw.ResponseWriter
+		}
+		handler.ServeHTTP(w, r)
+		return
+	}))
+}

--- a/proxy/amux/mux.go
+++ b/proxy/amux/mux.go
@@ -1,0 +1,70 @@
+// Many of the enproxy libraries require an http.Mux to work.
+//
+// Different muxex provide different properties. For example, some muxes cannot
+// match on domain names, break support for web sockets, or can use more or
+// less powerful patterns.
+//
+// Which mux to use is generally a choice of the application using the enproxy
+// libraries.
+//
+// This package defines a single Mux interface used throughout the enproxy
+// codebase with two goals:
+//
+// 1) Define the minimal requirements of the Mux, both in terms of function
+//    signatures and semantics, through interfaces and documentation.
+//
+// 2) Allow applications to use an arbitrary mux by simply implementing the
+//    defined interfaces.
+//
+// Note that although most muxes in the golang ecosystem provide similar
+// concepts, they vary wildly in terms of APIs and implementation.
+//
+// Subpackages of amux provide adapters for common muxes that over time
+// have been used or tested with the enproxy implementation.
+package amux
+
+import (
+	"net/http"
+)
+
+type Mux interface {
+	// Host allows to match on the domain name.
+	//
+	// The host string is expected to be a FQDN. Not a subdomain.
+	//
+	// The function returns a Mux that can be used to define handlers for
+	// specific paths in this specific domain, or add more host matches.
+	//
+	// The "empty host string" is considered a wildcard matching any FQDN.
+	// Any path defined via Handle()
+	//
+	// The enproxy code does not otherwise use any form of pattern matching.
+	// No regular expressions or wildcards are required.
+	//
+	// However, if the enproxy configuration file contains wildcards or
+	// regular expressions, they are passed unmodified to the supplied Mux
+	// interface and transparently handled by the configured handlers.
+	//
+	// If a Mux with support for patterns in Host() is thus provided to
+	// enproxy, the corresponding functionalities will work and be available
+	// to users of enproxy.
+	Host(host string) Mux
+
+	// Handle allows to match on an http path.
+	//
+	// The string is expected to be a full path, starting with "/".
+	//
+	// When Handle is called on a newly initialized Mux, eg, one that was
+	// not created by a call to Host(), the path is expected to be
+	// configured on the empty host domain, "". See the Host()
+	// documentation for details.
+	//
+	// If the path ends with "/", it is assumed to be a prefix match.
+	// Any subdirectory of such path will need to be routed to the handler.
+	//
+	// When the underlying mux invokes the corresponding http.Handler,
+	// the supplied ResponseWriter MUST be type castable to the
+	// https://pkg.go.dev/net/http#Hijacker in order to support WebSockets,
+	// required by enproxy.
+	Handle(path string, handler http.Handler)
+}

--- a/proxy/enproxy/BUILD.bazel
+++ b/proxy/enproxy/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
         "//lib/khttp:go_default_library",
         "//lib/logger:go_default_library",
         "//lib/oauth:go_default_library",
+        "//proxy/amux:go_default_library",
+        "//proxy/amux/amuxie:go_default_library",
         "//proxy/httpp:go_default_library",
         "//proxy/nasshp:go_default_library",
         "//proxy/utils:go_default_library",

--- a/proxy/httpp/BUILD.bazel
+++ b/proxy/httpp/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//lib/logger:go_default_library",
         "//lib/multierror:go_default_library",
         "//lib/oauth:go_default_library",
-        "@com_github_kataras_muxie//:go_default_library",
+        "//proxy/amux:go_default_library",
     ],
 )
 
@@ -24,6 +24,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//lib/khttp:go_default_library",
+        "//proxy/amux/amuxie:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/proxy/httpp/build_test.go
+++ b/proxy/httpp/build_test.go
@@ -3,6 +3,7 @@ package httpp
 import (
 	"fmt"
 	"github.com/enfabrica/enkit/lib/khttp"
+	"github.com/enfabrica/enkit/proxy/amux/amuxie"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
@@ -46,7 +47,9 @@ func TestBuild(t *testing.T) {
 		},
 	}
 
-	mux, dohttpps, err := BuildMux(nil, nil, mapping, creator)
+	mux := amuxie.New()
+
+	dohttpps, err := PopulateMux(mux, nil, mapping, creator)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{}, dohttpps)
 

--- a/proxy/nasshp/nassh_test.go
+++ b/proxy/nasshp/nassh_test.go
@@ -63,7 +63,7 @@ func TestBasic(t *testing.T) {
 	assert.Nil(t, err)
 
 	mux := http.NewServeMux()
-	nassh.Register(mux.HandleFunc)
+	nassh.Register(mux.Handle)
 
 	tu, err := ktest.Start(&khttp.Dumper{Log: t.Logf, Real: mux})
 	assert.Nil(t, err)

--- a/proxy/ptunnel/tunnel_test.go
+++ b/proxy/ptunnel/tunnel_test.go
@@ -91,7 +91,7 @@ func TestBasic(t *testing.T) {
 	assert.Nil(t, err)
 
 	mux := http.NewServeMux()
-	nassh.Register(mux.HandleFunc)
+	nassh.Register(mux.Handle)
 
 	log.Printf("SERVER")
 	tu, err := ktest.Start(&khttp.Dumper{Log: log.Printf, Real: mux})
@@ -173,7 +173,7 @@ func TestHostLookup(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	m := http.NewServeMux()
-	nassh.Register(m.HandleFunc)
+	nassh.Register(m.Handle)
 	s := httptest.NewServer(m)
 	t.Run("Test Host Resolution with Allowed List", func(t *testing.T) {
 		for _, h := range hosts {


### PR DESCRIPTION
Background:
http handlers that require WebSockets need to be passed an http.RequestWriter
that can be type casted into an http.Hijacker.
This dependency is not well documented.

The proxy code further requires a Mux that can match host names.
Given that the default http.Mux cannot match on hosts out of the box,
back when the code was written I ended up using muxie (popular and
very performant, used by the iris framework).

When testing nassh, I realized that the gorilla library for WebSockets
used by nassh was not working, but I could not pinpoint the exact issue, and
thought it was a problem between gorilla WebSockets, and non-gorilla
mux.

To work around the problem I ended up using a hack where I combined multiple
muxes together: a simple domain mux (in khttp, hand written), a default
http.Mux, and muxie. This allowed nassh to work.

This, however, had a couple of undesireable side effects:

1) Code complexity: it is hard to reason about the code, the
   mux nesting is just bad.
2) Breaking WebSockets for normal proxied connections.
   Turns out that the default golang proxy implementation also has a dependency
   on being able to use http.Hijacker on the http.RequestWriter
   in order to provide (supported) WebSockets.

In this PR:
1) Document the requirements of the mux used by enproxy through
   a new interface file, amux.
2) Added a generic adapter that gets muxie to work correctly in
   all case, thanks to a simple typecast when invoking the handler.
3) Greatly simplified the enproxy code by using a single mux,
   everywhere.

Tested:
a) A single mux is now used everywhere. If websockets are broken by
   the mux, the nassh tests fail. All tests are passing, and verified
   that with the typecast removed, the test hangs and eventually
   fails (retry strategy in trying to create a WebSocket, until it
   fails).
b) A variation of this PR has been running on our proxy for about
   a week for qualification purposes. I can see websockets via nassh
   and grafana working correctly.