### PR TITLE
bazel/bats: configure it in a way so it is usable from other repos.

### DIFF
--- a/bazel/dependencies/BUILD.bats.bazel
+++ b/bazel/dependencies/BUILD.bats.bazel
@@ -13,6 +13,7 @@ sh_binary(
         ":bats_lib",
         "@bats_assert//:bats_assert_lib",
         "@bats_support//:bats_support_lib",
+        "@bats_file//:bats_file_lib",
     ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/dependencies/BUILD.bats_file.bazel
+++ b/bazel/dependencies/BUILD.bats_file.bazel
@@ -1,0 +1,5 @@
+sh_library(
+    name = "bats_file_lib",
+    srcs = ["load.bash"] + glob(["src/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -46,7 +46,7 @@ def enkit_deps():
             name = "bats_support",
             url = "https://github.com/bats-core/bats-support/archive/refs/tags/v0.3.0.tar.gz",
             strip_prefix = "bats-support-0.3.0",
-            build_file = "@//bazel/dependencies:BUILD.bats_support.bazel",
+            build_file = "@enkit//bazel/dependencies:BUILD.bats_support.bazel",
             sha256 = "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
         )
 
@@ -54,7 +54,7 @@ def enkit_deps():
             name = "bats_assert",
             url = "https://github.com/bats-core/bats-assert/archive/refs/tags/v2.0.0.tar.gz",
             strip_prefix = "bats-assert-2.0.0",
-            build_file = "@//bazel/dependencies:BUILD.bats_assert.bazel",
+            build_file = "@enkit//bazel/dependencies:BUILD.bats_assert.bazel",
             sha256 = "15dbf1abb98db785323b9327c86ee2b3114541fe5aa150c410a1632ec06d9903",
         )
 
@@ -62,8 +62,15 @@ def enkit_deps():
             name = "bats_core",
             url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.4.1.tar.gz",
             strip_prefix = "bats-core-1.4.1",
-            build_file = "@//bazel/dependencies:BUILD.bats.bazel",
+            build_file = "@enkit//bazel/dependencies:BUILD.bats.bazel",
             sha256 = "bff517da043ae24440ec8272039f396c2a7907076ac67693c0f18d4a17c08f7d",
+        )
+        http_archive(
+            name = "bats_file",
+            url = "https://github.com/bats-core/bats-file/archive/refs/tags/v0.2.0.tar.gz",
+            strip_prefix = "bats-file-0.2.0",
+            build_file = "@enkit//bazel/dependencies:BUILD.bats_file.bazel",
+            sha256 = "1fa26407a68f4517cf9150d4763779ee66946a68eded33fa182ddf6a795c5062",
         )
 
     # rules_docker 0.14.4 is incompatible with rules_pkg 0.3.0 as of Oct/2020.


### PR DESCRIPTION
Background:
bats is a unit testing framework for shell scripts.
When using @// syntax to refer to a file, it always refers to the
current workspace. Eg, if the defs.bzl is invoked from a repository
by a namespace called internal, @// will refer to "internal".

In this change:
- use @enkit - so the BUILD.*.bazel files can be used from other
  repositories without copying them.
- import bats_file library, so we have the full set of tools.