### PR TITLE
proxy/nasshp: correctly handle close request.

### DIFF
--- a/proxy/nasshp/browser.go
+++ b/proxy/nasshp/browser.go
@@ -99,6 +99,10 @@ type TerminatingError struct {
 	error
 }
 
+func (te *TerminatingError) Unwrap() error {
+	return te.error
+}
+
 func (gb *ReplaceableBrowser) Close(err error) {
 	gb.lock.Lock() // This is an exclusive write lock.
 	defer gb.lock.Unlock()


### PR DESCRIPTION
Background:
The API allows users of ptunnel to, well, close the tunnel when desired.
In the current implementaion if a tunnel is closed without error,
the library will keep trying to connect anyway.

In this PR:
- make sure errors are propagated correctly, implement Unwrap in one
  of the internal error types.
- have a well defined error returned by close, so the rest of the
  code can do the right thing.

Tested:
end to end test (in another PR) does not timeout, Close() results in clean
shut down.