### PR TITLE
proxy/nasshp: make the code race free.

### DIFF
--- a/proxy/nasshp/browser.go
+++ b/proxy/nasshp/browser.go
@@ -22,9 +22,9 @@ type ReplaceableBrowser struct {
 	log logger.Logger
 
 	notifier chan error
+
 	wc       *websocket.Conn  // Protected by lock.
 	err      error            // Protected by lock.
-
 	lock sync.RWMutex
 	cond *sync.Cond
 


### PR DESCRIPTION
Background:
go support a great race detector. By turning on the race detector
for all the tests in proxy/, it detected a couple issues in browser.go.

This PR:
- addresses all detected races in the proxy/ codebase, by changing
  rack/wack variables to use atomics, which was the initial intent
  when the code was written.

Tested:
Before this change, running the tests for enproxy with the race
detector on reported problems in browser.go. After this change,
no races are detected.