### PR TITLE
enkit outputs: Change mount paths for various files

### DIFF
--- a/lib/kbuildbarn/BUILD.bazel
+++ b/lib/kbuildbarn/BUILD.bazel
@@ -24,8 +24,8 @@ go_test(
         "protoparse_test.go",
         "urls_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//lib/bes:go_default_library",
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "//third_party/buildbuddy/proto:buildbuddy_go_proto",

--- a/lib/kbuildbarn/buddy.go
+++ b/lib/kbuildbarn/buddy.go
@@ -2,17 +2,52 @@ package kbuildbarn
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/enfabrica/enkit/lib/bes"
 	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
 )
 
 type FilterOption func(event *bespb.BuildEvent, baseName, invocation, clusterName string) HardlinkList
 
+func outputDirForTest(label string, run int32, attempt int32) string {
+	components := strings.Split(label, "//")
+	if len(components) != 2 {
+		return ""
+	}
+	return filepath.Join(
+		"bazel-testlogs",
+		strings.Replace(components[1], ":", "/", -1),
+		fmt.Sprintf("run_%d", run),
+		fmt.Sprintf("attempt_%d", attempt),
+	)
+}
+
 func WithTestResults() FilterOption {
 	return func(event *bespb.BuildEvent, baseName, invocation, clusterName string) HardlinkList {
 		testResult := event.GetTestResult()
 		if testResult != nil {
-			return GenerateLinksForFiles(testResult.TestActionOutput, baseName, invocation, clusterName)
+			// Files that are typically in a test.outputs subdirectory come to this
+			// name field with the basename joined to the dirname with `__`. Turn this
+			// back into a path so we don't end up with paths like
+			// `test.outputs__outputs.zip`
+			for _, tao := range testResult.TestActionOutput {
+				tao.Name = strings.Replace(tao.Name, "__", "/", -1)
+			}
+
+			return GenerateLinksForFiles(
+				testResult.TestActionOutput,
+				baseName,
+				outputDirForTest(
+					event.GetId().GetTestResult().GetLabel(),
+					event.GetId().GetTestResult().GetRun(),
+					event.GetId().GetTestResult().GetShard(),
+				),
+				invocation,
+				clusterName,
+			)
 		}
 		return nil
 	}
@@ -22,7 +57,7 @@ func WithNamedSetOfFiles() FilterOption {
 	return func(event *bespb.BuildEvent, baseName, invocation, clusterName string) HardlinkList {
 		nsof := event.GetNamedSetOfFiles()
 		if nsof != nil {
-			return GenerateLinksForFiles(nsof.Files, baseName, invocation, clusterName)
+			return GenerateLinksForFiles(nsof.Files, baseName, "", invocation, clusterName)
 		}
 		return nil
 	}

--- a/lib/kbuildbarn/buddy_test.go
+++ b/lib/kbuildbarn/buddy_test.go
@@ -1,19 +1,20 @@
-package kbuildbarn_test
+package kbuildbarn
 
 import (
 	"bytes"
 	"context"
-	"github.com/enfabrica/enkit/lib/bes"
-	"github.com/enfabrica/enkit/lib/kbuildbarn"
-	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
-	bbpb "github.com/enfabrica/enkit/third_party/buildbuddy/proto"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/enfabrica/enkit/lib/bes"
+	bespb "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
+	bbpb "github.com/enfabrica/enkit/third_party/buildbuddy/proto"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeResults(t *testing.T) {
@@ -41,13 +42,13 @@ func TestMergeResults(t *testing.T) {
 	testHttpClient := newTestHttpClient(t, 200, e)
 	buddy := bes.NewTestClient(testHttpClient)
 	ctx := context.TODO()
-	onlyTestResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithTestResults())
+	onlyTestResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithTestResults())
 	assert.NoError(t, err)
 	assert.Equal(t, len(sameFiles), len(onlyTestResults))
-	onlyNamedFileResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithNamedSetOfFiles())
+	onlyNamedFileResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithNamedSetOfFiles())
 	assert.NoError(t, err)
 	assert.Equal(t, len(sameFiles), len(onlyNamedFileResults))
-	allResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithNamedSetOfFiles(), kbuildbarn.WithTestResults())
+	allResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithNamedSetOfFiles(), WithTestResults())
 	assert.NoError(t, err)
 	assert.Equal(t, len(sameFiles), len(allResults))
 
@@ -59,7 +60,7 @@ func TestMergeResults(t *testing.T) {
 
 }
 
-func linkToDestArray(l kbuildbarn.HardlinkList) []string {
+func linkToDestArray(l HardlinkList) []string {
 	var s []string
 	for _, v := range l {
 		s = append(s, v.Dest)
@@ -96,13 +97,13 @@ func TestUniqueResponses(t *testing.T) {
 	testHttpClient := newTestHttpClient(t, 200, e)
 	buddy := bes.NewTestClient(testHttpClient)
 	ctx := context.TODO()
-	onlyTestResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithTestResults())
+	onlyTestResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithTestResults())
 	assert.NoError(t, err)
 	assert.Equal(t, sharedFileSize, len(onlyTestResults))
-	onlyNamedFileResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithNamedSetOfFiles())
+	onlyNamedFileResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithNamedSetOfFiles())
 	assert.NoError(t, err)
 	assert.Equal(t, namedSetSize+sharedFileSize, len(onlyNamedFileResults))
