### PR TITLE
proxy/nasshp: fix incorrect resume under very specific conditions.

### DIFF
--- a/proxy/nasshp/window.go
+++ b/proxy/nasshp/window.go
@@ -290,9 +290,9 @@ func (w *SendWindow) Reset(trunc uint32) error {
 		return fmt.Errorf("invalid ack, requires going before last ack, for which we have no buffer (ack: %d, acked: %d)", value, w.acknowledged)
 	}
 	w.Acknowledge(int(value - w.acknowledged))
-	w.buffer.InsertListBefore(w.buffer.First(), &w.pending)
 
-	w.buffer.Last().offset = 0
+	w.buffer.First().offset = 0
+	w.buffer.InsertListBefore(w.buffer.First(), &w.pending)
 	w.buffer.First().offset = w.buffer.First().acknowledged
 
 	w.Emptied = w.acknowledged
@@ -401,6 +401,10 @@ func (w *ReceiveWindow) Fill(size int) uint64 {
 
 func (w *ReceiveWindow) ToEmpty() []byte {
 	first := w.buffer.First()
+	if w.reset != 0  && first.next == w.buffer.End() {
+		return nil
+	}
+
 	data := first.data[first.offset:]
 	if len(data) == 0 && first.next != w.buffer.End() {
 		w.pool.Put(w.buffer.Drop(first))


### PR DESCRIPTION
Background:
During latest rounds of testing, I noticed that during some rarer
error conditions and resumes, the connection would contain corrupted data.

This PR fixes those problems.

Specifically:
- "buffer" represents all data buffered. "pending" data still to
  acknowledge. "offset" indicates parts of the data that has already
  been consumed ("emptied") from the buffer.

  When a reset is received "rewinding" the connection, some data
  is "unemptied" - eg, the cursor can move back. This generally
  causes "pending" data to become "buffer" data again, and well,
  causes the "offset" counter to be moved back.

  The old code assumed that it was the _last_ buffer that had
  an offset to be zeroed/decremented, which is incorrect.
  Data is always emptied/consumed from the _first_ buffer.

  The code above worked just well for as long as the distance
  between reset was small (within the same buffer) or we only
  had one buffer ahead. The fix in the PR makes it work no
  matter how far buffer/pending and reset are.

- when emptying a receive window, the window may have been
  reset and be in a state where data received is discarded
  as it was already processed. Discarding is implemented
  by continuously overwriting the last buffer in the window.

  With the previous code, if the consumer of the data moved
  fast enough and reached the end of the window before
  the recovery completed, it could end up seeing some of this
  data, as ToEmpty() happily returned it.

  The fix in the PR makes it so this data is guaranteed
  invisible to callers of ToEmpty.

Tested:
the files changed have quite extensive coverage, tests were
still passing before sending this PR. A dedicated unit test
would be needed to trigger both conditions, but for now the
end to end test (in dedicated PR) is catching the errors here.