### PR TITLE
bestie: Use zipstream package to read outputs.zip

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -2050,6 +2050,14 @@ def go_repositories():
         sum = "h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=",
         version = "v0.2.1",
     )
+
+    go_repository(
+        name = "com_github_xenking_zipstream",
+        importpath = "github.com/xenking/zipstream",
+        sum = "h1:6LfcpXfxO9kAGi0a+2N5C0ZZ6jyG4XULPiogOM7gJBU=",
+        version = "v1.0.1",
+    )
+
     go_repository(
         name = "com_github_xiang90_probing",
         importpath = "github.com/xiang90/probing",

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@com_github_xenking_zipstream//:go_default_library",
         "@com_google_cloud_go_bigquery//:go_default_library",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
         "@org_golang_google_api//googleapi:go_default_library",


### PR DESCRIPTION
Change the handling of the outputs.zip file so that it is not
read into memory prior to processing each of its file elements.
Use the https://github.com/xenking/zipstream package to iterate
through each of the files, looking for file names ending in
.metrics.pb.

Tested: Ran BES Endpoint service both locally and in the staging
cluster, where it detected the test.metrics.pb file produced by
a standalone test app.

Jira: INFRA-504