### PR TITLE
faketree: support mount options.

### DIFF
--- a/faketree/faketree_test.go
+++ b/faketree/faketree_test.go
@@ -78,4 +78,22 @@ func TestParseFlags(t *testing.T) {
 
 	args = fl.Args()
 	assert.Equal(t, []string{"--uid", "12", "--gid", u.Gid, "--faketree", fl.Faketree, "--mount", "/etc/hosts:/tmp/hosts", "--mount", "/proc:/tmp/proc"}, args)
+
+	fl = NewFlags()
+	left, err = fl.Parse([]string{
+		"--uid=12", "--mount", ":/tmp/proc:ro,type=proc,data=foo", "--", "no pig",
+	})
+	assert.NoError(t, err)
+
+	args = fl.Args()
+	assert.Equal(t, []string{"--uid", "12", "--gid", u.Gid, "--faketree", fl.Faketree, "--mount", ":/tmp/proc:ro,type=proc,data=foo"}, args)
+
+	fl = NewFlags()
+	left, err = fl.Parse([]string{
+		"--uid=12", "--mount", "/test:/tmp/proc:   ro  ,recursive ,data=foo,bar,baz", "--", "no pig",
+	})
+	assert.NoError(t, err)
+
+	args = fl.Args()
+	assert.Equal(t, []string{"--uid", "12", "--gid", u.Gid, "--faketree", fl.Faketree, "--mount", "/test:/tmp/proc:ro,recursive,data=foo,bar,baz"}, args)
 }

--- a/faketree/faketree_test.sh
+++ b/faketree/faketree_test.sh
@@ -67,3 +67,8 @@ $ft -- sh -c 'pwd' &>/dev/null
 test "$?" == 0 || {
   fail "faketree did not succeed even after the command was fixed"
 }
+
+$ft --fail --mount :/tmp/root/mytmp:ro,type=tmpfs -- sh -c "cat /proc/mounts" 2>/dev/null |egrep "tmpfs\s+/tmp/root/mytmp\s+tmpfs\s+ro"
+test "$?" == 0 || {
+  fail "faketree mounts do not show the just mounted tmpfs directory"
+}


### PR DESCRIPTION
Background:
So far, faketree only supported bind mounts, eg, mounting one directory
on top of another.

This PR:
- implements a TODO in code, completing support for mounting arbitrary
  directories.

This is partially in preparation for the next PR, where more of this
feature will be needed, and is a step toward fixing INFRA-256 and 
INFRA-535.

Tested: added unit tests, passing.