### PR TITLE
gee: fix resurrection of deleted branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1864,15 +1864,18 @@ function gee__make_branch() {
   _checkout_or_die "${CURRENT_BRANCH}"
 
   local -a ARGS=( worktree add "${REPO_DIR}/${BRNAME}" )
-  if [[ -n "${SHA}" ]]; then
-    ARGS+=( "${SHA}" )
-  fi
   _git "${ARGS[@]}"
   _info "Created ${REPO_DIR}/${BRNAME}"
 
   _read_parents_file
   PARENTS["${BRNAME}"]="${CURRENT_BRANCH}"
   _write_parents_file
+
+  if [[ -n "${SHA}" ]]; then
+    _info "Setting HEAD of branch \"${BRNAME}\" to \"${SHA}\""
+    _checkout_or_die "${BRNAME}"
+    git reset --hard "${SHA}"
+  fi
 
   # If the user has created a branch whose name matches an
   # existing branch in their existing repo, pull those changes

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.14"
+readonly VERSION="0.2.15"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file


### PR DESCRIPTION
gee: fix resurrection of deleted branches

When the user says "gee rmbr foo", gee emits instructions for how to undo the
deletion of the branch, usually something like "gee make_branch foo <sha>".
Unfortunately, those instructions didn't work right, leaving the gee client in
a detached head state that was causing some gee operations to fail with fatal
errors.

This PR changes the behavior of "gee make_branch foo <sha>" to do what was
originally intended: it makes a new branch named "foo", and then resets the
HEAD ref of that branch to be <sha>.

Tested:
  1. Created a branch.
  2. Deleted that branch.
  3. Peformed branch necromancy using "gee mkbr".

PR generated by jonathan from branch gee_mkbr_sha.

