### PR TITLE
Bazel FUSE: Add enkit commands

### DIFF
--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//astore/client/commands:go_default_library",
+        "//enkit/outputs:go_default_library",
         "//lib/bazel/commands:go_default_library",
         "//lib/client:go_default_library",
         "//lib/client/commands:go_default_library",

--- a/enkit/main.go
+++ b/enkit/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/enfabrica/enkit/lib/client"
 	"github.com/enfabrica/enkit/proxy/enfuse/fusecmd"
 
 	acommands "github.com/enfabrica/enkit/astore/client/commands"
+	ocommands "github.com/enfabrica/enkit/enkit/outputs"
 	bazelcmds "github.com/enfabrica/enkit/lib/bazel/commands"
 	bcommands "github.com/enfabrica/enkit/lib/client/commands"
 	tcommands "github.com/enfabrica/enkit/proxy/ptunnel/commands"
@@ -49,7 +53,18 @@ func main() {
 	bazel := bazelcmds.New(base)
 	root.AddCommand(bazel.Command)
 
+	outputs, err := ocommands.New(base)
+	exitIf(err)
+	root.AddCommand(outputs.Command)
+
 	root.AddCommand(fusecmd.New())
 
 	base.Run(kcobra.HideFlags(set), populator, runner)
+}
+
+func exitIf(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 }

--- a/enkit/outputs/BUILD.bazel
+++ b/enkit/outputs/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["commands.go"],
+    importpath = "github.com/enfabrica/enkit/enkit/outputs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/client:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -174,7 +174,7 @@ func NewShutdown(root *Root) *Shutdown {
 			Use:   "shutdown",
 			Short: "Unmount all builds under particular directory",
 			Example: `  $ enkit outputs shutdown
-	Unmounts bb_clientd, and deletes all links to build artifacts.`,
+	Unmounts all builds in the given output root and resets the output root to a pristine state.`,
 		},
 		root: root,
 	}

--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -1,0 +1,187 @@
+package outputs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/enfabrica/enkit/lib/client"
+	"github.com/spf13/cobra"
+)
+
+type Root struct {
+	*cobra.Command
+	*client.BaseFlags
+
+	OutputsRoot string
+}
+
+func New(base *client.BaseFlags) (*Root, error) {
+	root, err := NewRoot(base)
+	if err != nil {
+		return nil, err
+	}
+
+	root.AddCommand(NewMount(root).Command)
+	root.AddCommand(NewUnmount(root).Command)
+	root.AddCommand(NewRun(root).Command)
+	root.AddCommand(NewShutdown(root).Command)
+
+	return root, nil
+}
+
+func NewRoot(base *client.BaseFlags) (*Root, error) {
+	rc := &Root{
+		Command: &cobra.Command{
+			Use:           "outputs",
+			Short:         "Commands for mounting remotely-built Bazel outputs",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			Long:          `outputs - commands for mounting remotely-built Bazel outputs`,
+		},
+		BaseFlags: base,
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect $HOME: %w", err)
+	}
+	defaultOutputsRoot := filepath.Join(homeDir, "outputs")
+
+	rc.PersistentFlags().StringVar(&rc.OutputsRoot, "outputs_root", defaultOutputsRoot, "Root dir of mounted outputs")
+	return rc, nil
+}
+
+type Mount struct {
+	*cobra.Command
+	root *Root
+}
+
+func NewMount(root *Root) *Mount {
+	command := &Mount{
+		Command: &cobra.Command{
+			Use:   "mount [invocation ID]",
+			Short: "Mount the build outputs of a particular invocation",
+			Example: `  $ enkit outputs mount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
+	Mounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 to the
+	default location.`,
+			Args: cobra.ExactArgs(1),
+		},
+		root: root,
+	}
+	command.Command.RunE = command.Run
+	return command
+}
+
+func (c *Mount) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("`enkit outputs mount` is unimplemented")
+}
+
+type Unmount struct {
+	*cobra.Command
+	root *Root
+}
+
+func NewUnmount(root *Root) *Unmount {
+	command := &Unmount{
+		Command: &cobra.Command{
+			Use:   "unmount [invocation ID]",
+			Short: "Unmount the build outputs of a particular invocation",
+			Example: `  $ enkit outputs unmount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
+	Unmounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 from the
+	default location.`,
+			Aliases: []string{"umount"},
+			Args:    cobra.ExactArgs(1),
+		},
+		root: root,
+	}
+	command.Command.RunE = command.Run
+	return command
+}
+
+func (c *Unmount) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("`enkit outputs unmount` is unimplemented")
+}
+
+type Run struct {
+	*cobra.Command
+	root *Root
+
+	InvocationID string
+	DirPath      string
+	ZipPath      string
+}
+
+func NewRun(root *Root) *Run {
+	command := &Run{
+		Command: &cobra.Command{
+			Use:   "run",
+			Short: "Mount build artifacts and execute an optional command on them",
+			Example: `  $ enkit outputs run --invocation=73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
+	Launches a shell with build outputs from a particular build re-rooted so that
+	paths are correct within the outputs themselves.
+
+  $ enkit outputs run --dir=/tmp/some_dir
+	Launches a shell with build outputs in /tmp/some_dir re-rooted so that paths
+	are correct within the outputs themselves.
+
+  $ enkit outputs run --zip=/tmp/some.zip
+	Unpacks the named zip into a tempdir, and then reroots the artifacts so that
+	paths are correct within the outputs themselves.
+
+  $ enkit outputs run --zip=/tmp/some-zip -- find .
+	Runs "find ." in the unpacked zip after it is rerooted.`,
+		},
+		root: root,
+	}
+
+	command.Command.RunE = command.Run
+	command.Command.PreRunE = command.validate
+	command.Flags().StringVar(&command.InvocationID, "invocation_id", "", "If set, the build's invocation ID from which to mount artifacts")
+	command.Flags().StringVar(&command.DirPath, "dir_path", "", "If set, the path to already-unpacked artifacts to reroot")
+	command.Flags().StringVar(&command.ZipPath, "zip_path", "", "If set, the path to a zipped outputs file to unpack and re-root")
+	return command
+}
+
+func (c *Run) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("`enkit outputs run` is unimplemented")
+}
+
+func (c *Run) validate(cmd *cobra.Command, args []string) error {
+	setCount := 0
+	for _, f := range []string{c.InvocationID, c.DirPath, c.ZipPath} {
+		if f != "" {
+			setCount++
+		}
+	}
+	switch {
+	case setCount == 0:
+		return fmt.Errorf("One of --invocation_id, --dir_path, --zip_path must be set")
+	case setCount >= 2:
+		return fmt.Errorf("Only one of --invocation_id, --dir_path, --zip_path may be set")
+	}
+	return nil
+}
+
+type Shutdown struct {
+	*cobra.Command
+	root *Root
+}
+
+func NewShutdown(root *Root) *Shutdown {
+	command := &Shutdown{
+		Command: &cobra.Command{
+			Use:   "shutdown",
+			Short: "Unmount all builds under particular directory",
+			Example: `  $ enkit outputs shutdown
+	Unmounts bb_clientd, and deletes all links to build artifacts.`,
+		},
+		root: root,
+	}
+	command.Command.RunE = command.Run
+	return command
+}
+
+func (c *Shutdown) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("`enkit outputs Shutdown` is unimplemented")
+}


### PR DESCRIPTION
This change adds enkit subcommands for bazel artifacts mounting, as laid
out in
https://docs.google.com/document/d/1L9skX1BKY-AZ15GVypQWxiy360UkUo5mNXglC9vvO9g/edit#.

These commands will need to tie together functionality from faketree,
bb_clientd management, and zipfile/tempdir management, so unlike other
enkit subcommand trees there is no pre-existing logical source location
to put the commands themselves. For now, they are added as a package
under `enkit` itself.

Tested: Output for help of each command:

`enkit outputs mount`:

```
Mount the build outputs of a particular invocation

