### PR TITLE
gazelle: Add target for updating from go.mod

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # create a new library or binary.
 #
 # To update the list of dependencies downloaded by bazel, run:
-#     bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=bazel/go_repositories.bzl%go_repositories
+#     bazelisk run //:gazelle_update_repos
 #
 # This will read the go.mod file, and based on that, add statements
 # to download the correct dependency for bazel to download. The dependency
@@ -21,6 +21,16 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 gazelle(
     name = "gazelle",
     prefix = "github.com/enfabrica/enkit",
+)
+
+gazelle(
+    name = "gazelle_update_repos",
+    args = [
+        "-from_file=go.mod",
+        "-to_macro=bazel/go_repositories.bzl%go_repositories",
+        "-prune",
+    ],
+    command = "update-repos",
 )
 
 # Custom gazelle resolve mappings

--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -1497,8 +1497,8 @@ def go_repositories():
     go_repository(
         name = "com_github_klauspost_compress",
         importpath = "github.com/klauspost/compress",
-        sum = "h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=",
-        version = "v1.13.6",
+        sum = "h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=",
+        version = "v1.15.1",
     )
     go_repository(
         name = "com_github_klauspost_cpuid",
@@ -2558,6 +2558,12 @@ def go_repositories():
         importpath = "github.com/xanzy/ssh-agent",
         sum = "h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=",
         version = "v0.2.1",
+    )
+    go_repository(
+        name = "com_github_xenking_zipstream",
+        importpath = "github.com/xenking/zipstream",
+        sum = "h1:6LfcpXfxO9kAGi0a+2N5C0ZZ6jyG4XULPiogOM7gJBU=",
+        version = "v1.0.1",
     )
 
     go_repository(

--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -1158,10 +1158,10 @@ def go_repositories():
     )
     go_repository(
         name = "com_github_grpc_ecosystem_grpc_gateway",
+        build_naming_convention = "go_default_library",
         importpath = "github.com/grpc-ecosystem/grpc-gateway",
         sum = "h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=",
         version = "v1.16.0",
-        build_naming_convention = "go_default_library",
     )
     go_repository(
         name = "com_github_hashicorp_consul_api",
@@ -2086,14 +2086,14 @@ def go_repositories():
     )
     go_repository(
         name = "com_github_prometheus_prometheus",
-        importpath = "github.com/prometheus/prometheus",
-        sum = "h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=",
-        version = "v2.5.0+incompatible",
         #build_directives = [
         #    "gazelle:resolve proto gogoproto/gogo.proto @com_github_gogo_protobuf//gogoproto:gogoproto_proto",
         #    "gazelle:resolve proto go gogoproto/gogo.proto @com_github_gogo_protobuf//gogoproto:gogoproto_go_proto",
         #],
         build_file_proto_mode = "disable",
+        importpath = "github.com/prometheus/prometheus",
+        sum = "h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=",
+        version = "v2.5.0+incompatible",
     )
 
     go_repository(
@@ -2561,13 +2561,6 @@ def go_repositories():
     )
 
     go_repository(
-        name = "com_github_xenking_zipstream",
-        importpath = "github.com/xenking/zipstream",
-        sum = "h1:6LfcpXfxO9kAGi0a+2N5C0ZZ6jyG4XULPiogOM7gJBU=",
-        version = "v1.0.1",
-    )
-
-    go_repository(
         name = "com_github_xiang90_probing",
         importpath = "github.com/xiang90/probing",
         sum = "h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=",
@@ -2623,13 +2616,13 @@ def go_repositories():
     go_repository(
         name = "com_google_cloud_go_datastore",
         importpath = "cloud.google.com/go/datastore",
-        sum = "h1:/May9ojXjRkPBNVrq+oWLqmWCkr4OU5uRY29bu0mRyQ=",
-        version = "v1.1.0",
+        patch_args = ["-p1"],
+        patch_tool = "patch",
         patches = [
             "//bazel/dependencies:datastore_query_toproto_exported.patch",
         ],
-        patch_tool = "patch",
-        patch_args = ["-p1"],
+        sum = "h1:/May9ojXjRkPBNVrq+oWLqmWCkr4OU5uRY29bu0mRyQ=",
+        version = "v1.1.0",
     )
     go_repository(
         name = "com_google_cloud_go_firestore",
@@ -2653,12 +2646,12 @@ def go_repositories():
 
     go_repository(
         name = "com_google_cloud_go_storage",
-        importpath = "cloud.google.com/go/storage",
-        sum = "h1:5NQw6tOn3eMm0oE8vTkfjau18kjL79FlMjy/CHTpmoY=",
-        version = "v1.18.2",
         build_directives = [
             "gazelle:resolve go google.golang.org/genproto/googleapis/storage/v2 @go_googleapis//google/storage/v2:storage_go_proto",
         ],
+        importpath = "cloud.google.com/go/storage",
+        sum = "h1:5NQw6tOn3eMm0oE8vTkfjau18kjL79FlMjy/CHTpmoY=",
+        version = "v1.18.2",
     )
     go_repository(
         name = "com_shuralyov_dmitri_gpu_mtl",
@@ -2889,10 +2882,10 @@ def go_repositories():
     )
     go_repository(
         name = "org_golang_google_grpc",
+        build_file_proto_mode = "disable",
         importpath = "google.golang.org/grpc",
         sum = "h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=",
         version = "v1.44.0",
-        build_file_proto_mode = "disable",
     )
     go_repository(
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",

--- a/go.mod
+++ b/go.mod
@@ -47,9 +47,9 @@ require (
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/kataras/muxie v1.1.1
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
+	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/klauspost/cpuid v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
@@ -58,7 +58,6 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
 	github.com/prashantv/gostub v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 // indirect
@@ -70,6 +69,7 @@ require (
 	github.com/tchap/zapext v1.0.0
 	github.com/ugorji/go v1.1.4 // indirect
 	github.com/ulikunitz/xz v0.5.8
+	github.com/xenking/zipstream v1.0.1 // indirect
 	github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7
 	github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77 // indirect
 	go.uber.org/zap v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -698,7 +698,10 @@ github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.0 h1:wJbzvpYMVGG9iTI9VxpnNZfd4DzMPoCWze3GgSqz8yg=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
+github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -1123,6 +1126,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6Jc
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+github.com/xenking/zipstream v1.0.1 h1:6LfcpXfxO9kAGi0a+2N5C0ZZ6jyG4XULPiogOM7gJBU=
+github.com/xenking/zipstream v1.0.1/go.mod h1:eV9JLfCRbQQUGcdipSENWByVYkPP8IAzuFiwBY+sChg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 h1:Vo3q7h44BfmnLQh5SdF+2xwIoVnHThmZLunx6odjrHI=


### PR DESCRIPTION
This change replaces the mystery command that I keep forgetting with a
bazel run target, making it easier than ever to generate
go_repositories.bzl from go.mod.

Tested: `bazel run //:gazelle_update_repos`