### PR TITLE
bkup: add volume id support, filters

### DIFF
--- a/scripts/bkup
+++ b/scripts/bkup
@@ -41,7 +41,7 @@ readonly BUCKET="rclone-devops-284019"
 readonly PAGER="${PAGER:-less}"
 
 LOCAL_VOLUME_ID="$(\
-  cat /proc/1/cgroup | grep -o -E 'docker/([a-f0-9]{12})' | sed 's/docker.//' | head -n 1 )"
+  grep </proc/1/cgroup -o -E 'docker/([a-f0-9]{12})' | sed 's/docker.//' | head -n 1 )"
 if ! [[ -d ~/.config/rclone ]]; then
   mkdir -p ~/.config/rclone
 fi
@@ -157,7 +157,7 @@ files to enable backups.
 EOT
 
 function _install_rclone() {
-  local URL ZIPFILE
+  local URL
   URL="https://downloads.rclone.org/rclone-current-linux-amd64.zip"
   _cmd curl -fsS "${URL}" -o /tmp/rclone.zip
   if ! command -v unzip; then
@@ -263,7 +263,7 @@ function bkup__backup() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
-    --transfers=8  # 8 threads
+    "--transfers=8"  # 8 threads
     --links     # store symlinks as metadata
     --progress  # show progress
     --fast-list # pre-scan directory.  Maybe buggy?
@@ -400,7 +400,7 @@ function bkup__diff() {
   fi
 
   local TMPFILE
-  TMPFILE="$(/usr/bin/mktemp "$(basename $1).XXXXXX")"
+  TMPFILE="$(/usr/bin/mktemp "$(basename "$1").XXXXXX")"
   _cmd "${RCLONE}" cat \
     "remote:${BUCKET}/${RPATH}${LPATH}" \
     "${OPTS[@]}" \
@@ -426,7 +426,7 @@ function bkup__restore() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
-    --transfers=8
+    "--transfers=8"
     --links
     --progress
     --update
@@ -443,7 +443,7 @@ function bkup__restore() {
   fi
 
   local TMPFILE F REL_P
-  TMPFILE="$(tempfile)"
+  TMPFILE="$(/usr/bin/mktemp bkup.restore.XXXXXX)"
   for F in "$@"; do
     REL_P="$(realpath -m --relative-base="${HOME}" "${F}")"
     if [[ "${REL_P}" =~ ^/ ]]; then
@@ -481,7 +481,7 @@ function bkup__restore_all() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
-    --transfers=8
+    "--transfers=8"
     --links
     --max-delete 0
   )
@@ -546,10 +546,11 @@ function bkup__lsvolumes() {
     --separator $'\t'
   )
 
-  local PATH="$(dirname "${RPATH}")"
+  local P
+  P="$(dirname "${RPATH}")"
 
   _cmd "${RCLONE}" lsf \
-    "remote:${BUCKET}/${PATH}" \
+    "remote:${BUCKET}/${P}" \
     "${OPTS[@]}" | /usr/bin/column -t -s $'\t'
 }
 

--- a/scripts/bkup
+++ b/scripts/bkup
@@ -40,12 +40,22 @@ readonly FILTERFILE="${CONFIGDIR}/filter-list.txt"
 readonly BUCKET="rclone-devops-284019"
 readonly PAGER="${PAGER:-less}"
 
-readonly DOCKER_ID="$(\
+LOCAL_VOLUME_ID="$(\
   cat /proc/1/cgroup | grep -o -E 'docker/([a-f0-9]{12})' | sed 's/docker.//' | head -n 1 )"
-if [[ -z "${DOCKER_ID}" ]]; then
+if ! [[ -d ~/.config/rclone ]]; then
+  mkdir -p ~/.config/rclone
+fi
+if [[ -f ~/.config/rclone/volume_id.txt ]]; then
+  read -r LOCAL_VOLUME_ID < ~/.config/rclone/volume_id.txt
+fi
+readonly VOLUME_ID="${VOLUME_ID:-"${LOCAL_VOLUME_ID}"}"
+if [[ -z "${VOLUME_ID}" ]]; then
   echo >&2 "Could not determine docker id, aborting."
 fi
-readonly RPATH="bkup/${USER}/${DOCKER_ID}"
+if ! [[ -f ~/.config/rclone/volume_id.txt ]]; then
+  echo "${VOLUME_ID}" > ~/.config/rclone/volume_id.txt
+fi
+readonly RPATH="bkup/${USER}/${VOLUME_ID}"
 
 function _check_remote() {
   "${RCLONE}" ls remote:"${BUCKET}" --max-depth 1 &> /dev/null
@@ -150,6 +160,10 @@ function _install_rclone() {
   local URL ZIPFILE
   URL="https://downloads.rclone.org/rclone-current-linux-amd64.zip"
   _cmd curl -fsS "${URL}" -o /tmp/rclone.zip
+  if ! command -v unzip; then
+    _cmd sudo apt update
+    _cmd sudo apt install unzip
+  fi
   _cmd unzip -j /tmp/rclone.zip \*/rclone -d "${BINDIR}"
   _cmd rm /tmp/rclone.zip
   _cmd "${RCLONE}" --version
@@ -243,6 +257,7 @@ function bkup__backup() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
+    --transfers=8  # 8 threads
     --links     # store symlinks as metadata
     --progress  # show progress
     --fast-list # pre-scan directory.  Maybe buggy?
@@ -405,11 +420,15 @@ function bkup__restore() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
+    --transfers=8
     --links
     --progress
     --update
     --max-delete 0
   )
+  if [[ -f "${FILTERFILE}" ]]; then
+    OPTS+=( --filter-from "${FILTERFILE}" )
+  fi
 
   if [[ "$#" -eq 0 ]]; then
     echo >&2 "\"restore\" requires at least one file to restore."
@@ -456,9 +475,13 @@ function bkup__restore_all() {
   _startup_checks
   _check_or_authorize_remote
   local -a OPTS=(
+    --transfers=8
     --links
     --max-delete 0
   )
+  if [[ -f "${FILTERFILE}" ]]; then
+    OPTS+=( --filter-from "${FILTERFILE}" )
+  fi
 
   local OVERWRITE=0
   local INTERACTIVE=0
@@ -492,6 +515,36 @@ function bkup__restore_all() {
     "remote:${BUCKET}/${RPATH}" \
     "${HOME}" \
     "${OPTS[@]}"
+}
+
+##########################################################################
+# lsvolumes command
+##########################################################################
+
+_register_help ls "List remote volumes." <<'EOT'
+Usage: bkup lsvolumes [<path>]
+
+Lists the set of volume ids associated with this account.  Volume ids
+are used to distinguish between backups of different machines for the
+same user.  If you are restoring a old machine to a new machine, and
+you want to associate the old machine's volume id with the new machine,
+write the volume id you want to `~/.config/rclone/volume_id.txt` .
+
+EOT
+function bkup__lsvolumes() {
+  _startup_checks
+  _check_or_authorize_remote
+  local -a OPTS=(
+    --links
+    --format pst
+    --separator $'\t'
+  )
+
+  local PATH="$(dirname "${RPATH}")"
+
+  _cmd "${RCLONE}" lsf \
+    "remote:${BUCKET}/${PATH}" \
+    "${OPTS[@]}" | /usr/bin/column -t -s $'\t'
 }
 
 ##########################################################################

--- a/scripts/bkup
+++ b/scripts/bkup
@@ -206,10 +206,13 @@ EOT
   # check for exclude file
   if ! [[ -e "${FILTERFILE}" ]]; then
     cat >"${FILTERFILE}" <<'EOT'
+# Exclude git data that is potentially backed up to a remote server
++ /gee/*/.gee/*  # do back up gee's metadata files
+- /gee/          # don't back up anything else in gee-controlled repositories
+- /.git/         # don't back up the contents of any .git directories.
+- **/.git/       # don't back up the contents of any .git directories.
+
 # Exclude these directories from backups:
-- /gee/        # don't back up gee-controlled repositories
-- /.git/       # don't back up the contents of any .git directories.
-- **/.git/    # don't back up the contents of any .git directories.
 - /bazel-**/
 - /**/bazel-*/  # bazel-out, bazel-bin, bazel-testlogs, bazel-<brname>, etc.
 - /.gvfs/                           # contains mounted file systems?

--- a/scripts/bkup
+++ b/scripts/bkup
@@ -207,6 +207,9 @@ EOT
   if ! [[ -e "${FILTERFILE}" ]]; then
     cat >"${FILTERFILE}" <<'EOT'
 # Exclude these directories from backups:
+- /gee/        # don't back up gee-controlled repositories
+- /.git/       # don't back up the contents of any .git directories.
+- **/.git/    # don't back up the contents of any .git directories.
 - /bazel-**/
 - /**/bazel-*/  # bazel-out, bazel-bin, bazel-testlogs, bazel-<brname>, etc.
 - /.gvfs/                           # contains mounted file systems?
@@ -225,7 +228,7 @@ EOT
 
 #Files:
 - bin/rclone
-- .bash_history
+- .bash_history*
 - .python_history
 - .xsession-errors            # contains errors from the current graphical session
 - .recently-used              # recently used files


### PR DESCRIPTION
bkup: add volume id support, filters

When I had to use bkup to restore an old laptop's file to a new laptop, one
snag I ran into is that bkup uses the docker ID as a UUID to disambiguate
different machines owned by the same user.  But if I want to restore another
machine's data to this one, I need a way to override the generated ID.

This PR solves the problem by dropping a "volume_id.txt" file in the
.config/rclone directory.  If this file doesn't exist, it is created
and populated with the docker image ID.  This file can be overriden
to restore backups that were created on a different machine.

I also added a "lsvolumes" command to list all available volume ids.

Also, I learned that git repositories are too big to realistically
save and restore.  These are *probably* backed up to remote servers,
so I updated bkup's filters to skip them entirely.

TODO(jonathan): prompt the user for a human-readable ID instead.

Tested:

*  Restored a backup created on another machine.
*  Ran "lsvolumes".

