### PR TITLE
flextape: Add license release type metric

### DIFF
--- a/flextape/service/license.go
+++ b/flextape/service/license.go
@@ -43,6 +43,15 @@ var (
 			"license_type",
 		},
 	)
+	metricLicenseReleaseReason = promauto.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: "flextape",
+		Name:      "license_release_count",
+		Help:      "License release count by reason",
+	},
+		[]string{
+			"reason",
+		},
+	)
 )
 
 // license manages allocations and queued invocations for a single license type.
@@ -116,6 +125,7 @@ func (l *license) ExpireAllocations(expiry time.Time) {
 	for k, v := range l.allocations {
 		if !v.LastCheckin.After(expiry) {
 			l.prioritizer.OnRelease(v)
+			metricLicenseReleaseReason.WithLabelValues("allocated_expired").Inc()
 			continue
 		}
 		newAllocations[k] = v
@@ -133,6 +143,7 @@ func (l *license) ExpireQueued(expiry time.Time) {
 		}
 
 		l.prioritizer.OnDequeue(inv)
+		metricLicenseReleaseReason.WithLabelValues("queued_expired").Inc()
 		return true
 	})
 }
@@ -183,6 +194,7 @@ func (l *license) Forget(invID string) int {
 	newAllocations := map[string]*invocation{}
 	for k, v := range l.allocations {
 		if k == invID {
+			metricLicenseReleaseReason.WithLabelValues("allocated_released").Inc()
 			l.prioritizer.OnRelease(v)
 			count++
 			continue
@@ -194,6 +206,7 @@ func (l *license) Forget(invID string) int {
 	if inv := l.queue.Forget(invID); inv != nil {
 		l.prioritizer.OnDequeue(inv)
 		count += 1
+		metricLicenseReleaseReason.WithLabelValues("queued_released").Inc()
 	}
 
 	l.allocations = newAllocations


### PR DESCRIPTION
This change adds a metric that tracks the count of license releases
across different reasons, including when licenses expire. This is
intended to help debug an issue where errors are being returned by
Flextape for unknown invocations.

If we see metrics indicating that these invocations are expiring prior
to these errors being returned, we may be able to narrow down the
problem. In general, it will be useful to see how often expirations
occur, as ideally this would be close to 0.

Jira: INFRA-607