### PR TITLE
fuse: fix outputs mount command

### DIFF
--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	localTunnelPort = 8822
+	localTunnelPort = 8866
 )
 
 type Root struct {
@@ -158,7 +158,7 @@ func (c *Mount) Run(cmd *cobra.Command, args []string) error {
 		bc,
 		bbOpts.MountDir,
 		c.InvocationID,
-		c.ClusterHost,
+		host,
 		kbuildbarn.WithNamedSetOfFiles(),
 		kbuildbarn.WithTestResults(),
 	)


### PR DESCRIPTION
problems: 
- cluster host in the url should not include port
- default port was wrong

[INFRA-518]

[INFRA-518]: https://enfabrica.atlassian.net/browse/INFRA-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