-	allResults, err := kbuildbarn.GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", kbuildbarn.WithNamedSetOfFiles(), kbuildbarn.WithTestResults())
+	allResults, err := GenerateHardlinks(ctx, buddy, "/base", "invocation", "cluster", WithNamedSetOfFiles(), WithTestResults())
 	assert.NoError(t, err)
 	assert.Equal(t, namedSetSize+sharedFileSize, len(allResults))
 

--- a/lib/kbuildbarn/urls_test.go
+++ b/lib/kbuildbarn/urls_test.go
@@ -1,9 +1,9 @@
-package kbuildbarn_test
+package kbuildbarn
 
 import (
-	"github.com/enfabrica/enkit/lib/kbuildbarn"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type BytStreamResult struct {
@@ -54,7 +54,7 @@ var TestByteStreamUrlTable = []BytStreamResult{
 
 func TestByteStreamUrl(t *testing.T) {
 	for _, c := range TestByteStreamUrlTable {
-		hash, size, err := kbuildbarn.ParseByteStreamUrl(c.Url)
+		hash, size, err := ParseByteStreamUrl(c.Url)
 		if c.ShouldFail {
 			assert.Error(t, err)
 		} else {
@@ -67,34 +67,34 @@ func TestByteStreamUrl(t *testing.T) {
 
 func TestDefaultUrlGeneration(t *testing.T) {
 	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
-	hash, size, err := kbuildbarn.ParseByteStreamUrl(exampleUrl)
+	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	assert.NoError(t, err)
 	baseName := "buildbarn.local"
-	assert.Equal(t, "http://buildbarn.local/blobs/action/foo-bar", kbuildbarn.Url(baseName, hash, size, kbuildbarn.WithActionUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/command/foo-bar", kbuildbarn.Url(baseName, hash, size, kbuildbarn.WithCommandUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/directory/foo-bar", kbuildbarn.Url(baseName, hash, size, kbuildbarn.WithDirectoryUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/", kbuildbarn.Url(baseName, hash, size, kbuildbarn.WithFileName("")))
+	assert.Equal(t, "http://buildbarn.local/blobs/action/foo-bar", Url(baseName, hash, size, WithActionUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/command/foo-bar", Url(baseName, hash, size, WithCommandUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/directory/foo-bar", Url(baseName, hash, size, WithDirectoryUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/", Url(baseName, hash, size, WithFileName("")))
 }
 
 func TestFileUrlGeneration(t *testing.T) {
 	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
-	hash, size, err := kbuildbarn.ParseByteStreamUrl(exampleUrl)
+	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "buildbarn.local"
 	assert.NoError(t, err)
-	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/mickey.mouse", kbuildbarn.Url(basename, hash, size, kbuildbarn.WithFileName("mickey.mouse")))
+	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/mickey.mouse", Url(basename, hash, size, WithFileName("mickey.mouse")))
 }
 func TestByteStreamGeneration(t *testing.T) {
 	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
-	hash, size, err := kbuildbarn.ParseByteStreamUrl(exampleUrl)
+	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "buildbarn.local"
 	assert.NoError(t, err)
-	assert.Equal(t, "bytestream://buildbarn.local/blobs/foo/bar", kbuildbarn.Url(basename, hash, size, kbuildbarn.WithByteStreamTemplate()))
+	assert.Equal(t, "bytestream://buildbarn.local/blobs/foo/bar", Url(basename, hash, size, WithByteStreamTemplate()))
 }
 
 func TestFileGeneration(t *testing.T) {
 	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
-	hash, size, err := kbuildbarn.ParseByteStreamUrl(exampleUrl)
+	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "/root"
 	assert.NoError(t, err)
-	assert.Equal(t, "/root/blobs/file/foo-bar/foo.go", kbuildbarn.File(basename, hash, size, kbuildbarn.WithFileName("foo.go")))
+	assert.Equal(t, "/root/blobs/file/foo-bar/foo.go", File(basename, hash, size, WithFileName("foo.go")))
 }


### PR DESCRIPTION
Prior to this change, all files mentioned in the output stream are
mounted in the scratch directory under the invocation ID using the path
specified in the BuildEvent message verbatim. This change modifies paths
in the following way:

* If the artifact is a test artifact, it is rerooted at
  `bazel-testlogs/$LABEL/$RUN/$ATTEMPT/`, where `$LABEL` is a subdirectory
  generated from the test target's label, `$RUN` is the run number
  (there may be multiple runs for a given test if `--runs_per_test` was
   passed on the bazel commandline) and `$ATTEMPT` is the attempt number
  (if bazel retried a test marked flaky).

* If the artifact is a test artifact, its path is unmangled by replacing
  `__` with `/`, which allows paths like `test.outputs__outputs.zip` to
  be the more intelligible `test.outputs/outputs.zip`.

* If the artifact is a build artifact (has a path prefix of
  `bazel-out/$CONFIG/bin` for any `$CONFIG`, it is rerooted under a
  `bazel-bin` subdirectory.

This change also modifies the unit tests to follow conventions:

* Unit tests are part of the same package as the actual library
* Expected Hardlink list is constructed directly and tested with
  `assert.ElementsMatch`, which removes a nil panic from the test when
  the test fails.

Tested:

* Mounted last HW regression to see all testlogs: `enkit outputs
  mount --invocation-id 0c7c3857-c823-4092-bb0d-8e7ec7c80a73`
* Modified unit tests to ensure `subdir` is added to dest path correctly

Jira: INFRA-546