### PR TITLE
enkit: Import gRPC to fix py_proto_library issue

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,27 @@ enkit_init()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "com_github_grpc_grpc",
+    patch_args = ["-p1"],
+    patches = [
+        "//bazel/dependencies/grpc:no_remote_tag.patch",
+    ],
+    sha256 = "12a4a6f8c06b96e38f8576ded76d0b79bce13efd7560ed22134c2f433bc496ad",
+    strip_prefix = "grpc-1.41.1",
+    urls = [
+        "https://github.com/grpc/grpc/archive/refs/tags/v1.41.1.tar.gz",
+    ],
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()
+
+http_archive(
     name = "com_github_bazelbuild_buildtools",
     strip_prefix = "buildtools-master",
     url = "https://github.com/bazelbuild/buildtools/archive/master.zip",

--- a/bazel/dependencies/grpc/no_remote_tag.patch
+++ b/bazel/dependencies/grpc/no_remote_tag.patch
@@ -1,0 +1,87 @@
+diff --git a/bazel/cython_library.bzl b/bazel/cython_library.bzl
+index 8e003c2246..8439e7723b 100644
+--- a/bazel/cython_library.bzl
++++ b/bazel/cython_library.bzl
+@@ -73,6 +73,7 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
+             srcs = [stem + ".cpp"],
+             deps = deps + ["@local_config_python//:python_headers"],
+             linkshared = 1,
++            tags = ["no-remote"],
+         )
+         shared_objects.append(shared_object_name)
+ 
+diff --git a/third_party/py/python_configure.bzl b/third_party/py/python_configure.bzl
+index d06fa2b558..bc4ec126e1 100644
+--- a/third_party/py/python_configure.bzl
++++ b/third_party/py/python_configure.bzl
+@@ -93,14 +93,21 @@ def _read_dir(repository_ctx, src_dir):
+         )
+         return find_result.stdout
+ 
+-def _genrule(src_dir, genrule_name, command, outs):
++def _genrule(src_dir, genrule_name, command, outs, tags = []):
+     """Returns a string with a genrule.
+ 
+   Genrule executes the given command and produces the given outputs.
+   """
+-    return ("genrule(\n" + '    name = "' + genrule_name + '",\n' +
+-            "    outs = [\n" + outs + "\n    ],\n" + '    cmd = """\n' +
+-            command + '\n   """,\n' + ")\n")
++    genrule = ("genrule(\n" + '    name = "' + genrule_name + '",\n' +
++               "    outs = [\n" + outs + "\n    ],\n" + '    cmd = """\n' +
++               command + '\n   """,\n')
++    if tags:
++        genrule += "    tags = [\n"
++        for tag in tags:
++            genrule += '"' + tag + '"\n'
++        genrule += "\n    ],\n"
++    genrule += ")\n"
++    return genrule
+ 
+ def _normalize_path(path):
+     """Returns a path with '/' and remove the trailing slash."""
+@@ -150,6 +157,7 @@ def _symlink_genrule_for_dir(
+         genrule_name,
+         " && ".join(command),
+         "\n".join(outs),
++        ["no-remote"],
+     )
+ 
+ def _get_python_bin(repository_ctx, bin_path_key, default_bin_path, allow_absent):
+@@ -293,11 +301,13 @@ def _create_single_version_package(
+ 
+     python_bin = _get_python_bin(repository_ctx, bin_path_key, default_bin_path, allow_absent)
+     if (python_bin == None or
+-        _check_python_bin(repository_ctx,
+-                          python_bin,
+-                          bin_path_key,
+-                          allow_absent) == None) and allow_absent:
+-            python_include_rule = empty_include_rule
++        _check_python_bin(
++            repository_ctx,
++            python_bin,
++            bin_path_key,
++            allow_absent,
++        ) == None) and allow_absent:
++        python_include_rule = empty_include_rule
+     else:
+         python_lib = _get_python_lib(repository_ctx, python_bin, lib_path_key)
+         _check_python_lib(repository_ctx, python_lib)
+@@ -350,7 +360,7 @@ def _python_autoconf_impl(repository_ctx):
+         _PYTHON2_BIN_PATH,
+         "python2",
+         _PYTHON2_LIB_PATH,
+-        True
++        True,
+     )
+     _create_single_version_package(
+         repository_ctx,
+@@ -358,7 +368,7 @@ def _python_autoconf_impl(repository_ctx):
+         _PYTHON3_BIN_PATH,
+         "python3",
+         _PYTHON3_LIB_PATH,
+-        False
++        False,
+     )
+     _tpl(repository_ctx, "BUILD")
+ 


### PR DESCRIPTION
This change imports gRPC to fix an issue where `py_proto_library`
targets work in workspaces that import enkit but not in enkit
standalone.

The crux of the issue is that other workspaces rely on gRPC's workspace
rules to initialize various binds, including one that maps local Python
headers to `//external:python_headers`. Since enkit doesn't import grpc,
it doesn't make this bind, which breaks the build graph.

This change moves the gRPC import configuration from
`enfabrica/internal` to this repository; once we update the enkit
reference in internal, the grpc initialization code there can be
dropped.

Tested: `bazel query 'deps(//...)'` was broken with #471 but is working
with #471 and this change.