### PR TITLE
bes: Add library to fetch BES logs from BuildBuddy

### DIFF
--- a/flextape/service/BUILD.bazel
+++ b/flextape/service/BUILD.bazel
@@ -26,13 +26,12 @@ go_test(
     deps = [
         "//flextape/proto:go_default_library",
         "//lib/errdiff:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
+        "//lib/testutil:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_prashantv_gostub//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/flextape/service/service_test.go
+++ b/flextape/service/service_test.go
@@ -8,14 +8,13 @@ import (
 
 	fpb "github.com/enfabrica/enkit/flextape/proto"
 	"github.com/enfabrica/enkit/lib/errdiff"
+	"github.com/enfabrica/enkit/lib/testutil"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -54,14 +53,6 @@ func (s *Service) withAllocation(licenseType string, inv *invocation) *Service {
 func (s *Service) withQueued(licenseType string, inv *invocation) *Service {
 	s.licenses[licenseType].queue = append(s.licenses[licenseType].queue, inv)
 	return s
-}
-
-// assertProtoEqual fails a test with a descriptive diff if got != want.
-func assertProtoEqual(t *testing.T, got proto.Message, want proto.Message) {
-	t.Helper()
-	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-		t.Errorf("Proto messages do not match:\n%s\n", diff)
-	}
 }
 
 // assertCmp fails a test with a descriptive diff if got != want, respecting a
@@ -460,7 +451,7 @@ func TestAllocate(t *testing.T) {
 			if gotErr != nil {
 				return
 			}
-			assertProtoEqual(t, tc.want, got)
+			testutil.AssertProtoEqual(t, tc.want, got)
 		})
 	}
 }
@@ -701,7 +692,7 @@ func TestRefresh(t *testing.T) {
 			if gotErr != nil {
 				return
 			}
-			assertProtoEqual(t, tc.want, got)
+			testutil.AssertProtoEqual(t, tc.want, got)
 		})
 	}
 }
@@ -841,7 +832,7 @@ func TestRelease(t *testing.T) {
 			if gotErr != nil {
 				return
 			}
-			assertProtoEqual(t, tc.want, got)
+			testutil.AssertProtoEqual(t, tc.want, got)
 		})
 	}
 }
@@ -942,7 +933,7 @@ func TestLicensesStatus(t *testing.T) {
 			if gotErr != nil {
 				return
 			}
-			assertProtoEqual(t, tc.want, got)
+			testutil.AssertProtoEqual(t, tc.want, got)
 		})
 	}
 }

