### PR TITLE
fuse: implement shutdown command

### DIFF
--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -199,7 +199,8 @@ func (c *Mount) Run(cmd *cobra.Command, args []string) error {
 
 type Unmount struct {
 	*cobra.Command
-	root *Root
+	root       *Root
+	Invocation string
 }
 
 func NewUnmount(root *Root) *Unmount {
@@ -216,11 +217,16 @@ func NewUnmount(root *Root) *Unmount {
 		root: root,
 	}
 	command.Command.RunE = command.Run
+	command.Flags().StringVarP(&command.Invocation, "invocation", "i", "", "invocation id to mount")
 	return command
 }
 
 func (c *Unmount) Run(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("`enkit outputs unmount` is unimplemented")
+	invoPath := filepath.Join(c.root.OutputsRoot, c.Invocation)
+	if err := os.RemoveAll(invoPath); err != nil {
+		return fmt.Errorf("error removing %s: %v", invoPath, err)
+	}
+	return nil
 }
 
 type Run struct {

--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -133,8 +133,6 @@ func (c *Mount) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	host, port = host, port
-
 	buddyUrl, err := url.Parse(c.BuildBuddyUrl)
 	if err != nil {
 		return fmt.Errorf("failed parsing buildbuddy url: %w", err)

--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -2,6 +2,7 @@ package outputs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -215,12 +216,14 @@ func NewUnmount(root *Root) *Unmount {
 		root: root,
 	}
 	command.Command.RunE = command.Run
-	command.Flags().StringVarP(&command.Invocation, "invocation", "i", "", "invocation id to mount")
 	return command
 }
 
 func (c *Unmount) Run(cmd *cobra.Command, args []string) error {
-	invoPath := filepath.Join(c.root.OutputsRoot, c.Invocation)
+	if len(args) != 1 {
+		return errors.New("must provide a valid invocation")
+	}
+	invoPath := filepath.Join(c.root.OutputsRoot, args[0])
 	if err := os.RemoveAll(invoPath); err != nil {
 		return fmt.Errorf("error removing %s: %v", invoPath, err)
 	}


### PR DESCRIPTION
Implements a the basic unmount function, which just deletes the soft symlink at <root>/invocation  

Also removes an ineffectual assignment. 