### PR TITLE
marshal: Fix type detection when passed a URL

### DIFF
--- a/lib/config/marshal/select.go
+++ b/lib/config/marshal/select.go
@@ -31,7 +31,9 @@ var Known = []FileMarshaller{
 // Represents a sorted list of marshallers. Lowest index is the most preferred marshaller.
 type FileMarshallers []FileMarshaller
 
-// ByExtension returns the first FileMarshaller based on the extension of the path provided.
+// ByExtension returns the first FileMarshaller based on the extension of the
+// path provided. `path` can be either a local file path or a URL; if `path` is
+// a URL, the Path component of the URL is used for extension-based detection.
 func (fm FileMarshallers) ByExtension(path string) FileMarshaller {
 	u, err := url.Parse(path)
 	if err == nil && u != nil {

--- a/lib/config/marshal/select.go
+++ b/lib/config/marshal/select.go
@@ -2,11 +2,13 @@ package marshal
 
 import (
 	"fmt"
-	"github.com/enfabrica/enkit/lib/multierror"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/enfabrica/enkit/lib/multierror"
 )
 
 // Use marshal.Toml to encode/decode from Toml format.
@@ -31,6 +33,10 @@ type FileMarshallers []FileMarshaller
 
 // ByExtension returns the first FileMarshaller based on the extension of the path provided.
 func (fm FileMarshallers) ByExtension(path string) FileMarshaller {
+	u, err := url.Parse(path)
+	if err == nil && u != nil {
+		path = u.Path
+	}
 	ext := strings.TrimPrefix(filepath.Ext(path), ".")
 	if ext == "" {
 		return nil

--- a/lib/config/marshal/select_test.go
+++ b/lib/config/marshal/select_test.go
@@ -30,3 +30,38 @@ func TestMarshalFile(t *testing.T) {
 
 	assert.Equal(t, data, readback)
 }
+
+func TestFileMarshallersByExtension(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		path        string
+		wantEncoder FileMarshaller
+	}{
+		{
+			desc:        "absolute file path",
+			path:        "/foo/bar/baz.json",
+			wantEncoder: Json,
+		},
+		{
+			desc:        "relative file path",
+			path:        "foo/bar/baz.gob",
+			wantEncoder: Gob,
+		},
+		{
+			desc:        "url",
+			path:        "https://astore.example.com/g/foo/bar/baz.yaml",
+			wantEncoder: Yaml,
+		},
+		{
+			desc:        "url with query parameters",
+			path:        "https://astore.example.com/g/foo/bar/baz.toml?u=123abc",
+			wantEncoder: Toml,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := FileMarshallers(Known).ByExtension(tc.path)
+			assert.Equal(t, got, tc.wantEncoder)
+		})
+	}
+}


### PR DESCRIPTION
When a YAML config is included in another config today by URL, the
config language detection by extension fails because it is passed a URL
that has a query string suffix instead of a local file path. When this
happens, the default unmarshaler of JSON is used, which causes obtuse
parse errors to be thrown when parsing other formats.

This change first tries to parse the input path as a URL, falling back
to the assumption that the path is a local file path if URL parsing
fails. URL parsing allows us to pick out the path component, ignoring
all other components like query strings that may suffix the string.

Tested: Added unit test to demonstrate issue and verify fix.

Jira: INFRA-487