### PR TITLE
kbuildbarn: start formatting symlink urls

### DIFF
--- a/lib/kbuildbarn/BUILD.bazel
+++ b/lib/kbuildbarn/BUILD.bazel
@@ -4,18 +4,26 @@ go_library(
     name = "go_default_library",
     srcs = [
         "options.go",
+        "protoparse.go",
         "urls.go",
     ],
     importpath = "github.com/enfabrica/enkit/lib/kbuildbarn",
     visibility = ["//visibility:public"],
-    deps = ["//lib/multierror:go_default_library"],
+    deps = [
+        "//lib/multierror:go_default_library",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+    ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["urls_test.go"],
+    srcs = [
+        "protoparse_test.go",
+        "urls_test.go",
+    ],
     deps = [
         ":go_default_library",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/lib/kbuildbarn/options.go
+++ b/lib/kbuildbarn/options.go
@@ -1,7 +1,5 @@
 package kbuildbarn
 
-import "fmt"
-
 type options struct {
 	Scheme       string
 	PathTemplate string
@@ -69,13 +67,36 @@ func WithDirectoryUrlTemplate() Option {
 	return pathTemplateOption(DefaultDirectoryTemplate)
 }
 
-type templateArgsOption []interface{}
+type templateArgsOption [][]interface{}
 
 func (ta templateArgsOption) apply(opts *options) {
+	opts.TemplateArgs = ta[0]
+}
+
+func WithTemplateArgs(args []interface{}) Option {
+	return templateArgsOption{args}
+}
+
+type templateAppendArgsOption []interface{}
+
+func (ta templateAppendArgsOption) apply(opts *options) {
 	opts.TemplateArgs = append(opts.TemplateArgs, ta...)
-	fmt.Println(opts.TemplateArgs)
+}
+
+func WithAdditionalTemplateArgs(args ...interface{}) Option {
+	return templateAppendArgsOption{args}
 }
 
 func WithFileName(s string) Option {
-	return multipleOption{pathTemplateOption(DefaultFileTemplate), templateArgsOption{s}}
+	return multipleOption{pathTemplateOption(DefaultFileTemplate), templateAppendArgsOption{s}}
+}
+
+type customTemplate string
+
+func (ct customTemplate) apply(opts *options) {
+	opts.PathTemplate = string(ct)
+}
+
+func WithFileTemplate(s string) Option {
+	return customTemplate(s)
 }

--- a/lib/kbuildbarn/options.go
+++ b/lib/kbuildbarn/options.go
@@ -67,14 +67,18 @@ func WithDirectoryUrlTemplate() Option {
 	return pathTemplateOption(DefaultDirectoryTemplate)
 }
 
-type templateArgsOption [][]interface{}
+type templateArgsOption []string
 
 func (ta templateArgsOption) apply(opts *options) {
-	opts.TemplateArgs = ta[0]
+	s := make([]interface{}, len(ta))
+	for i, v := range ta {
+		s[i] = v
+	}
+	opts.TemplateArgs = s
 }
 
-func WithTemplateArgs(args []interface{}) Option {
-	return templateArgsOption{args}
+func WithTemplateArgs(args ...string) Option {
+	return templateArgsOption(args)
 }
 
 type templateAppendArgsOption []interface{}

--- a/lib/kbuildbarn/protoparse.go
+++ b/lib/kbuildbarn/protoparse.go
@@ -1,0 +1,68 @@
+package kbuildbarn
+
+import (
+	"fmt"
+	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
+	"strconv"
+)
+
+const (
+	DefaultBBClientdCasFileTemplate     = "cas/%s/blobs/file/%s"
+	DefaultBBClientdScratchFileTemplate = "scratch/%s/%s"
+)
+
+// BBClientDLink represents a single symlink of a file in the cas to a hard symlink in the scratch directory
+type BBClientDLink struct {
+	Src  string
+	Dest string
+	Next *BBClientDLink
+}
+
+// FindBySrc will search through its children and find where the Src strictly matches, otherwise it will return nil.
+func (l *BBClientDLink) FindBySrc(s string) *BBClientDLink {
+	curr := l
+	for curr != nil {
+		fmt.Println("current is ")
+		if curr.Src == s {
+			return curr
+		}
+		curr = curr.Next
+	}
+	return nil
+}
+
+// FindByDest will search through its children and find where the Dest strictly matches, otherwise it will return nil.
+func (l *BBClientDLink) FindByDest(s string) *BBClientDLink {
+	curr := l
+	for curr != nil {
+		if curr.Dest == s {
+			return curr
+		}
+		curr = curr.Next
+	}
+	return nil
+}
+
+// GenerateLinksForNamedSetOfFiles will generate a BBClientDLink who has a list of all symlinks from the single bespb.NamedSetOfFiles msg.
+// If the msg has no files, it will return nil.
+func GenerateLinksForNamedSetOfFiles(filesPb *bespb.NamedSetOfFiles, baseName, invocationPrefix, clusterName string) *BBClientDLink {
+	var curr *BBClientDLink
+	var head *BBClientDLink
+	for _, f := range filesPb.GetFiles() {
+		size := strconv.Itoa(int(f.Length))
+		simSource := File(baseName, f.Digest, size,
+			WithFileTemplate(DefaultBBClientdCasFileTemplate),
+			WithTemplateArgs([]interface{}{clusterName, f.Digest}))
+		simDest := File(baseName, f.Digest, size,
+			WithFileTemplate(DefaultBBClientdScratchFileTemplate),
+			WithTemplateArgs([]interface{}{invocationPrefix, f.Name}))
+		if curr == nil {
+			head = &BBClientDLink{Dest: simDest, Src: simSource}
+			curr = head
+			continue
+		}
+		curr.Next = &BBClientDLink{Dest: simDest, Src: simSource}
+		curr = curr.Next
+	}
+	return head
+}

--- a/lib/kbuildbarn/protoparse.go
+++ b/lib/kbuildbarn/protoparse.go
@@ -46,10 +46,10 @@ func GenerateLinksForNamedSetOfFiles(filesPb *bespb.NamedSetOfFiles, baseName, i
 		size := strconv.Itoa(int(f.Length))
 		simSource := File(baseName, f.Digest, size,
 			WithFileTemplate(DefaultBBClientdCasFileTemplate),
-			WithTemplateArgs([]interface{}{clusterName, f.Digest}))
+			WithTemplateArgs(clusterName, f.Digest))
 		simDest := File(baseName, f.Digest, size,
 			WithFileTemplate(DefaultBBClientdScratchFileTemplate),
-			WithTemplateArgs([]interface{}{invocationPrefix, f.Name}))
+			WithTemplateArgs(invocationPrefix, f.Name))
 		toReturn = append(toReturn, &BBClientDLink{Dest: simDest, Src: simSource})
 	}
 	return toReturn

--- a/lib/kbuildbarn/protoparse_test.go
+++ b/lib/kbuildbarn/protoparse_test.go
@@ -19,8 +19,8 @@ func TestSingleContain(t *testing.T) {
 		},
 	}}
 	result := kbuildbarn.GenerateLinksForNamedSetOfFiles(simple, "/enfabrica/mymount", "myInvocation", "localCluster")
-	assert.Equal(t, "/enfabrica/mymount/cas/localCluster/blobs/file/digest", result.Src)
-	assert.Equal(t, "/enfabrica/mymount/scratch/myInvocation/simple.txt", result.Dest)
+	assert.Equal(t, "/enfabrica/mymount/cas/localCluster/blobs/file/digest", result[0].Src)
+	assert.Equal(t, "/enfabrica/mymount/scratch/myInvocation/simple.txt", result[0].Dest)
 }
 
 func TestParseMany(t *testing.T) {

--- a/lib/kbuildbarn/protoparse_test.go
+++ b/lib/kbuildbarn/protoparse_test.go
@@ -1,0 +1,60 @@
+package kbuildbarn_test
+
+import (
+	"github.com/enfabrica/enkit/lib/kbuildbarn"
+	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmpty(t *testing.T) {
+	result := kbuildbarn.GenerateLinksForNamedSetOfFiles(&bespb.NamedSetOfFiles{}, "", "", "")
+	assert.Nil(t, result)
+}
+
+func TestSingleContain(t *testing.T) {
+	simple := &bespb.NamedSetOfFiles{Files: []*bespb.File{
+		{
+			Name: "simple.txt", Digest: "digest", Length: 614,
+		},
+	}}
+	result := kbuildbarn.GenerateLinksForNamedSetOfFiles(simple, "/enfabrica/mymount", "myInvocation", "localCluster")
+	assert.Equal(t, "/enfabrica/mymount/cas/localCluster/blobs/file/digest", result.Src)
+	assert.Equal(t, "/enfabrica/mymount/scratch/myInvocation/simple.txt", result.Dest)
+}
+
+func TestParseMany(t *testing.T) {
+	many := &bespb.NamedSetOfFiles{Files: []*bespb.File{
+		{
+			Name: "simple.txt", Digest: "digest0", Length: 614,
+		},
+		{
+			Name: "hello/simple.txt", Digest: "digest1", Length: 43,
+		},
+		{
+			Name: "one/two/foo.bar", Digest: "digest2", Length: 888,
+		},
+		{
+			Name: "tarball.tar", Digest: "digest3", Length: 777,
+		},
+	}}
+	baseName := "/foo/bar"
+	clusterName := "duster"
+	invocationPrefix := "invocation"
+	expected := map[string]string{
+		"/foo/bar/scratch/invocation/simple.txt":       "/foo/bar/cas/duster/blobs/file/digest0",
+		"/foo/bar/scratch/invocation/hello/simple.txt": "/foo/bar/cas/duster/blobs/file/digest1",
+		"/foo/bar/scratch/invocation/one/two/foo.bar":  "/foo/bar/cas/duster/blobs/file/digest2",
+		"/foo/bar/scratch/invocation/tarball.tar":      "/foo/bar/cas/duster/blobs/file/digest3",
+	}
+	r := kbuildbarn.GenerateLinksForNamedSetOfFiles(many, baseName, invocationPrefix, clusterName)
+	for expectedDest, expectedSim := range expected {
+		foundByDest := r.FindByDest(expectedDest)
+		foundBySim := r.FindBySrc(expectedSim)
+		assert.NotNil(t, foundBySim)
+		assert.NotNil(t, foundByDest)
+		assert.Equal(t, foundBySim, foundByDest)
+		assert.Equal(t, expectedDest, foundByDest.Dest)
+		assert.Equal(t, expectedSim, foundBySim.Src)
+	}
+}

--- a/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
+++ b/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
     visibility = [
+        "//lib/kbuildbarn:__subpackages__",
         "//third_party/bazel:__subpackages__",
         "//third_party/buildbuddy/proto:__pkg__",
     ],
@@ -31,6 +32,7 @@ go_proto_library(
     visibility = [
         "//bestie:__subpackages__",
         "//lib/bes:__subpackages__",
+        "//lib/kbuildbarn:__subpackages__",
         "//third_party/buildbuddy/proto:__pkg__",
     ],
     deps = [


### PR DESCRIPTION
What this does:

Generates out a generic LL of symlinks out of a NamedSetOfFiles protobuff message. Each node of the LL contains a source and destination symlink, formatted for bb_clientd cas and scratch directory.