### PR TITLE
machinist: add _info endpoint

### DIFF
--- a/machinist/mserver/controller.go
+++ b/machinist/mserver/controller.go
@@ -145,6 +145,7 @@ func (en *Controller) addNodeToDns(name string, ips []net.IP, tags []string) {
 
 // ServeAllAndInfoRecords will continuously poll Nodes() and create multiple _all.<domain> records containing the ip addresses
 // of all machines attached.
+// It also serves the current state of the dns server via the _info record.
 // TODO(adam): be able to pass in a wrapped ticker for testing intervals
 func (en *Controller) ServeAllAndInfoRecords(killChannel chan struct{}, killChannelAck chan struct{}) {
 	for {

--- a/machinist/mserver/mserver.go
+++ b/machinist/mserver/mserver.go
@@ -49,7 +49,7 @@ func (s *ControlPlane) Run() error {
 		s.killChannel <- s.Controller.dnsServer.Run()
 	}()
 	s.Controller.Init()
-	go s.Controller.ServeAllRecords(s.allRecordsKillChannel, s.allRecordsKillAckChannel)
+	go s.Controller.ServeAllAndInfoRecords(s.allRecordsKillChannel, s.allRecordsKillAckChannel)
 	go s.Controller.WriteState()
 	return grpcs.Serve(s.Listener)
 }

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -109,11 +109,16 @@ func TestJoinServerAndPoll(t *testing.T) {
 	allRecordsRes, err := customResolver.LookupHost(context.TODO(), "_all.enkitdev")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(allRecordsRes))
+
+	infoRecords, err := customResolver.LookupTXT(context.TODO(), "_info.enkitdev")
+	assert.NoError(t, err)
+	assert.Equal(t, len(infoRecords), 2)
+	assert.ElementsMatch(t, []string{"{name:test01,ip:10.0.0.4}", "{name:test02,ip:10.0.0.1}"}, infoRecords)
+
 	assert.Nil(t, s.Stop())
 	assert.Nil(t, lis.Close())
 	assert.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
 	time.Sleep(20 * time.Millisecond)
-
 	//Test serialization
 	dnsLis, customResolver = registerPort(t)
 	dnsAddr, err = dnsLis.Address()


### PR DESCRIPTION
Adds a feature where people can see what machines are currently in the dns server by calling the _info record 