--- a/lib/bes/BUILD.bazel
+++ b/lib/bes/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["buildbuddy.go"],
+    importpath = "github.com/enfabrica/enkit/lib/bes",
+    visibility = ["//bes_log_fetcher:__pkg__"],
+    deps = [
+        "//lib/client:go_default_library",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+        "//third_party/buildbuddy/proto:buildbuddy_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["buildbuddy_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//lib/errdiff:go_default_library",
+        "//lib/testutil:go_default_library",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+        "//third_party/buildbuddy/proto:buildbuddy_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/lib/bes/buildbuddy.go
+++ b/lib/bes/buildbuddy.go
@@ -1,0 +1,140 @@
+package bes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+
+	"github.com/enfabrica/enkit/lib/client"
+	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
+	bbpb "github.com/enfabrica/enkit/third_party/buildbuddy/proto"
+
+	"github.com/golang/protobuf/proto"
+)
+
+var (
+	BuildBuddyProdURL    = mustParseURL("https://buddy.bazel.corp.enfabrica.net")
+	BuildBuddyStagingURL = mustParseURL("https://buddy.staging-bazel.corp.enfabrica.net")
+
+	getInvocationEndpoint = mustParseURL("rpc/BuildBuddyService/GetInvocation")
+)
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type BuildBuddyClient struct {
+	baseEndpoint *url.URL
+	httpClient   httpDoer
+	apiKey       string
+}
+
+// NewBuildBuddyClient creates a client for the BuildBuddy instance at the
+// specified URL. If not nil, auth cookies are discovered via BaseFlags and
+// added to every request. apiKey must be a valid BuildBuddy API key (other
+// forms of auth are not currently supported).
+func NewBuildBuddyClient(u *url.URL, bf *client.BaseFlags, apiKey string) (*BuildBuddyClient, error) {
+	var jar http.CookieJar
+	if bf != nil {
+		_, cookie, err := bf.IdentityCookie()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load identity cookie: %w", err)
+		}
+
+		jar, err = cookiejar.New(nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cookiejar: %w", err)
+		}
+		jar.SetCookies(u, []*http.Cookie{cookie})
+	}
+
+	httpClient := &http.Client{Jar: jar}
+	return &BuildBuddyClient{
+		baseEndpoint: u,
+		httpClient:   httpClient,
+		apiKey:       apiKey,
+	}, nil
+}
+
+// GetBuildEvents fetches all BES events from the specified invocation by ID. It
+// returns an error if the call fails or exactly one invocation is not returned
+// for the specified ID.
+func (c *BuildBuddyClient) GetBuildEvents(ctx context.Context, invocationId string) ([]*bespb.BuildEvent, error) {
+	reqBody := &bbpb.GetInvocationRequest{
+		Lookup: &bbpb.InvocationLookup{
+			InvocationId: invocationId,
+		},
+	}
+	resBody := &bbpb.GetInvocationResponse{}
+	err := c.doAPICall(ctx, getInvocationEndpoint, reqBody, resBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resBody.Invocation) != 1 {
+		return nil, fmt.Errorf("query by invocation_id returned %d results; want 1", len(resBody.Invocation))
+	}
+
+	var events []*bespb.BuildEvent
+	for _, event := range resBody.Invocation[0].Event {
+		events = append(events, event.BuildEvent)
+	}
+
+	return events, nil
+}
+
+// doAPICall performs a call at the specified input, marshaling `req` to binary
+// proto and unmarshaling the response into `res`.
+func (c *BuildBuddyClient) doAPICall(ctx context.Context, endpoint *url.URL, req proto.Message, res proto.Message) error {
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request to protobuf: %w", err)
+	}
+
+	r, err := http.NewRequestWithContext(
+		ctx,
+		"POST",
+		c.baseEndpoint.ResolveReference(getInvocationEndpoint).String(),
+		bytes.NewReader(reqBytes),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	r.Header.Add("x-buildbuddy-api-key", c.apiKey)
+	r.Header.Add("Content-Type", "application/protobuf")
+
+	httpRes, err := c.httpClient.Do(r)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer httpRes.Body.Close()
+	resBodyBytes, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return fmt.Errorf("error reading body: %w", err)
+	}
+
+	if httpRes.StatusCode < 200 || httpRes.StatusCode > 299 {
+		return fmt.Errorf("HTTP response %d: %s", httpRes.StatusCode, resBodyBytes)
+	}
+
+	if err := proto.Unmarshal(resBodyBytes, res); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return nil
+}
+
+// mustParseURL parses a string to a URL, panicking on failure. This function
+// should only be called with hard-coded strings, preferably only during
+// initialization.
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("URL parse failure for %q: %v\n NOTE: mustParseURL() should only be called with hard-coded strings", s, err))
+	}
+	return u
+}

--- a/lib/bes/buildbuddy.go
+++ b/lib/bes/buildbuddy.go
@@ -17,9 +17,6 @@ import (
 )
 
 var (
-	BuildBuddyProdURL    = mustParseURL("https://buddy.bazel.corp.enfabrica.net")
-	BuildBuddyStagingURL = mustParseURL("https://buddy.staging-bazel.corp.enfabrica.net")
-
 	getInvocationEndpoint = mustParseURL("rpc/BuildBuddyService/GetInvocation")
 )
 

