### PR TITLE
bestie: Rename metric tag test_name to test_target

### DIFF
--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "@com_github_xenking_zipstream//:go_default_library",
         "@com_google_cloud_go_bigquery//:go_default_library",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
-        "@org_golang_google_api//googleapi:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",

--- a/bestie/server/bigquery_metrics.go
+++ b/bestie/server/bigquery_metrics.go
@@ -151,7 +151,7 @@ func translateMetric(stream *bazelStream, m *testMetric) (*bigQueryMetric, error
 	dat["invocation_id"] = stream.invocationId
 	dat["invocation_sha"] = stream.invocationSha
 	dat["run"] = stream.run
-	dat["test_name"] = stream.testName
+	dat["test_target"] = stream.testTarget
 	tags, err := json.Marshal(dat)
 	if err != nil {
 		return nil, fmt.Errorf("Error converting JSON to string: %w", err)

--- a/bestie/server/testresult.go
+++ b/bestie/server/testresult.go
@@ -28,7 +28,7 @@ var deploymentBaseUrl string
 type bazelStream struct {
 	buildId       string
 	invocationId  string
-	testName      string
+	testTarget    string
 	run           string
 	invocationSha string // derived
 }
@@ -49,7 +49,7 @@ func identifyStream(bazelBuildEvent bes.BuildEvent, streamId *build.StreamId) *b
 		buildId:      streamId.GetBuildId(),
 		invocationId: streamId.GetInvocationId(),
 		run:          strconv.Itoa(int(bazelBuildEvent.GetId().GetTestResult().GetRun())),
-		testName:     bazelBuildEvent.GetId().GetTestResult().GetLabel(),
+		testTarget:   bazelBuildEvent.GetId().GetTestResult().GetLabel(),
 	}
 	// Calculate a SHA256 hash using the following fields to uniquely identify this stream.
 	stream.invocationSha = deriveInvocationSha([]string{stream.invocationId, stream.buildId, stream.run})
@@ -98,7 +98,7 @@ func handleTestResultEvent(bazelBuildEvent bes.BuildEvent, streamId *build.Strea
 	}
 
 	var sbuf strings.Builder
-	sbuf.WriteString(fmt.Sprintf("\nTestResult for %s: %s\n", stream.testName, m.GetStatus()))
+	sbuf.WriteString(fmt.Sprintf("\nTestResult for %s: %s\n", stream.testTarget, m.GetStatus()))
 	sbuf.WriteString(fmt.Sprintf("\trun: %s\n", stream.run))
 	sbuf.WriteString(fmt.Sprintf("\tbuildId: %s\n", stream.buildId))
 	sbuf.WriteString(fmt.Sprintf("\tinvocationId: %s\n", stream.invocationId))


### PR DESCRIPTION
Just renaming one of the metric tags that get inserted by the
BES Endpoint using information from the BES TestResult event.
The 'test_name' tag identifier can be easily confused with a
testcase name tag supplied by the test client application.
Since this represents the test target specified for the
'bazel test' command, the 'test_target' tag identifier
seems more appropriate.

Tested: Verified using a localhost instance of the BES Endpoint
that the new tag identifier is processed correctly and appears
in the BigQuery testmetrics table.

Jira: INFRA-551