### PR TITLE
Bazel FUSE: Implement run with zip_path, dir_path

### DIFF
--- a/enkit/outputs/BUILD.bazel
+++ b/enkit/outputs/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/enfabrica/enkit/enkit/outputs",
     visibility = ["//visibility:public"],
     deps = [
+        "//faketree/exec:go_default_library",
         "//lib/bes:go_default_library",
         "//lib/client:go_default_library",
+        "//lib/karchive:go_default_library",
         "//lib/kbuildbarn:go_default_library",
         "//lib/kbuildbarn/exec:go_default_library",
         "//lib/logger:go_default_library",

--- a/faketree/exec/exec.go
+++ b/faketree/exec/exec.go
@@ -19,7 +19,7 @@ func Run(ctx context.Context, promptStr string, dirMap map[string]string, chdir 
 	if chdir != "" {
 		args = append(args, "--chdir", chdir)
 	}
-	if innerCmd != nil {
+	if len(innerCmd) > 0 {
 		args = append(args, "--")
 		args = append(args, innerCmd...)
 	}


### PR DESCRIPTION
This change implements `enkit outputs run` when either a zip file is
passed (perhaps from a previous `enkit outputs mount`) or a dir is
passed (maybe from an already-unzipped outputs.zip)

Tested: `enkit outputs run --zip_path ~/tmp/outputs.zip` manually on
local zip file - reroots the zip to `/enfabrica`, and starts a shell at
that path.

`enkit outputs run --zip_path ~/tmp/outputs.zip cat cartoons.txt` skips
the shell and instead prints the contents of the file.

Jira: INFRA-514