### PR TITLE
bats_core: add missing source files, patch BATS_ROOT bug.

### DIFF
--- a/bazel/dependencies/BUILD.bats.bazel
+++ b/bazel/dependencies/BUILD.bats.bazel
@@ -3,7 +3,7 @@
 
 sh_library(
     name = "bats_lib",
-    srcs = glob(["libexec/**"]),
+    srcs = glob(["lib/**", "libexec/**"]),
 )
 
 sh_binary(

--- a/bazel/dependencies/BUILD.bazel
+++ b/bazel/dependencies/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["*.patch"],
+    visibility=["//visibility:public"],
+)

--- a/bazel/dependencies/bats_root.patch
+++ b/bazel/dependencies/bats_root.patch
@@ -1,0 +1,13 @@
+diff --git a/bin/bats b/bin/bats
+index 1f7ce2e..269caf0 100755
+--- a/bin/bats
++++ b/bin/bats
+@@ -54,6 +54,7 @@ if ! BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}" 2>/dev/null); then
+   BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}")
+ fi
+ 
+-export BATS_ROOT=${BATS_PATH%/*/*}
++export BATS_ROOT="${BATS_PATH%/bats}"
++export BATS_ROOT="${BATS_ROOT%/bin}"
+ export -f bats_readlinkf
+ exec env BATS_ROOT="$BATS_ROOT" "$BATS_ROOT/libexec/bats-core/bats" "$@"

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -59,18 +59,24 @@ def enkit_deps():
         )
 
         http_archive(
-            name = "bats_core",
-            url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.4.1.tar.gz",
-            strip_prefix = "bats-core-1.4.1",
-            build_file = "@enkit//bazel/dependencies:BUILD.bats.bazel",
-            sha256 = "bff517da043ae24440ec8272039f396c2a7907076ac67693c0f18d4a17c08f7d",
-        )
-        http_archive(
             name = "bats_file",
             url = "https://github.com/bats-core/bats-file/archive/refs/tags/v0.2.0.tar.gz",
             strip_prefix = "bats-file-0.2.0",
             build_file = "@enkit//bazel/dependencies:BUILD.bats_file.bazel",
             sha256 = "1fa26407a68f4517cf9150d4763779ee66946a68eded33fa182ddf6a795c5062",
+        )
+
+        http_archive(
+            name = "bats_core",
+            url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.5.0.tar.gz",
+            strip_prefix = "bats-core-1.5.0",
+            sha256 = "36a3fd4413899c0763158ae194329af8f48bb1ff0d1338090b80b3416d5793af",
+            patch_args = ["-p1"],
+            patch_tool = "patch",
+            patches = [
+                "@enkit//bazel/dependencies:bats_root.patch",
+            ],
+            build_file = "@enkit//bazel/dependencies:BUILD.bats.bazel",
         )
 
     # rules_docker 0.14.4 is incompatible with rules_pkg 0.3.0 as of Oct/2020.


### PR DESCRIPTION
* Update to `bats_core 1.5.0`
* Patch `bats_core` to fix `BATS_ROOT` bug that fails to correctly
  calculate `BATS_ROOT` when executed in a remote bazel environment.
* Fix missing library tree in BUILD file.

Tested:
re-ran a few bats tests.

Jira: INFRA-498

