### PR TITLE
enkit outputs: Start tunnel when necessary

### DIFF
--- a/enkit/outputs/BUILD.bazel
+++ b/enkit/outputs/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
         "//lib/kbuildbarn/exec:go_default_library",
         "//lib/logger:go_default_library",
         "//lib/multierror:go_default_library",
+        "//proxy/ptunnel:go_default_library",
+        "//proxy/ptunnel/exec:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/proxy/ptunnel/BUILD.bazel
+++ b/proxy/ptunnel/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     srcs = ["tunnel_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//lib/errdiff:go_default_library",
         "//lib/khttp:go_default_library",
         "//lib/khttp/ktest:go_default_library",
         "//lib/khttp/protocol:go_default_library",

--- a/proxy/ptunnel/exec/BUILD.bazel
+++ b/proxy/ptunnel/exec/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["exec.go"],
+    importpath = "github.com/enfabrica/enkit/proxy/ptunnel/exec",
+    visibility = ["//visibility:public"],
+)

--- a/proxy/ptunnel/exec/exec.go
+++ b/proxy/ptunnel/exec/exec.go
@@ -1,0 +1,38 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	osexec "os/exec"
+	"strconv"
+)
+
+// NewBackgroundTunnel starts and detaches a tunnel listening on `hostPort` that
+// tunnels to `target:targetPort`. There is no way to stop a backgrounded
+// tunnel, other than to kill it manually via the OS.
+func NewBackgroundTunnel(target string, targetPort int, hostPort int) error {
+	cmd := osexec.Command(
+		"enkit",
+		"tunnel",
+		"--background",
+		"-L", strconv.FormatInt(int64(hostPort), 10),
+		target, strconv.FormatInt(int64(targetPort), 10),
+	)
+	output, err := cmd.CombinedOutput()
+	var exitErr *osexec.ExitError
+	if err != nil {
+		if errors.As(err, &exitErr) {
+			switch exitErr.ExitCode() {
+			case 10:
+				// Ignore; tunnel is already started
+				return nil
+			case 100:
+				return fmt.Errorf("Authentication required; please run `enkit login`")
+			default:
+				return err
+			}
+		}
+		return fmt.Errorf("failed to start background tunnel: %v\nOutput:\n%s\n", err, string(output))
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds a few helper functions:
* A function to determine if a particular host requires a tunnel for
  communication
* A function to start and background a tunnel to a particular host
  listening on a port

These helper functions are used to allow `enkit outputs` subcommands to
determine:
* if a tunnel should be started to communicate with buildbarn
* if so, start a tunnel and replace the destination port with the local
port the tunnel is currently listening on

Tested: `enkit outputs mount` gets past tunnel initialization to a
BuildBuddy error (no invocation ID supplied)

Jira: INFRA-507