### PR TITLE
Bazel FUSE: Separate request host from tunnel endpoint

### DIFF
--- a/lib/kbuildbarn/exec/bb_clientd.go
+++ b/lib/kbuildbarn/exec/bb_clientd.go
@@ -154,7 +154,8 @@ func (l *outputLog) Write(p []byte) (int, error) {
 
 // ClientOptions contains all the configuration needed to start bb_clientd.
 type ClientOptions struct {
-	TunnelPort int
+	BuildbarnHost string
+	BuildbarnPort int
 	OutputBase string
 
 	// Template directories
@@ -182,12 +183,13 @@ type ClientOptions struct {
 
 // NewClientOptions returns options with sane defaults based on the specified
 // outputBase.
-func NewClientOptions(log logger.Logger, tunnelPort int, outputBase string) *ClientOptions {
+func NewClientOptions(log logger.Logger, host string, port int, outputBase string) *ClientOptions {
 	clientRoot := filepath.Join(outputBase, ".bb_clientd")
 	cacheDir := filepath.Join(clientRoot, "cache")
 	mountDir := filepath.Join(clientRoot, "mount")
 	return &ClientOptions{
-		TunnelPort:         tunnelPort,
+		BuildbarnHost:         host,
+		BuildbarnPort: port,
 		OutputBase:         outputBase,
 		CacheDir:           cacheDir,
 		MountDir:           mountDir,

--- a/lib/kbuildbarn/exec/templates/config.jsonnet
+++ b/lib/kbuildbarn/exec/templates/config.jsonnet
@@ -1,10 +1,10 @@
 // List of clusters to which bb_clientd is permitted to connect.
 local clusters = [
-  'build.local.enfabrica.net',
+  '{{.BuildbarnHost}}',
 ];
 
 local grpcClient(cluster) = {
-  address: cluster + ':{{.TunnelPort}}',
+  address: cluster + ':{{.BuildbarnPort}}',
   forwardMetadata: ['build.bazel.remote.execution.v2.requestmetadata-bin'],
   // Enable gRPC keepalives. Make sure to tune these settings based on
   // what your cluster permits.


### PR DESCRIPTION
When using a tunnel, two hostnames are requried:
* The host to tunnel to (`pbzl.service.enfabrica.net`)
* The host to make requests to (`build.local.enfabrica.net`)

The latter is required because the tunnel host is typically a
non-routable internal IP, whereas this host resolves to localhost if a
tunnel is required; additionally, ingress will route requests based on
the destination host, which is expected to be the build.local... host.

This change breaks the single host flag into two flags: One is used to
resolve to a non-localhost address (if no tunnel is required) or a
localhost address (if a tunnel is required), and requests are to be
directed to this URL. The new flag specifies the endpoint to tunnel to
if a tunnel is required.

Tested:

```
bazelisk run //enkit:enkit -- \
           outputs \
           mount \
           --buildbarn_host=<redacted> \
           --buildbarn_tunnel_target=<redacted> \
           --api_key=<redacted> \
           --buildbuddy_url=<redacted> \
           --invocation=532263bf-6522-4d05-8c63-f15621e6de4c &&
cat ~/outputs/532263bf-6522-4d05-8c63-f15621e6de4c/test.log
```

...on the corp network (no tunnel required)

Case that requires tunnel not tested.

Jira: INFRA-518