### PR TITLE
gee pr_make: support DRAFT and ABORT

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1650,8 +1650,10 @@ function _get_pull_requests() {
   fi
   "${GH}" pr view \
     --repo="${UPSTREAM}/${REPO}" "${FROM_BRANCH}" \
-    --json "state,number,title" \
-    --jq '[.state, .number, .title] | join(" ")' \
+    --json "state,number,title,isDraft" \
+    --jq 'if .isDraft then ["DRAFT", .number, .title] ' \
+      'else [.state, .number, .title] ' \
+      '| join(" ")' \
     | cat
 }
 
@@ -2959,6 +2961,7 @@ function gee__pr_debug() {
   _check_cwd
   _check_gh_auth
   local -a PRS=()
+  _get_pull_requests "$(_get_current_branch)"
   mapfile -t PRS < <( _list_open_pr_numbers )
   _info "Open pull requests: ${PRS[*]}"
   mapfile -t PRS < <( _list_merged_pr_numbers "")
@@ -3021,12 +3024,21 @@ function gee__pr_make() {
   _info "Destination branch: ${DEST_BRANCH}"
   _info "Merge base: ${MERGE_BASE}"
 
-  local -a OPEN_PRS
-  mapfile -t OPEN_PRS < <( _list_open_pr_numbers )
-  if (( "${#OPEN_PRS[@]}" )); then
-    _info "Open PR exists: ${OPEN_PRS[*]}" \
+  local STATE NUMBER TITLE
+  read -r STATE NUMBER TITLE < \
+    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED)
+  if [[ "${STATE}" == "OPEN" ]]; then
+    _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \
           "Use \"gee commit\" to update existing PR."
     _fatal Aborted.
+  elif [[ "${STATE}" == "DRAFT" ]]; then
+    _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
+    if _confirm_default_yes "Do you want to mark PR as ready for review? (Y/n)  "; then
+      _gh pr ready "${NUMBER}"
+      exit 0
+    else
+      _fatal "Leaving PR #${NUMBER} as a draft."
+    fi
   fi
 
   local UNCOMMITTED
@@ -3149,6 +3161,7 @@ EndOfPrTemplate
 
   local DRAFT=0
   if grep --quiet -E "^\s*DRAFT" "${BODYFILE}"; then
+    DRAFT=1
     PR_ARGS+=( --draft )
   fi
 
@@ -3156,16 +3169,21 @@ EndOfPrTemplate
 
   _gh pr create "${PR_ARGS[@]}"
 
-  gee__codeowners --comment
+  if (( DRAFT != 1 )); then
+    gee__codeowners --comment
+  fi
 
   # _gh pr checks  # These take a while to run, no point checking now.
   _gh_pr_view
-  local NUM_REVIEWERS
-  NUM_REVIEWERS="$(gh pr view \
-    --repo "${UPSTREAM}/${REPO}" "${GHUSER}:${CURRENT_BRANCH}" \
-    --json reviewRequests --jq '.reviewRequests | length')"
-  if (( NUM_REVIEWERS == 0 )); then
-    _warn "Don't forget to add reviewers!"
+
+  if (( DRAFT != 1 )); then
+    local NUM_REVIEWERS
+    NUM_REVIEWERS="$(gh pr view \
+      --repo "${UPSTREAM}/${REPO}" "${GHUSER}:${CURRENT_BRANCH}" \
+      --json reviewRequests --jq '.reviewRequests | length')"
+    if (( NUM_REVIEWERS == 0 )); then
+      _warn "Don't forget to add reviewers!"
+    fi
   fi
   rm "${BODYFILE}"
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -147,7 +147,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.22"
+readonly VERSION="0.2.23"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3085,6 +3085,9 @@ Tested:
 # For example:
 # Jira: PROJ-1234,PROJ-5678
 
+# Having second thoughts?  Uncomment one of these two lines:
+# DRAFT   # To mark this PR as a "draft"
+# ABORT   # To abort the creation of a PR.
 
 EndOfPrTemplate
 
@@ -3116,6 +3119,11 @@ EndOfPrTemplate
   # lines into single blank lines:
   sed -i '/^#/d;/\S/,/^\s*$/!d' "${BODYFILE}"
 
+  if grep -E "^\s*ABORT"; then
+    _fatal "Aborting creation of new PR, as requested."
+    exit 1
+  fi
+
   # Check that the PR description looks valid
   _check_pr_description "${BODYFILE}"
 
@@ -3138,7 +3146,14 @@ EndOfPrTemplate
     -H "${GHUSER}:${CURRENT_BRANCH}"
     --body-file "${BODYFILE}"
   )
