### PR TITLE
bestie: Add py_proto_library target for test_metrics.proto

### DIFF
--- a/bestie/proto/BUILD.bazel
+++ b/bestie/proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -27,5 +28,11 @@ go_library(
         ":bestie_go_proto"
     ],
     importpath = "github.com/enfabrica/enkit/bestie/proto",
+    visibility = ["//visibility:public"],
+)
+
+py_proto_library(
+    name = "bestie_py_proto",
+    srcs = ["test_metrics.proto"],
     visibility = ["//visibility:public"],
 )

--- a/bestie/proto/test_metrics.proto
+++ b/bestie/proto/test_metrics.proto
@@ -46,13 +46,13 @@ option go_package = "github.com/enfabrica/enkit/bestie/proto";
 //       updating the BES Endpoint service.
 message TestMetric {
     string metricname = 1;
-    repeated KeyValuePair tags = 2;
+    repeated Tag tags = 2;
     double value = 3;
     int64 timestamp = 4;  // nanoseconds since epoch (e.g. Python: time.time_ns())
 }
 
 // Each metric tag must be supplied in the form of a key/value string pair.
-message KeyValuePair {
+message Tag {
     string key = 1;
     string value = 2;
 }


### PR DESCRIPTION
The enkit repo owns the definition of test_metrics.proto and needs
to produce each of the language-specific protobuf libraries being
used, currently Go and Python. The latter is @enkit referenced
by the internal repo for writing metrics to its test.metrics.pb file.

Summary of changes:
- Added py_proto_library() target in bestie/proto/BUILD.bazel.
- Renamed KeyValuePair submessage to Tag in test_metrics.proto file.

Tested: Using a local instance of BES Endpoint, sent simulated test
metrics in a test.metrics.pb file for processing by the endpoint.
Required use of the --override_repository command line arg by
the client 'bazel test' command to reference the changes in the
enkit repo.

Jira: INFRA-593