### PR TITLE
Bazel FUSE: Propagate correct port to bb_clientd

### DIFF
--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	localTunnelPort = 8866
+	localTunnelPort = 8822
 )
 
 type Root struct {
@@ -145,7 +145,7 @@ func (c *Mount) Run(cmd *cobra.Command, args []string) error {
 	}
 	bbOpts := bbexec.NewClientOptions(
 		&logger.DefaultLogger{Printer: log.Printf}, // TODO: pipe this logger everywhere
-		8866, // TODO: This needs to come from a managed tunnel
+		port,
 		c.root.OutputsRoot,
 	)
 	_, err = bbexec.MaybeStartClient(bbOpts)


### PR DESCRIPTION
Prior to this change, bb_clientd was started with a hardcoded port,
instead of the port of the actual service or the tunnel, if one
was opened.

This change removes the hardcoded port and passes the correct port to
bb_clientd initialization.

Tested:

```
bazel run //enkit:enkit -- \
  outputs \
  mount \
  --invocation=6175ddd6-de64-447d-a827-87bba04391f4 \
  --url=<REDACTED> \
  --api-key=<REDACTED> \
  --buildbarn_host=<REDACTED>

cat ~/outputs/6175ddd6-de64-447d-a827-87bba04391f4/test.log
```

Jira: INFRA-518