+
+  local DRAFT=0
+  if grep -E "^\s*DRAFT"; then
+    PR_ARGS+=( --draft )
+  fi
+
   PR_ARGS+=( "$@" )
+
   _gh pr create "${PR_ARGS[@]}"
 
   gee__codeowners --comment

--- a/scripts/gee
+++ b/scripts/gee
@@ -1648,12 +1648,14 @@ function _get_pull_requests() {
     # gh-cli treats this as a special case for some reason.
     FROM_BRANCH="${BRANCH}"
   fi
+  local Q
+  Q='if .isDraft then ["DRAFT", .number, .title] '
+  Q+='else [.state, .number, .title] '
+  Q+='end | join(" ")'
   "${GH}" pr view \
     --repo="${UPSTREAM}/${REPO}" "${FROM_BRANCH}" \
     --json "state,number,title,isDraft" \
-    --jq 'if .isDraft then ["DRAFT", .number, .title] ' \
-      'else [.state, .number, .title] ' \
-      '| join(" ")' \
+    --jq "${Q}" \
     | cat
 }
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3148,7 +3148,7 @@ EndOfPrTemplate
   )
 
   local DRAFT=0
-  if grep -E "^\s*DRAFT"; then
+  if grep -E "^\s*DRAFT" "${BODYFILE}"; then
     PR_ARGS+=( --draft )
   fi
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3036,7 +3036,7 @@ function gee__pr_make() {
   elif [[ "${STATE}" == "DRAFT" ]]; then
     _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
     if _confirm_default_yes "Do you want to mark this PR as ready for review? (Y/n)  "; then
-      _gh pr ready "${NUMBER}"
+      _gh pr ready "${NUMBER}" || echo $?
       exit 0
     else
       _info "Leaving PR #${NUMBER} as a draft."

--- a/scripts/gee
+++ b/scripts/gee
@@ -3119,7 +3119,7 @@ EndOfPrTemplate
   # lines into single blank lines:
   sed -i '/^#/d;/\S/,/^\s*$/!d' "${BODYFILE}"
 
-  if grep -E "^\s*ABORT" "${BODYFILE}"; then
+  if grep --quiet -E "^\s*ABORT" "${BODYFILE}"; then
     _fatal "Aborting creation of new PR, as requested."
     exit 1
   fi
@@ -3148,7 +3148,7 @@ EndOfPrTemplate
   )
 
   local DRAFT=0
-  if grep -E "^\s*DRAFT" "${BODYFILE}"; then
+  if grep --quiet -E "^\s*DRAFT" "${BODYFILE}"; then
     PR_ARGS+=( --draft )
   fi
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3035,11 +3035,12 @@ function gee__pr_make() {
     _fatal Aborted.
   elif [[ "${STATE}" == "DRAFT" ]]; then
     _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
-    if _confirm_default_yes "Do you want to mark PR as ready for review? (Y/n)  "; then
+    if _confirm_default_yes "Do you want to mark this PR as ready for review? (Y/n)  "; then
       _gh pr ready "${NUMBER}"
       exit 0
     else
-      _fatal "Leaving PR #${NUMBER} as a draft."
+      _info "Leaving PR #${NUMBER} as a draft."
+      exit 0
     fi
   fi
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3119,7 +3119,7 @@ EndOfPrTemplate
   # lines into single blank lines:
   sed -i '/^#/d;/\S/,/^\s*$/!d' "${BODYFILE}"
 
-  if grep -E "^\s*ABORT"; then
+  if grep -E "^\s*ABORT" "${BODYFILE}"; then
     _fatal "Aborting creation of new PR, as requested."
     exit 1
   fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -3000,7 +3000,12 @@ _register_help "pr_make" \
   "mail" "send" "make_pr" "mkpr" "prmk" <<'EOT'
 Usage: gee make_pr <gh-options>
 
-Creates a new pull request from this branch.
+Creates a new pull request from this branch.  The user will be asked to
+edit a PR description file before the PR is created.
+
+If you have any second thoughts during this process: Adding the token "DRAFT"
+to your PR description will cause the PR to be marked as a draft.  Adding the
+token "ABORT" will cause gee to abort the creation of your PR.
 
 Uses the same options as "gh pr create".
 EOT

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -1,0 +1,7 @@
+# gee changelog
+
+## Releases
+
+### Release 0.2.23
+
+* `pr_make`: Add support for marking PRs as "DRAFTs" or "ABORTing".


### PR DESCRIPTION
gee pr_make: support DRAFT and ABORT

Tested:

Used this PR to test:  PR was at first aborted, then
marked as a draft, and the converted from draft to ready.

