### PR TITLE
proxy/amux: handle domains with trailing ".", add conformance tests.

### DIFF
--- a/proxy/amux/BUILD.bazel
+++ b/proxy/amux/BUILD.bazel
@@ -1,8 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["mux.go"],
     importpath = "github.com/enfabrica/enkit/proxy/amux",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mux_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proxy/amux/amuxie:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/proxy/amux/amuxie/amuxie.go
+++ b/proxy/amux/amuxie/amuxie.go
@@ -6,6 +6,7 @@ import (
 	"github.com/enfabrica/enkit/proxy/amux"
 	"github.com/kataras/muxie"
 	"net/http"
+	"strings"
 )
 
 type Mux struct {
@@ -19,6 +20,9 @@ func New() *Mux {
 func (m *Mux) Host(host string) amux.Mux {
 	h := muxie.NewMux()
 	m.HandleRequest(muxie.Host(host), h)
+	if !strings.HasSuffix(host, ".") {
+		m.HandleRequest(muxie.Host(host + "."), h)
+	}
 
 	return &Mux{h}
 }

--- a/proxy/amux/mux.go
+++ b/proxy/amux/mux.go
@@ -36,7 +36,7 @@ type Mux interface {
 	// specific paths in this specific domain, or add more FQDN matches.
 	//
 	// If the specified FQDN does not terminate with a ".", the Mux is
-	// expected to match the FQDN both with a terminating "." and without. 
+	// expected to match the FQDN both with a terminating "." and without.
 	//
 	// The "empty host string" is considered a wildcard matching any FQDN,
 	// meaning that the route will be used in any case there is no more

--- a/proxy/amux/mux.go
+++ b/proxy/amux/mux.go
@@ -33,34 +33,48 @@ type Mux interface {
 	// The host string is expected to be a FQDN. Not a subdomain.
 	//
 	// The function returns a Mux that can be used to define handlers for
-	// specific paths in this specific domain, or add more host matches.
+	// specific paths in this specific domain, or add more FQDN matches.
 	//
-	// The "empty host string" is considered a wildcard matching any FQDN.
-	// Any path defined via Handle()
+	// If the specified FQDN does not terminate with a ".", the Mux is
+	// expected to match the FQDN both with a terminating "." and without. 
 	//
-	// The enproxy code does not otherwise use any form of pattern matching.
-	// No regular expressions or wildcards are required.
+	// The "empty host string" is considered a wildcard matching any FQDN,
+	// meaning that the route will be used in any case there is no more
+	// specific host match. If a default route for all hosts is needed,
+	// the route must be added on all hosts.
+	//
+	// The enproxy code does not otherwise expect any form of pattern
+	// matching in host names. No regular expressions or wildcards are
+	// required.
 	//
 	// However, if the enproxy configuration file contains wildcards or
-	// regular expressions, they are passed unmodified to the supplied Mux
+	// regular expressions, those are passed unmodified to the supplied Mux
 	// interface and transparently handled by the configured handlers.
 	//
 	// If a Mux with support for patterns in Host() is thus provided to
-	// enproxy, the corresponding functionalities will work and be available
-	// to users of enproxy.
+	// enproxy, the corresponding functionalities will work and be
+	// available to users of enproxy.
 	Host(host string) Mux
 
 	// Handle allows to match on an http path.
 	//
 	// The string is expected to be a full path, starting with "/".
+	// The empty string is not allowed, and will result in undefined behavior.
 	//
 	// When Handle is called on a newly initialized Mux, eg, one that was
-	// not created by a call to Host(), the path is expected to be
-	// configured on the empty host domain, "". See the Host()
-	// documentation for details.
+	// not created by a call to Host(), the path is treated as being configured
+	// on the empty host domain, "". See the Host() documentation for details.
 	//
-	// If the path ends with "/", it is assumed to be a prefix match.
-	// Any subdirectory of such path will need to be routed to the handler.
+	// The match is always exact, unless it ends with a "*". A trailing "*"
+	// indicates that any suffix of that path is accepted.
+	//
+	// enproxy only requires trailing "*" support after a /, indicating all
+	// sub-paths of a specific directory.
+	//
+	// Just like the Host() directive, however, patterns are forwarded
+	// without further validation or transformation to the Mux, so any
+	// additional functionality of the Mux can be directly exposed in the
+	// config.
 	//
 	// When the underlying mux invokes the corresponding http.Handler,
 	// the supplied ResponseWriter MUST be type castable to the

--- a/proxy/amux/mux_test.go
+++ b/proxy/amux/mux_test.go
@@ -1,0 +1,124 @@
+package amux_test
+
+import (
+	"testing"
+	  "github.com/stretchr/testify/assert"
+	"github.com/enfabrica/enkit/proxy/amux"
+	"github.com/enfabrica/enkit/proxy/amux/amuxie"
+	"net/http"
+	"net/http/httptest"
+	"fmt"
+)
+
+func CountHandler(counter *int) http.Handler {
+return http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	*counter += 1
+})
+}
+
+var NilHandler = http.HandlerFunc(
+func (w http.ResponseWriter, r *http.Request) {
+},
+)
+
+func Request(m amux.Mux, host, path string) int {
+	r := httptest.NewRequest("GET", fmt.Sprintf("http://%s%s", host, path), nil)
+	w := httptest.NewRecorder()
+
+	h := m.(http.Handler)
+	h.ServeHTTP(w, r)
+
+	resp := w.Result()
+	return resp.StatusCode
+}
+
+
+func TestMuxConformance(t *testing.T) {
+	var m amux.Mux
+
+	// TODO: if support for multiple muxes is added, the test here should pass
+	// on all added muxes. An error means the new mux introduces a backward
+	// incompatible change into how routes are treated.
+	m = amuxie.New()
+	assert.NotNil(t, m)
+
+	m.Handle("/quote", NilHandler)
+	m.Handle("/exactdir/", NilHandler)
+
+	var countPrefix, countOverlap int
+	m.Handle("/prefix/*", CountHandler(&countPrefix))
+	m.Handle("/tooverlap/", CountHandler(&countOverlap))
+
+	h1 := m.Host("host1.net")
+
+	h1.Handle("/", NilHandler)
+	h1.Handle("/separate", NilHandler)
+
+	var countBar, countFoo, countOverride int
+	h1.Handle("/prefix/bar/", CountHandler(&countBar))
+	h1.Handle("/prefix/foo/*", CountHandler(&countFoo))
+	h1.Handle("/tooverlap/", CountHandler(&countOverride))
+
+	h2 := m.Host("host2.net")
+	var countHost2 int
+	h2.Handle("/*", CountHandler(&countHost2))
+
+	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/"))
+
+	assert.Equal(t, http.StatusOK, Request(m, "whatever", "/quote"))
+	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/quote"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/quote/sub"))
+
+	assert.Equal(t, http.StatusOK, Request(m, "whatever", "/exactdir"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/exactdir/foo"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/exactdir/"))
+
+	assert.Equal(t, http.StatusOK, Request(m, "whatever", "/prefix/"))
+	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/prefix/test1"))
+	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/prefix/test1/test2/test3"))
+	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/prefix/bar/test2/test3"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/prefix"))
+
+
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net", "/not-found"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/separate"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net.", "/separate"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net.", "/separate/"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net.", "/separate/foo"))
+
+	assert.Equal(t, http.StatusOK, Request(m, "non-existing", "/tooverlap"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "non-existing", "/tooverlap/"))
+	assert.Equal(t, 1, countOverlap)
+	assert.Equal(t, 0, countOverride)
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/tooverlap"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net.", "/tooverlap"))
+	assert.Equal(t, 1, countOverlap)
+	assert.Equal(t, 2, countOverride)
+
+	countPrefix = 0
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net", "/prefix/bar/whatever"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net.", "/prefix/bar/whatever"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net", "/prefix/foo"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net.", "/prefix/foo"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net", "/prefix/nanna"))
+	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net.", "/prefix/nanna"))
+	assert.Equal(t, 0, countPrefix)
+	assert.Equal(t, 0, countBar)
+	assert.Equal(t, 0, countFoo)
+
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/prefix/bar"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net.", "/prefix/bar"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/prefix/foo/test/toast"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net.", "/prefix/foo/test/toast"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/prefix/foo/"))
+	assert.Equal(t, http.StatusOK, Request(m, "host1.net.", "/prefix/foo/"))
+	assert.Equal(t, 0, countPrefix)
+	assert.Equal(t, 2, countBar)
+	assert.Equal(t, 4, countFoo)
+
+	assert.Equal(t, 0, countHost2)
+	assert.Equal(t, http.StatusOK, Request(m, "host2.net", "/"))
+	assert.Equal(t, http.StatusOK, Request(m, "host2.net.", "/whatever"))
+	assert.Equal(t, 2, countHost2)
+}

