### PR TITLE
bestie: Remove Cloud Run support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-/bestie/ @minor-fixes @msgoldflam
+/bestie/ @minor-fixes @msgoldflam @gpaussaenf
 
 # Changes to //third_party must be done exclusively via Copybara for imported
 # files. Reviewers should ensure this is the case.

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -57,13 +57,3 @@ container_push(
     # TODO: Change this tag to "live"
     tag = "testing",
 )
-
-cloud_run_deploy(
-    name = "bestie_cloud_run_deploy",
-    access = "public",
-    image = "gcr.io/devops-284019/infra/bestie",
-    image_version = "testing",
-    project = "bestie-builds",
-    region = "us-west1",
-    service = "bestie",
-)

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
-load("//bazel/cloud_run:defs.bzl", "cloud_run_deploy")
 
 go_library(
     name = "go_default_library",

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/enfabrica/enkit/lib/server"
 	bes "github.com/enfabrica/enkit/third_party/bazel/buildeventstream" // Allows prototext to automatically decode embedded messages
-	"github.com/golang/protobuf/ptypes"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/grpc"
@@ -77,5 +77,5 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	server.CloudRun(mux, grpcs)
+	server.Run(mux, grpcs)
 }


### PR DESCRIPTION
This change modifies bestie to prepare it to run in k8s instead of Cloud
Run:
* Server is changed to the "normal" server rather than the one
  specifically for Cloud Run (which needed a different setup for
  proper HTTP/2 handling)
* Bazel rule to deploy to Cloud Run is removed

This change also adds Greg as a codeowner of bestie.

Tested:
* brought up server locally with `bazel run //bestie/server:bestie`
* Metrics endpoint is alive: `curl localhost:6433/metrics`
* Prints BES messages when pointing bazel at it with `bazel build
  //bestie/... --bes_backend=grpc://localhost:6433`

Jira: INFRA-436