### PR TITLE
Support for Bytestream Urls, Options and Url generation testing

### DIFF
--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -1,13 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "postsubmit_proto",
     srcs = ["postsubmit.proto"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "postsubmit_go_proto",
     importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
     proto = ":postsubmit_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":postsubmit_go_proto"],
+    importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
+    visibility = ["//visibility:public"],
 )

--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -1,23 +1,13 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "postsubmit_proto",
     srcs = ["postsubmit.proto"],
-    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "postsubmit_go_proto",
     importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
     proto = ":postsubmit_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "go_default_library",
-    embed = [":postsubmit_go_proto"],
-    importpath = "github.com/enfabrica/enkit/infra/postsubmit/proto",
-    visibility = ["//visibility:public"],
 )

--- a/lib/kbuildbarn/BUILD.bazel
+++ b/lib/kbuildbarn/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["urls.go"],
+    srcs = [
+        "options.go",
+        "urls.go",
+    ],
     importpath = "github.com/enfabrica/enkit/lib/kbuildbarn",
     visibility = ["//visibility:public"],
     deps = ["//lib/multierror:go_default_library"],

--- a/lib/kbuildbarn/BUILD.bazel
+++ b/lib/kbuildbarn/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["urls.go"],
+    importpath = "github.com/enfabrica/enkit/lib/kbuildbarn",
+    visibility = ["//visibility:public"],
+    deps = ["//lib/multierror:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["urls_test.go"],
+    deps = [
+        ":go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)

--- a/lib/kbuildbarn/README.md
+++ b/lib/kbuildbarn/README.md
@@ -1,0 +1,4 @@
+This package is designed for integration between buildbarn and other first party applications written in enkit.
+
+Buildbarn and other remote executors format their external tools around already defined .proto definitions. This library
+is designed to be configurable based on external templates.

--- a/lib/kbuildbarn/README.md
+++ b/lib/kbuildbarn/README.md
@@ -2,3 +2,17 @@ This package is designed for integration between buildbarn and other first party
 
 Buildbarn and other remote executors format their external tools around already defined .proto definitions. This library
 is designed to be configurable based on external templates.
+
+Examples:
+
+
+    MyApplication --buildbarn-dsn=http://foo.internal
+    Delivered: bytestream://127.0.0.1/blobs/curry/444
+    ====== 
+    hash, size, err := kbuildbarn.ByteStreamUrl("bytestream://127.0.0.1/blobs/curry/444")
+
+    bbparam := kbuildbarn.NewBuildBarnParams("http://foo.internal", "foo.bar", hash, size)
+    
+    ======
+    MyApplication.Upload(bbparams.FileUrl())
+

--- a/lib/kbuildbarn/README.md
+++ b/lib/kbuildbarn/README.md
@@ -11,7 +11,7 @@ Examples:
     ====== 
     hash, size, err := kbuildbarn.ByteStreamUrl("bytestream://127.0.0.1/blobs/curry/444")
 
-    bbparam := kbuildbarn.NewBuildBarnParams("http://foo.internal", "foo.bar", hash, size)
+    bbparam := kbuildbarn.NewBuildBarnParams("http://foo.internal", hash, size, kbuildbarn.WithFileName("foo.bar"))
     
     ======
     MyApplication.Upload(bbparams.FileUrl())

--- a/lib/kbuildbarn/options.go
+++ b/lib/kbuildbarn/options.go
@@ -2,7 +2,6 @@ package kbuildbarn
 
 type options struct {
 	Scheme string
-
 	FileName           string
 	ByteStreamTemplate string
 }

--- a/lib/kbuildbarn/options.go
+++ b/lib/kbuildbarn/options.go
@@ -1,0 +1,42 @@
+package kbuildbarn
+
+type options struct {
+	Scheme string
+
+	FileName           string
+	ByteStreamTemplate string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type schemeOption string
+
+func (so schemeOption) apply(opts *options) {
+	opts.Scheme = string(so)
+}
+
+func WithScheme(s string) Option {
+	return schemeOption(s)
+}
+
+type byteStreamTemplateOption string
+
+func (so byteStreamTemplateOption) apply(opts *options) {
+	opts.ByteStreamTemplate = string(so)
+}
+
+func WithByteStreamTemplate(s string) Option {
+	return byteStreamTemplateOption(s)
+}
+
+type fileNameOption string
+
+func (fno fileNameOption) apply(opts *options) {
+	opts.FileName = string(fno)
+}
+
+func WithFileName(s string) Option {
+	return fileNameOption(s)
+}

--- a/lib/kbuildbarn/urls.go
+++ b/lib/kbuildbarn/urls.go
@@ -1,0 +1,130 @@
+package kbuildbarn
+
+import (
+	"fmt"
+	"github.com/enfabrica/enkit/lib/multierror"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ByteStreamUrl retieves the CAS id and bytes of an action based on the input url.
+// For example, bytestream://build.local.enfabrica.net:8000/blobs/a9a664559b4d29ecb70613fad33acfb287f2fa378178e131feaaebb5dafa231a/465
+// should return (a9a664559b4d29ecb70613fad33acfb287f2fa378178e131feaaebb5dafa231a, 465, nil)
+// which is a BuildBarnParams.Hash, BuildBarnParams.Size, error.Error
+func ByteStreamUrl(byteStream string) (string, string, error) {
+	u, err := url.Parse(byteStream)
+	if err != nil {
+		return "", "", err
+	}
+	splitUrl := strings.Split(u.Path, "/")
+	if len(splitUrl) != 4 {
+		return "", "", fmt.Errorf("ByteStreamUrl() bytestream url is not well formed %s", byteStream)
+	}
+	return splitUrl[2], splitUrl[3], nil
+}
+
+// BuildBarnParams are the parameter necessary to reverse proxy to a bb_browser instance.
+type BuildBarnParams struct {
+	FileName     string
+	Hash         string
+	Size         string
+	InvocationID string
+
+	// This is the base Url
+	BaseUrl string
+	Scheme  string
+
+	// These are the default buildbarn templates for their different types inside the CAS
+	FileTemplate      string
+	ActionTemplate    string
+	CommandTemplate   string
+	DirectoryTemplate string
+}
+
+// the following default values are arbitrary, based on what current works with buildbarn
+var (
+	DefaultFileTemplate      = "/blobs/file/%s-%s/%s"
+	DefaultActionTemplate    = "/blobs/action/%s-%s/"
+	DefaultCommandTemplate   = "/blobs/command/%s-%s"
+	DefaultDirectoryTemplate = "/blobs/directory/%s-%s/"
+)
+
+func NewBuildBarnParams(baseUrl, fileName, hash, size string) *BuildBarnParams {
+	// These are prefilled defaults, we can change at will
+	return &BuildBarnParams{
+		Scheme:            "http",
+		FileName:          fileName,
+		BaseUrl:           baseUrl,
+		Hash:              hash,
+		Size:              size,
+		FileTemplate:      DefaultFileTemplate,
+		ActionTemplate:    DefaultActionTemplate,
+		CommandTemplate:   DefaultCommandTemplate,
+		DirectoryTemplate: DefaultDirectoryTemplate,
+	}
+}
+
+func performRequest(client *http.Client, url string) (io.ReadCloser, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+func (bbp BuildBarnParams) FileUrl() string {
+	u := &url.URL{
+		Scheme: bbp.Scheme,
+		Host:   bbp.BaseUrl,
+		Path:   fmt.Sprintf(bbp.FileTemplate, bbp.Hash, bbp.Size, bbp.FileName),
+	}
+	return u.String()
+}
+
+func (bbp BuildBarnParams) ActionUrl() string {
+	u := &url.URL{
+		Scheme: bbp.Scheme,
+		Host:   bbp.BaseUrl,
+		Path:   fmt.Sprintf(bbp.ActionTemplate, bbp.Hash, bbp.Size),
+	}
+	return u.String()
+}
+
+func (bbp BuildBarnParams) DirectoryUrl() string {
+	u := &url.URL{
+		Scheme: bbp.Scheme,
+		Host:   bbp.BaseUrl,
+		Path:   fmt.Sprintf(bbp.DirectoryTemplate, bbp.Hash, bbp.Size),
+	}
+	return u.String()
+}
+
+func (bbp BuildBarnParams) CommandUrl() string {
+	u := &url.URL{
+		Scheme: bbp.Scheme,
+		Host:   bbp.BaseUrl,
+		Path:   fmt.Sprintf(bbp.CommandTemplate, bbp.Hash, bbp.Size),
+	}
+	return u.String()
+}
+
+// RetryUntilSuccess just blasts through all possible urls until it hits one that works. This is intended for
+// applications that are blind to the type of artifact
+func RetryUntilSuccess(params BuildBarnParams) ([]byte, error) {
+	urls := []string{
+		params.FileUrl(), params.ActionUrl(), params.CommandUrl(), params.DirectoryUrl(),
+	}
+	var errs []error
+	for _, uri := range urls {
+		rc, err := performRequest(http.DefaultClient, uri)
+		if err != nil {
+			errs = append(errs)
+			continue
+		}
+		return ioutil.ReadAll(rc)
+	}
+	return nil, multierror.New(errs)
+}

--- a/lib/kbuildbarn/urls.go
+++ b/lib/kbuildbarn/urls.go
@@ -38,38 +38,49 @@ type BuildBarnParams struct {
 	Scheme  string
 
 	// These are the default buildbarn templates for their different types inside the CAS
-	ActionTemplate    string
-	CommandTemplate   string
-	DirectoryTemplate string
-	FileTemplate      string
+	ActionTemplate     string
+	CommandTemplate    string
+	DirectoryTemplate  string
+	FileTemplate       string
+	ByteStreamTemplate string
 }
 
 // the following default values are arbitrary, based on what current works with buildbarn
 var (
-	DefaultFileTemplate      = "/blobs/file/%s-%s/%s"
-	DefaultActionTemplate    = "/blobs/action/%s-%s/"
-	DefaultCommandTemplate   = "/blobs/command/%s-%s"
-	DefaultDirectoryTemplate = "/blobs/directory/%s-%s/"
+	DefaultFileTemplate       = "/blobs/file/%s-%s/%s"
+	DefaultActionTemplate     = "/blobs/action/%s-%s"
+	DefaultCommandTemplate    = "/blobs/command/%s-%s"
+	DefaultDirectoryTemplate  = "/blobs/directory/%s-%s"
+	DefaultByteStreamTemplate = "/blobs/%s/%s"
 )
 
 // NewBuildBarnParams generates a new Buildbarn url translator for other apis.
 // The intended use case is something like RetryUntilSuccess where:
 // The application retrieves a dead bytestream//: url, and extracts the artifact information from that using ByteStreamUrl
 // The external application can then use baseurl (which changes based on the location of the buildbarn instance),
-// fileName (which is optional) and the extracted hash and size to generate valid urls via BuildBarnParams.ActionUrl etc.
+// and the extracted hash and size to generate valid urls via BuildBarnParams.ActionUrl etc.
 // External applications can use them e.g. save the now valid urls; load balance onto the urls that are valid, etc.
-func NewBuildBarnParams(baseUrl, fileName, hash, size string) *BuildBarnParams {
+func NewBuildBarnParams(baseUrl, hash, size string, opts ...Option) *BuildBarnParams {
+	defaultOpts := options{
+		Scheme:             "http",
+		ByteStreamTemplate: DefaultByteStreamTemplate,
+		FileName:           "",
+	}
+	for _, o := range opts {
+		o.apply(&defaultOpts)
+	}
 	// These are prefilled defaults, we can change at will
 	return &BuildBarnParams{
-		Scheme:            "http",
-		FileName:          fileName,
-		BaseUrl:           baseUrl,
-		Hash:              hash,
-		Size:              size,
-		FileTemplate:      DefaultFileTemplate,
-		ActionTemplate:    DefaultActionTemplate,
-		CommandTemplate:   DefaultCommandTemplate,
-		DirectoryTemplate: DefaultDirectoryTemplate,
+		Scheme:             defaultOpts.Scheme,
+		FileName:           defaultOpts.FileName,
+		BaseUrl:            baseUrl,
+		Hash:               hash,
+		Size:               size,
+		FileTemplate:       DefaultFileTemplate,
+		ActionTemplate:     DefaultActionTemplate,
+		CommandTemplate:    DefaultCommandTemplate,
+		DirectoryTemplate:  DefaultDirectoryTemplate,
+		ByteStreamTemplate: defaultOpts.ByteStreamTemplate,
 	}
 }
 
@@ -113,6 +124,15 @@ func (bbp BuildBarnParams) CommandUrl() string {
 		Scheme: bbp.Scheme,
 		Host:   bbp.BaseUrl,
 		Path:   fmt.Sprintf(bbp.CommandTemplate, bbp.Hash, bbp.Size),
+	}
+	return u.String()
+}
+
+func (bbp BuildBarnParams) ByteStreamUrl() string {
+	u := &url.URL{
+		Scheme: bbp.Scheme,
+		Host:   bbp.BaseUrl,
+		Path:   fmt.Sprintf(bbp.ByteStreamTemplate, bbp.Hash, bbp.Size),
 	}
 	return u.String()
 }

--- a/lib/kbuildbarn/urls_test.go
+++ b/lib/kbuildbarn/urls_test.go
@@ -1,0 +1,66 @@
+package kbuildbarn_test
+
+import (
+	"github.com/enfabrica/enkit/lib/kbuildbarn"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+type BytStreamResult struct {
+	ShouldFail   bool
+	Url          string
+	ExpectedHash string
+	ExpectedSize string
+}
+
+var TestByteStreamUrlTable = []BytStreamResult{
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000/blobs/a9a664559b4d29ecb70613fad33acfb287f2fa378178e131feaaebb5dafa231a/465",
+		ShouldFail:   false,
+		ExpectedHash: "a9a664559b4d29ecb70613fad33acfb287f2fa378178e131feaaebb5dafa231a",
+		ExpectedSize: "465",
+	},
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000/a9a664559b4d29ecb70613fad33acfb287f2fa378178e131feaaebb5dafa231a/465",
+		ShouldFail:   true,
+		ExpectedHash: "",
+		ExpectedSize: "",
+	},
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar",
+		ShouldFail:   false,
+		ExpectedHash: "foo",
+		ExpectedSize: "bar",
+	},
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000",
+		ShouldFail:   true,
+		ExpectedHash: "",
+		ExpectedSize: "",
+	},
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000////",
+		ShouldFail:   true,
+		ExpectedHash: "",
+		ExpectedSize: "",
+	},
+	{
+		Url:          "bytestream://build.local.enfabrica.net:8000",
+		ShouldFail:   true,
+		ExpectedHash: "",
+		ExpectedSize: "",
+	},
+}
+
+func TestByteStreamUrl(t *testing.T) {
+	for _, c := range TestByteStreamUrlTable {
+		hash, size, err := kbuildbarn.ByteStreamUrl(c.Url)
+		if c.ShouldFail {
+			assert.Error(t, err)
+		}else {
+			assert.NoError(t, err)
+			assert.Equal(t, c.ExpectedHash, hash)
+			assert.Equal(t, c.ExpectedSize, size)
+		}
+	}
+}

--- a/lib/kbuildbarn/urls_test.go
+++ b/lib/kbuildbarn/urls_test.go
@@ -2,8 +2,8 @@ package kbuildbarn_test
 
 import (
 	"github.com/enfabrica/enkit/lib/kbuildbarn"
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 type BytStreamResult struct {
@@ -57,10 +57,37 @@ func TestByteStreamUrl(t *testing.T) {
 		hash, size, err := kbuildbarn.ByteStreamUrl(c.Url)
 		if c.ShouldFail {
 			assert.Error(t, err)
-		}else {
+		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, c.ExpectedHash, hash)
 			assert.Equal(t, c.ExpectedSize, size)
 		}
 	}
+}
+
+func TestDefaultUrlGeneration(t *testing.T) {
+	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
+	hash, size, err := kbuildbarn.ByteStreamUrl(exampleUrl)
+	assert.NoError(t, err)
+	defaultGenerator := kbuildbarn.NewBuildBarnParams("buildbarn.local", hash, size)
+	assert.Equal(t, "http://buildbarn.local/blobs/action/foo-bar", defaultGenerator.ActionUrl())
+	assert.Equal(t, "http://buildbarn.local/blobs/command/foo-bar", defaultGenerator.CommandUrl())
+	assert.Equal(t, "http://buildbarn.local/blobs/directory/foo-bar", defaultGenerator.DirectoryUrl())
+	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/", defaultGenerator.FileUrl())
+}
+
+func TestFileUrlGeneration(t *testing.T) {
+	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
+	hash, size, err := kbuildbarn.ByteStreamUrl(exampleUrl)
+	assert.NoError(t, err)
+	defaultGenerator := kbuildbarn.NewBuildBarnParams("buildbarn.local", hash, size, kbuildbarn.WithFileName("mickey.mouse"))
+	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/mickey.mouse", defaultGenerator.FileUrl())
+}
+func TestByteStreamGeneration(t *testing.T) {
+	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
+	hash, size, err := kbuildbarn.ByteStreamUrl(exampleUrl)
+	assert.NoError(t, err)
+	defaultGenerator := kbuildbarn.NewBuildBarnParams("buildbarn.local", hash, size,
+		kbuildbarn.WithScheme("bytestream"))
+	assert.Equal(t, "bytestream://buildbarn.local/blobs/foo/bar", defaultGenerator.ByteStreamUrl())
 }


### PR DESCRIPTION
Does the following:
- establishes the pattern to add functional, "optional" options
- adds in support and testing to generate bytestream urls.
- tests all url generation.