### PR TITLE
CODEOWNERS: use right syntax for usernames

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-*.sh jonathan-enf ccontavalli ahungrynacho minor-fixes aaahrens
-/scripts jonathan-enf  ccontavalli minor-fixes
+*.sh @jonathan-enf @ccontavalli @ahungrynacho @minor-fixes @aaahrens
+/scripts @jonathan-enf @ccontavalli @minor-fixes
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.21"
+readonly VERSION="0.2.22"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -1780,8 +1780,8 @@ function _print_codeowners() {
       local owner
       for owner in "${owners[@]}"; do
         local oname="${owner}"
-        if [[ "${oname}" != *@* ]]; then
-          oname="\@${oname}"
+        if [[ "${oname}" == @* ]]; then
+          oname="${oname:1}"
         fi
         if [[ "${RMAP["${owner}"]+found}" ]]; then
           echo "${oname}(${RMAP["${owner}"]})"

--- a/scripts/gee
+++ b/scripts/gee
@@ -1783,10 +1783,10 @@ function _print_codeowners() {
         if [[ "${oname}" == @* ]]; then
           oname="${oname:1}"
         fi
-        if [[ "${RMAP["${owner}"]+found}" ]]; then
-          echo "${oname}(${RMAP["${owner}"]})"
+        if [[ "${RMAP["${oname}"]+found}" ]]; then
+          echo "${owner}(${RMAP["${oname}"]})"
         else
-          echo "${oname}"
+          echo "${owner}"
         fi
       done | xargs
     fi


### PR DESCRIPTION
CODEOWNERS: use right syntax for usernames

This is the companion PR to https://github.com/enfabrica/internal/pull/3101.
This corrects the syntax for specifying users by username in CODEOWNERS files.

Tested:

