### PR TITLE
presubmit: Fix issues

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,10 +84,21 @@ node_repositories(
     yarn_version = "1.22",
 )
 
-load("@rules_proto_grpc//:repositories.bzl", "grpc_web_plugin_linux", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+load(
+    "@rules_proto_grpc//:repositories.bzl",
+    "grpc_web_plugin_darwin",
+    "grpc_web_plugin_linux",
+    "grpc_web_plugin_windows",
+    "rules_proto_grpc_repos",
+    "rules_proto_grpc_toolchains",
+)
 
 rules_proto_grpc_toolchains()
 
 rules_proto_grpc_repos()
 
 grpc_web_plugin_linux()
+
+grpc_web_plugin_darwin()
+
+grpc_web_plugin_windows()

--- a/infra/cloudbuild/presubmit_bazel.yaml
+++ b/infra/cloudbuild/presubmit_bazel.yaml
@@ -73,6 +73,6 @@ availableSecrets:
     - versionName: projects/496137108493/secrets/github-enfabrica-bot-key/versions/latest
       env: SSH_KEY
 
-timeout: 20m
+timeout: 30m
 options:
   machineType: E2_HIGHCPU_8

--- a/proxy/amux/BUILD.bazel
+++ b/proxy/amux/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["mux_test.go"],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//proxy/amux/amuxie:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],


### PR DESCRIPTION
This change has fixes to address the following issues we see in
presubmits currently:

* occasional timeouts -> timeout raised to 30m from 20m
* query errors on grpc_web repositories -> grpc web plugin repositories
  loaded for Windows and MacOS, even though they are unused

Tested: `bazel query 'deps(//...)'` now runs successfully locally