### PR TITLE
bestie: Add cc_proto_library target for test_metrics.proto

### DIFF
--- a/bestie/proto/BUILD.bazel
+++ b/bestie/proto/BUILD.bazel
@@ -13,6 +13,12 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
+cc_proto_library(
+    name = "bestie_cc_proto",
+    deps = [":test_metrics_proto"],
+    visibility = ["//visibility:public"],
+)
+
 go_proto_library(
     name = "bestie_go_proto",
     importpath = "github.com/enfabrica/enkit/bestie/proto",


### PR DESCRIPTION
Anticipating BES Endpoint usage by the performance test team,
whose test cases are written in C++, this change adds a build
target to create the C++ protobuf bindings for the test_metrics.proto
file, which can be externally referenced from the internal repo
as "@enkit//bestie/proto:bestie_cc_proto".

Tested: 'bazel build //bestie/proto:bestie_cc_proto` to generate
the appropriate C++ protobuf .h and .cc files.

Jira: INFRA-615