### PR TITLE
gee: add "restore_all_branches" command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -173,7 +173,7 @@ done
 readonly ENKIT=/opt/enfabrica/bin/enkit
 readonly GIT_AT_GITHUB="org-64667743@github.com"
 readonly NEWLINE=$'\n'
-readonly CLONE_DEPTH=3  # a little bit of history
+readonly CLONE_DEPTH_MONTHS=3  # months of history to fetch
 readonly YESYESYES="${YESYESYES:-0}"  # for testing: disables all interactivity.
 GHUSER="${GHUSER:-}"  # can be set by _startup_checks
 VERBOSE="${VERBOSE:-1}"
@@ -1857,8 +1857,14 @@ function gee__init() {
   if ! "${GH}" repo list | grep "^${GHUSER}/${REPO}" > /dev/null; then
     _gh repo fork --clone=false "${UPSTREAM}/${REPO}"
   fi
+  # Get the data from N months ago.  This is more useful than specifying
+  # --depth=3, and provides a big enough window that a user who is
+  # restoring a deleted gee repository is unlikely to have issues.
+  local OLDEST_COMMIT
+  OLDEST_COMMIT="$(date --date="-${CLONE_DEPTH_MONTHS} months" +"%Y-%M-%d")"
+  _info "Fetching all commits since ${OLDEST_COMMIT}"
   _git clone \
-    --depth "${CLONE_DEPTH}" \
+    --shallow-since "${OLDEST_COMMIT}" \
     --no-single-branch \
     "${URL}" \
     "${REPO_DIR}/${MAIN}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -149,7 +149,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.23"
+readonly VERSION="0.2.24"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file
@@ -3845,6 +3845,9 @@ Usage: gee restore_all_branches
 
 Gee looks up all branches on the origin remote, and makes sure an equivalent
 branch is checked out and updated locally.
+
+Note that gee isn't able to restore parentage metadata in this way.  Be
+sure to invoke `gee set_parent` in branches that benefit from this.
 EOT
 
 function gee__restore_all_branches() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -3853,8 +3853,10 @@ function gee__restore_all_branches() {
 
   _gee_fix_remote_origin_fetch_config
 
-  # TODO(jonathan): do I need to deepen this for shallow branches?
-  _git fetch origin
+  local OLDEST_COMMIT
+  OLDEST_COMMIT="$(date --date="-${CLONE_DEPTH_MONTHS} months" +"%Y-%M-%d")"
+  _info "Fetching all commits in origin since ${OLDEST_COMMIT}"
+  _git fetch origin --shallow-since "${OLDEST_COMMIT}"
 
   local -a BRANCHES=()
   mapfile -t BRANCHES < <( \

--- a/scripts/gee
+++ b/scripts/gee
@@ -3853,6 +3853,7 @@ function gee__restore_all_branches() {
 
   _gee_fix_remote_origin_fetch_config
 
+  # TODO(jonathan): do I need to deepen this for shallow branches?
   _git fetch origin
 
   local -a BRANCHES=()

--- a/scripts/gee
+++ b/scripts/gee
@@ -3859,7 +3859,9 @@ function gee__restore_all_branches() {
     local B BDIR
     B="$(basename "${RB}")"
     BDIR="${REPO_DIR}/${B}"
-    if ! [[ -d "${BDIR}" ]]; then
+    if [[ -d "${BDIR}" ]]; then
+      _info "Branch ${B} already exists, skipping."
+    else
       _info "Restoring ${B} from ${RB}"
       _checkout_or_die "${B}"
       local -a COUNTS
@@ -3872,6 +3874,7 @@ function gee__restore_all_branches() {
     fi
   done
 
+  _info "Running \"gee repair\" to reconstruct parents information."
   gee__repair
 
   _info "Done."

--- a/scripts/gee
+++ b/scripts/gee
@@ -3831,6 +3831,53 @@ function gee__repair() {
 }
 
 ##########################################################################
+# restore_all_branches command
+##########################################################################
+
+_register_help "restore_all_branches" "Check out all remote branches." <<'EOT'
+Usage: gee restore_all_branches
+
+Gee looks up all branches on the origin remote, and makes sure an equivalent
+branch is checked out and updated locally.
+EOT
+
+function gee__restore_all_branches() {
+  # Make sure all tools are available
+  _install_tools
+
+  _gee_fix_remote_origin_fetch_config
+
+  _git fetch origin
+
+  local -a BRANCHES=()
+  mapfile -t BRANCHES < <( \
+    git branch -r --format="%(refname:short)" | grep ^origin/ | grep -v HEAD )
+
+  _set_main
+  local RB
+  for RB in "${BRANCHES[@]}"; do
+    local B BDIR
+    B="$(basename "${RB}")"
+    BDIR="${REPO_DIR}/${B}"
+    if ! [[ -d "${BDIR}" ]]; then
+      _info "Restoring ${B} from ${RB}"
+      _checkout_or_die "${B}"
+      local -a COUNTS
+      read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${B}...${RB}" | cat)
+      if (( COUNTS[1] != 0 )); then
+        _git reset --hard "${RB}"
+      else
+        _info "${B} is already up to date."
+      fi
+    fi
+  done
+
+  gee__repair
+
+  _info "Done."
+}
+
+##########################################################################
 # bash_setup command
 ##########################################################################
 

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Release 0.2.24
+
+* Added `restore_all_branches` command.
+
 ### Release 0.2.23
 
 * Rendered gee help as a user manual, in markdown.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.23
+gee version: 0.2.24
 
 gee is a wrapper around the "git" and "gh-cli" tools.  "gee" captures all
 tribal knowledge about how to use git the right way (for us), implementing one
@@ -115,6 +115,7 @@ review.
 | <a href="#pr_view">`pr_view`</a> | View an existing pull request. |
 | <a href="#remove_branch">`remove_branch`</a> | Remove a branch. |
 | <a href="#repair">`repair`</a> | Repair your gee workspace. |
+| <a href="#restore_all_branches">`restore_all_branches`</a> | Check out all remote branches. |
 | <a href="#revert">`revert`</a> | Revert specified files to match the parent branch. |
 | <a href="#rupdate">`rupdate`</a> | Recursively integrate changes from parents into this branch. |
 | <a href="#set_parent">`set_parent`</a> | Set another branch as parent of this branch. |
@@ -487,6 +488,16 @@ Gee tries to control some metadata and attempts to file away some of the
 sharp edges from git.  Sometimes, bypassing gee to use git directly can
 cause some of gee's metadata to become stale.  This command fixes up
 any missing or incorrect metadata.
+
+### restore_all_branches
+
+Usage: `gee restore_all_branches`
+
+Gee looks up all branches on the origin remote, and makes sure an equivalent
+branch is checked out and updated locally.
+
+Note that gee isn't able to restore parentage metadata in this way.  Be
+sure to invoke `gee set_parent` in branches that benefit from this.
 
 ### bash_setup
 


### PR DESCRIPTION
gee: add "restore_all_branches" command

I recently had to restore my work environment from github.

This command ensures that my local repository reflects my remote origin
repository, adding all branches to the worklist and synchronizing them
with the remote heads.  It then runs "gee repair" to (imperfectly)
reconstruct branch parentage.

I have a "TODO" to find a way to make parentage metadata version controlled,
but that's a task for another day.

Tested:

I blew away my gee repository, and restored everything using:

    gee init
    gcd master
    gee restore_all_branches