--- a/lib/bes/buildbuddy_test.go
+++ b/lib/bes/buildbuddy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/enfabrica/enkit/lib/errdiff"
@@ -152,7 +153,7 @@ func TestGetBuildEvents(t *testing.T) {
 			ctx := context.Background()
 			testClient := newTestHttpClient(t, tc.resCode, tc.response)
 			buildBuddy := &BuildBuddyClient{
-				baseEndpoint: BuildBuddyStagingURL,
+				baseEndpoint: &url.URL{},
 				httpClient:   testClient,
 				apiKey:       "foobar",
 			}

--- a/lib/bes/buildbuddy_test.go
+++ b/lib/bes/buildbuddy_test.go
@@ -1,0 +1,168 @@
+package bes
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/enfabrica/enkit/lib/errdiff"
+	"github.com/enfabrica/enkit/lib/testutil"
+	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
+	bbpb "github.com/enfabrica/enkit/third_party/buildbuddy/proto"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type testHttpClient struct {
+	cannedResponse *http.Response
+}
+
+func newTestHttpClient(t *testing.T, code int, res proto.Message) *testHttpClient {
+	t.Helper()
+	if code == 0 {
+		code = 200
+	}
+	msg, err := proto.Marshal(res)
+	if err != nil {
+		t.Fatalf("failed to marshal proto: %w", err)
+	}
+	b := bytes.NewBuffer(msg)
+	return &testHttpClient{
+		cannedResponse: &http.Response{
+			Body:       io.NopCloser(b),
+			StatusCode: code,
+		},
+	}
+}
+
+func (c *testHttpClient) Do(req *http.Request) (*http.Response, error) {
+	return c.cannedResponse, nil
+}
+
+func TestGetBuildEvents(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		invocationID string
+		resCode      int
+		response     *bbpb.GetInvocationResponse
+		wantEvents   []*bespb.BuildEvent
+		wantErr      string
+	}{
+		{
+			desc:         "one invocation returned",
+			invocationID: "180c8fc1-bfe1-444e-a00c-2d53768125b0",
+			response: &bbpb.GetInvocationResponse{
+				Invocation: []*bbpb.Invocation{
+					&bbpb.Invocation{
+						Event: []*bbpb.InvocationEvent{
+							&bbpb.InvocationEvent{
+								BuildEvent: &bespb.BuildEvent{
+									Id: &bespb.BuildEventId{
+										Id: &bespb.BuildEventId_Started{
+											Started: &bespb.BuildEventId_BuildStartedId{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantEvents: []*bespb.BuildEvent{
+				&bespb.BuildEvent{
+					Id: &bespb.BuildEventId{
+						Id: &bespb.BuildEventId_Started{
+							Started: &bespb.BuildEventId_BuildStartedId{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:         "zero invocations returned",
+			invocationID: "180c8fc1-bfe1-444e-a00c-2d53768125b0",
+			response: &bbpb.GetInvocationResponse{
+				Invocation: []*bbpb.Invocation{},
+			},
+			wantErr: "returned 0 results",
+		},
+		{
+			desc:         "two invocations returned",
+			invocationID: "180c8fc1-bfe1-444e-a00c-2d53768125b0",
+			response: &bbpb.GetInvocationResponse{
+				Invocation: []*bbpb.Invocation{
+					&bbpb.Invocation{
+						Event: []*bbpb.InvocationEvent{
+							&bbpb.InvocationEvent{
+								BuildEvent: &bespb.BuildEvent{
+									Id: &bespb.BuildEventId{
+										Id: &bespb.BuildEventId_Started{
+											Started: &bespb.BuildEventId_BuildStartedId{},
+										},
+									},
+								},
+							},
+						},
+					},
+					&bbpb.Invocation{
+						Event: []*bbpb.InvocationEvent{
+							&bbpb.InvocationEvent{
+								BuildEvent: &bespb.BuildEvent{
+									Id: &bespb.BuildEventId{
+										Id: &bespb.BuildEventId_Started{
+											Started: &bespb.BuildEventId_BuildStartedId{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "returned 2 results",
+		},
+		{
+			desc:         "HTTP error",
+			invocationID: "180c8fc1-bfe1-444e-a00c-2d53768125b0",
+			response: &bbpb.GetInvocationResponse{
+				Invocation: []*bbpb.Invocation{
+					&bbpb.Invocation{
+						Event: []*bbpb.InvocationEvent{
+							&bbpb.InvocationEvent{
+								BuildEvent: &bespb.BuildEvent{
+									Id: &bespb.BuildEventId{
+										Id: &bespb.BuildEventId_Started{
+											Started: &bespb.BuildEventId_BuildStartedId{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			resCode: 500,
+			wantErr: "HTTP response 500",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			testClient := newTestHttpClient(t, tc.resCode, tc.response)
+			buildBuddy := &BuildBuddyClient{
+				baseEndpoint: BuildBuddyStagingURL,
+				httpClient:   testClient,
+				apiKey:       "foobar",
+			}
+
+			got, gotErr := buildBuddy.GetBuildEvents(ctx, tc.invocationID)
+			errdiff.Check(t, gotErr, tc.wantErr)
+			if gotErr != nil {
+				return
+			}
+			testutil.AssertProtoEqual(t, got, tc.wantEvents)
+		})
+	}
+}

--- a/lib/knetwork/echo/BUILD.bazel
+++ b/lib/knetwork/echo/BUILD.bazel
@@ -2,8 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["echo.go"],
     testonly = True,
+    srcs = ["echo.go"],
     importpath = "github.com/enfabrica/enkit/lib/knetwork/echo",
     visibility = ["//visibility:public"],
 )

--- a/lib/testutil/BUILD.bazel
+++ b/lib/testutil/BUILD.bazel
@@ -3,8 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     testonly = True,
-    srcs = ["fs.go"],
+    srcs = [
+        "assert.go",
+        "fs.go",
+    ],
     importpath = "github.com/enfabrica/enkit/lib/testutil",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_psanford_memfs//:go_default_library"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_psanford_memfs//:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+    ],
 )

--- a/lib/testutil/assert.go
+++ b/lib/testutil/assert.go
@@ -1,0 +1,15 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func AssertProtoEqual(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("Proto messages do not match:\n%s\n", diff)
+	}
+}

--- a/lib/token/BUILD.bazel
+++ b/lib/token/BUILD.bazel
@@ -29,5 +29,8 @@ go_test(
         "token_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+    deps = [
+        "//lib/config/marshal:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )


### PR DESCRIPTION
This change adds a simple BuildBuddy HTTP-based client with a method
that can fetch all BES events for a particular invocation ID.

`assertProtoEqual` test helper method moves out of flextape tests to the
`testutil` package so it can be shared by package `bes`'s tests.

Jira: INFRA-468