### PR TITLE
proxy/nasshp: ensure the tunnel never blocks.

### DIFF
--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "blocking_test.go",
         "nassh_test.go",
         "window_test.go",
     ],

--- a/proxy/nasshp/blocking_test.go
+++ b/proxy/nasshp/blocking_test.go
@@ -1,0 +1,78 @@
+package nasshp
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
+)
+
+func ExampleWaiter() {
+	lock := &sync.Mutex{}
+	waiter := NewWaiter(lock)
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	counter := 0
+	// Produces events: increments counter.
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(10 * time.Millisecond)
+			lock.Lock()
+			counter += 1
+			waiter.Signal()
+			lock.Unlock()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		lock.Lock()
+		defer lock.Unlock()
+		for counter < 10 {
+			waiter.Wait()
+		}
+		fmt.Println("counter is now >= 10")
+		wg.Done()
+	}()
+	wg.Wait()
+	// Output: counter is now >= 10
+}
+
+func TestWaiterFail(t *testing.T) {
+	lock := &sync.Mutex{}
+	waiter := NewWaiter(lock)
+
+	// It is safe to fail multiple times.
+	// (could happen from separate threads).
+	waiter.Fail(errors.New("test error"))
+	waiter.Fail(errors.New("second error"))
+}
+
+func TestWaiterBasic(t *testing.T) {
+	lock := &sync.Mutex{}
+	waiter := NewWaiter(lock)
+	counter := 0
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(50 * time.Millisecond)
+
+			lock.Lock()
+			counter += 1
+			lock.Unlock()
+
+			waiter.Signal()
+		}
+	}()
+
+	lock.Lock()
+	defer lock.Unlock()
+	for counter < 10 {
+		e := waiter.Wait()
+		assert.NoError(t, e)
+	}
+	assert.Equal(t, 10, counter)
+}


### PR DESCRIPTION
Background:
tunnel users will block waiting for data to arrive or for space in buffers.
When new data arrives, or when more space becomes available, those clients
need to be woken up and signaled. This is implemented using the Waiter()
class in this file.

This PR introduces 3 changes:

1) Wake up clients more aggressively. Specifically, it may be viable to
   empty more of the buffer on reset (buffer can be rewind), and there
   may be more space to fill after... data has been removed.

2) Don't close the channel on Fail. closing channels in go is optional,
   the garbage collector can entirely take care of that. But once a channel
   is closed.. closing it again, or writing on it, will result in panic.

   This made writing code calling Close() extremely fragile and very
   hard to get right, as it required strict coordination on which goroutine
   and consumer of the window would close the channel.

   This PR replaces the close() call with a simple notification, so
   the consumer of the notification is still woken up, and let's the
   golang garbage collection deal with the channel.

3) Check for errors queued before Wait(), as the error may invalidate
   the need to sleep, and the other thread may not try to signal us
   again once a failure has been reported.

A simple unit test was added. Note that the end to end test in
the PR I'm about to send also detects stalls here.