### PR TITLE
faketree: change how the pid namespace is handled.

### DIFF
--- a/faketree/faketree_test.sh
+++ b/faketree/faketree_test.sh
@@ -72,3 +72,16 @@ $ft --fail --mount :/tmp/root/mytmp:ro,type=tmpfs -- sh -c "cat /proc/mounts" 2>
 test "$?" == 0 || {
   fail "faketree mounts do not show the just mounted tmpfs directory"
 }
+
+$ft --fail --mount :/proc:type=proc -- sh -c 'echo $$' &>/dev/null
+test "$?" == 125 || {
+  fail "faketree allowed to mount /proc despite --fail and no --proc option"
+}
+
+shpid=$($ft --fail -- sh -c 'echo $$')
+test "$?" == 0 || {
+  fail "faketree failed to run a simple 'echo $$'"
+}
+test "$shpid" != 1 || {
+  fail "shell had pid of init in a dedicated pid namespace"
+}


### PR DESCRIPTION
Before this PR:

The PID namespace was created *LAST*, just before execing the
desired command. This caused "a few problems":

1) The spawned command was effectively PID 1 in the namespace.
   PID 1 is always a bit of an oddball, as the kernel treats it
   differently from other processes. See "man pid_namespaces"
   for details.

   Specifically, if PID 1 dies all its children are SIGKILLed
   automatically by the kernel, which in turn means that child
   management has to be done correctly in the spawned command
   (makes next PR not working/impossible to implement).

2) If --mount of /proc was specified, the mount would either
   not work, or point to /proc outside of the namespace.

   Mounting it correctly *required* doing it after the PID
   namespace is mounted. Further, golang libraries fail
   to properly create a uid and gid namespace unless
   /proc is re-mounted (see comment in code).

Goal of this PR is to make sure a) faketree remains the PID#1,
b) /proc is mounted correctly. Both a) and b) can only be done
together.

Additionally:
- clarified help string and messages, now that the API has settled
  a little bit, and mounts are working as expected.

Tested:
- unit tests are still passing - note that the different PID
  mechanics was causing most tests to fail at first attempt
  (no correct /proc handling).
- added a few trivial tests.

This is another step toward a workaround for INFRA-256 and INFRA-535.