### PR TITLE
gee diff: support diffing upstream pull requests.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2025,6 +2025,10 @@ function gee__diff() {
   local PARENT_BRANCH
   _read_parents_file
   PARENT_BRANCH="$(_get_parent_branch)"
+  if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
+    _git fetch upstream "${PARENT_BRANCH#upstream/}"
+    PARENT_BRANCH="FETCH_HEAD"
+  fi
   if (( "$#" )); then
     _git_can_fail diff "${PARENT_BRANCH}"...HEAD -- "$@"
   else

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.19"
+readonly VERSION="0.2.20"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -2025,6 +2025,7 @@ function gee__diff() {
   local PARENT_BRANCH
   _read_parents_file
   PARENT_BRANCH="$(_get_parent_branch)"
+  # branches created with "gee pr_checkout" need special handling:
   if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
     _git fetch upstream "${PARENT_BRANCH#upstream/}"
     PARENT_BRANCH="FETCH_HEAD"

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.18"
+readonly VERSION="0.2.19"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -2014,8 +2014,7 @@ _register_help "diff" \
   "Differences in this branch." <<'EOT'
 Usage: gee diff [<files...>]
 
-Shows changes since this branch diverged from it's parent branch, including
-unstaged (uncommitted) changes.
+Diffs the current branch against its parent branch.
 
 If <files...> are omited, defaults to all files.
 EOT
@@ -2031,9 +2030,9 @@ function gee__diff() {
     PARENT_BRANCH="FETCH_HEAD"
   fi
   if (( "$#" )); then
-    _git_can_fail diff "${PARENT_BRANCH}"...HEAD -- "$@"
+    _git_can_fail diff "${PARENT_BRANCH}" -- "$@"
   else
-    _git_can_fail diff "${PARENT_BRANCH}"...HEAD
+    _git_can_fail diff "${PARENT_BRANCH}"
   fi
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."


### PR DESCRIPTION
gee diff: support diffing upstream pull requests.

`gee pr_checkout` works to create a branch from an upstream PR.

`gee up` successfully integrates new commits from upstream.

but `gee diff` wasn't working, even though it used the same syntax as `gee up`.

I finally figured out why, and the hack I need to fix it.  I've updated
`gee diff` to do the right thing when diffing against an upstream pull ref.

Tested:
  Ran "gee diff" from within a pr_NNN branch.

```
$ cd ~/gee/enkit/pr_432
$ ../gee_diff_upstream/scripts/gee diff
CMD: /usr/bin/git fetch upstream refs/pull/432/head
From github.com:enfabrica/enkit
 * branch            refs/pull/432/head -> FETCH_HEAD
CMD: /usr/bin/git diff FETCH_HEAD
diff --git a/scripts/gee b/scripts/gee
index c9b89bc..beb5e61 100755
--- a/scripts/gee
+++ b/scripts/gee
@@ -1927,7 +1927,8 @@ _register_help "diff" \
   "Differences in this branch." <<'EOT'
 Usage: gee diff [<files...>]

-Diffs the current branch against its parent branch.
+Shows changes since this branch diverged from it's parent branch, including
+unstaged (uncommitted) changes.

 If <files...> are omited, defaults to all files.
 EOT
@@ -1937,15 +1938,14 @@ function gee__diff() {
   local PARENT_BRANCH
   _read_parents_file
   PARENT_BRANCH="$(_get_parent_branch)"
-  # branches created with "gee pr_checkout" need special handling:
   if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
     _git fetch upstream "${PARENT_BRANCH#upstream/}"
     PARENT_BRANCH="FETCH_HEAD"
   fi
   if (( "$#" )); then
-    _git_can_fail diff "${PARENT_BRANCH}" -- "$@"
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD -- "$@"
   else
-    _git_can_fail diff "${PARENT_BRANCH}"
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD
   fi
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."
```

PR generated by jonathan from branch gee_diff_upstream.

