### PR TITLE
machinist:  remove atomic integer count

### DIFF
--- a/machinist/polling/register.go
+++ b/machinist/polling/register.go
@@ -29,7 +29,7 @@ func SendRegisterRequests(ctx context.Context, client machinist_rpc.ControllerCl
 			_, err := pollStream.Recv()
 			s, ok := status.FromError(err)
 			if ok {
-				l.Errorf("unable to send register request: %+v", s)
+				l.Errorf("unable to send register request: %+v", s.Message())
 			} else {
 				l.Errorf("unable to send request, unknown err: %w", err)
 			}


### PR DESCRIPTION
Problem:

atomic integers pin a cpu if dmesg is flooded, this removes the atomic integer.  

This is technically a NoOp since we don't have any grafana metrics currently using these machinist metrics.


Tested:
Ran 
```
bazelisk run //machinist/cmd:cmd -- controlplane --port=8080 --domains=hello.world --bind-net=127.0.0.1
```
```
bazelisk run //machinist/cmd:cmd -- node poll --auth-server=https://auth.corp.enfabrica.net --control-port=8080 --control-host=127.0.0.1 --ips=99.99.99.99 --name=hello
```
Flooded Dmesg via iptables:
```
sudo iptables -A INPUT -j LOG --log-level 3
```
And watched process usage.