### PR TITLE
presubmit: Move to canonical dev image

### DIFF
--- a/infra/cloudbuild/presubmit_bazel.yaml
+++ b/infra/cloudbuild/presubmit_bazel.yaml
@@ -24,7 +24,7 @@ steps:
       - name: ssh
         path: /root/.ssh
 
-  - name: gcr.io/devops-284019/developer_testing:scott_presubmit_test
+  - name: gcr.io/devops-284019/developer:enkit-bazel-presubmit
     entrypoint: /opt/enfabrica/bin/enkit
     args:
       - bazel
@@ -49,7 +49,7 @@ steps:
       - name: affected-targets
         path: /affected-targets
 
-  - name: gcr.io/devops-284019/developer_testing:scott_presubmit_test
+  - name: gcr.io/devops-284019/developer:enkit-bazel-presubmit
     entrypoint: bash
     args:
       - -c
@@ -58,7 +58,7 @@ steps:
       - name: affected-targets
         path: /affected-targets
 
-  - name: gcr.io/devops-284019/developer_testing:scott_presubmit_test
+  - name: gcr.io/devops-284019/developer:enkit-bazel-presubmit
     entrypoint: bash
     args:
       - -c


### PR DESCRIPTION
Now that the developer image has a recent version of enkit, we can
migrate off of the custom version with the patched version of enkit
(originally done to get a version of enkit with the bazel presubmit
subcommands).

This change causes the presubmit to use whichever image is tagged
`enkit-bazel-presubmit`, which will allow us to update the presubmit
container without code changes in the future (build reproducibility
concerns are relaxed around the presubmit itself, so no need to pin to
specific image hashes).

Tagged image is `3a1381e7931d2d50304acba6bb6d2848af6937369481572cb0719dcbe41ab33e`, uploaded yesterday by @ccontavalli:

![image](https://user-images.githubusercontent.com/8988434/152192210-e9787df2-ff0b-4d20-af01-58e491b2db67.png)

Jira: INFRA-111