Usage:
  enkit outputs mount [invocation ID] [flags]

Examples:
  $ enkit outputs mount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
        Mounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 to the
        default location.

Flags:
  -h, --help   help for mount

Global Flags:
      --help-all              Show all the flags available, even those that are less useful and normally hidden.
      --outputs_root string   Root dir of mounted outputs (default "/home/bminor/outputs")
```

`enkit outputs unmount`:

```
Unmount the build outputs of a particular invocation

Usage:
  enkit outputs unmount [invocation ID] [flags]

Aliases:
  unmount, umount

Examples:
  $ enkit outputs unmount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
        Unmounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 from the
        default location.

Flags:
  -h, --help   help for unmount

Global Flags:
      --help-all              Show all the flags available, even those that are less useful and normally hidden.
      --outputs_root string   Root dir of mounted outputs (default "/home/bminor/outputs")
```

`enkit outputs run`:

```
Mount build artifacts and execute an optional command on them

Usage:
  enkit outputs run [flags]

Examples:
  $ enkit outputs run --invocation=73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
        Launches a shell with build outputs from a particular build re-rooted so that
        paths are correct within the outputs themselves.

  $ enkit outputs run --dir=/tmp/some_dir
        Launches a shell with build outputs in /tmp/some_dir re-rooted so that paths
        are correct within the outputs themselves.

  $ enkit outputs run --zip=/tmp/some.zip
        Unpacks the named zip into a tempdir, and then reroots the artifacts so that
        paths are correct within the outputs themselves.

  $ enkit outputs run --zip=/tmp/some-zip -- find .
        Runs "find ." in the unpacked zip after it is rerooted.

Flags:
      --dir_path string        If set, the path to already-unpacked artifacts to reroot
  -h, --help                   help for run
      --invocation_id string   If set, the build's invocation ID from which to mount artifacts
      --zip_path string        If set, the path to a zipped outputs file to unpack and re-root

Global Flags:
      --help-all              Show all the flags available, even those that are less useful and normally hidden.
      --outputs_root string   Root dir of mounted outputs (default "/home/bminor/outputs")
```

`enkit outputs shutdown`:

```
Unmount all builds under particular directory

Usage:
  enkit outputs shutdown [flags]

Examples:
  $ enkit outputs shutdown
        Unmounts all builds in the given output root and resets the output root to a pristine state.

Flags:
  -h, --help   help for shutdown

Global Flags:
      --help-all              Show all the flags available, even those that are less useful and normally hidden.
      --outputs_root string   Root dir of mounted outputs (default "/home/bminor/outputs")
```

Jira: INFRA-469
Jira: INFRA-488