### PR TITLE
bugfixes: update yarn lock

### DIFF
--- a/astore/rpc/BUILD.bazel
+++ b/astore/rpc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # Gazelle seems to not detect my existing proto_library rules, and
 # create new ones with names I don't like. So here you go, gazelle!
@@ -19,8 +20,6 @@ proto_library(
     deps = [
     ],
 )
-
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 go_proto_library(
     name = "astore-proto-lib",

--- a/machinist/rpc/BUILD.bazel
+++ b/machinist/rpc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # Gazelle seems to not detect my existing proto_library rules, and
 # create new ones with names I don't like. So here you go, gazelle!
@@ -14,8 +15,6 @@ proto_library(
     deps = [
     ],
 )
-
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 go_proto_library(
     name = "machinist-proto-lib",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6709,7 +6709,12 @@ google-protobuf@3.18.0:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.18.0.tgz#687449d8e858305d658dc1145852c306d8222f5a"
   integrity sha512-WlaQWRkUOo/lm9uTgNH6nk9IQt814RggWPzKBfnAVewOFzSzRUSmS1yUWRT6ixW1vS7er5p6tmLSmwzpPpmc8A==
 
-google-protobuf@^3.15.5, google-protobuf@^3.6.1:
+google-protobuf@^3.15.5:
+  version "3.19.4"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.19.4.tgz#8d32c3e34be9250956f28c0fb90955d13f311888"
+  integrity sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg==
+
+google-protobuf@^3.6.1:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.19.1.tgz#5af5390e8206c446d8f49febaffd4b7f4ac28f41"
   integrity sha512-Isv1RlNC+IzZzilcxnlVSf+JvuhxmY7DaxYCBy+zPS9XVuJRtlTTIXR9hnZ1YL1MMusJn/7eSy2swCzZIomQSg==


### PR DESCRIPTION
Problems: 
- once of the dependencies was not on the right version in the yarn.lock, causing `bazelisk build //...` to fail. Regenerating yarn.lock fixes this. 
- changes the ordering of proto declaration in machinist and astore 

...works now with bazel 5.0