--- a/proxy/amux/mux_test.go
+++ b/proxy/amux/mux_test.go
@@ -1,24 +1,24 @@
 package amux_test
 
 import (
-	"testing"
-	  "github.com/stretchr/testify/assert"
-	"github.com/enfabrica/enkit/proxy/amux"
-	"github.com/enfabrica/enkit/proxy/amux/amuxie"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"fmt"
+	"testing"
+	"github.com/enfabrica/enkit/proxy/amux"
+	"github.com/enfabrica/enkit/proxy/amux/amuxie"
+	"github.com/stretchr/testify/assert"
 )
 
 func CountHandler(counter *int) http.Handler {
-return http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
-	*counter += 1
-})
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*counter += 1
+	})
 }
 
 var NilHandler = http.HandlerFunc(
-func (w http.ResponseWriter, r *http.Request) {
-},
+	func(w http.ResponseWriter, r *http.Request) {
+	},
 )
 
 func Request(m amux.Mux, host, path string) int {
@@ -31,7 +31,6 @@ func Request(m amux.Mux, host, path string) int {
 	resp := w.Result()
 	return resp.StatusCode
 }
-
 
 func TestMuxConformance(t *testing.T) {
 	var m amux.Mux
@@ -78,7 +77,6 @@ func TestMuxConformance(t *testing.T) {
 	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/prefix/test1/test2/test3"))
 	assert.Equal(t, http.StatusOK, Request(m, "whatever.", "/prefix/bar/test2/test3"))
 	assert.Equal(t, http.StatusNotFound, Request(m, "whatever", "/prefix"))
-
 
 	assert.Equal(t, http.StatusOK, Request(m, "host1.net", "/"))
 	assert.Equal(t, http.StatusNotFound, Request(m, "host1.net", "/not-found"))


### PR DESCRIPTION
Background:
DNS allows domain names ending with a trailing ".", eg, "www.enfabrica.net."
or "www.google.com.". Adding a trailing dot is considered best practice
when specifying domain names in cli tools, bots, or automated systems
in general, as - without a trailing . - the name is considered "relative"
by DNS resolver library, and will be looked up multiple times in DNS
using the "search" domains in resolv.conf, increasing the load on DNS,
and possibly leading to very unexpected results.

An http server should generally treat "enfabrica.net" and "enfabrica.net." as
exactly the same domain. Golang muxes (and most web servers) don't do this by
default, introducing various kind of problems (see a good discussion here:
https://news.ycombinator.com/item?id=5384864, using a trailing period on
some sites allows to even bypass authentication or subscriptons).

In enkit, however, enkit/lib/khttp had code to deal with it by default,
and transparently.

Problem:
When moved away from the enkit/lib/khttp library for domain match,
the automated handling of domains with trailing "." was accidentally
dropped, meaning that tools trying to access "enfabrica.net." rather
than "enfabrica.net" started getting an error.

In this PR:
- update the documentation of amux, further specifying the expected contract.
- update the amux wrapper for muxie to transparently handle trailing ".",
  just like the previous mux used by enproxy.
- while testing the code, I realised that enproxy also requires at least
  one form of pattern matching, which has been added to the documentation.

Tested:
- this PR adds a conformance test, covering a lot of the edge cases
  in how the mux behaves, including trailing ".".