### PR TITLE
astore_upload: Base script name off of target name

### DIFF
--- a/astore/client/BUILD.bazel
+++ b/astore/client/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/astore:defs.bzl", "astore_upload")
 
 go_library(
     name = "go_default_library",
@@ -47,8 +48,6 @@ go_binary(
     static = "on",
     visibility = ["//visibility:public"],
 )
-
-load("//bazel/astore:defs.bzl", "astore_upload")
 
 astore_upload(
     name = "deploy",

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -9,7 +9,7 @@ def astore_url(package, uid, instance = "https://astore.corp.enfabrica.net"):
     )
 
 def _astore_upload(ctx):
-    push = ctx.actions.declare_file("astore_upload.sh")
+    push = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
 
     if ctx.attr.dir and ctx.attr.file:
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")


### PR DESCRIPTION
This change ensures that the script generated by `astore_upload` rules
has a unique name per `astore_upload` target, so that multiple
`astore_upload` targets can coexist in the same BUILD file.

Tested: `bazel aquery //developer/enkit:all` errors in enfabrica/internal on master currently, but doesn't error with enkit patched with this change: `bazel aquery //developer/enkit:all --override_repository=enkit=/home/bminor/dev/enkit`

Jira: INFRA-583