### PR TITLE
infra: create buildbuddy shim

### DIFF
--- a/shims/buildbuddy/BUILD.bazel
+++ b/shims/buildbuddy/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["urls.go"],
+    importpath = "github.com/enfabrica/enkit/shims/buildbuddy",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_rs_cors//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["urls_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+)

--- a/shims/buildbuddy/cmd/BUILD.bazel
+++ b/shims/buildbuddy/cmd/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/shims/buildbuddy/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//shims/buildbuddy:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "bb-shim",
+    base = "@golang_base//image",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+container_push(
+    name = "upload-shim",
+    format = "Docker",
+    image = ":bb-shim",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/bb-shim",
+    tag = "latest",
+    visibility = ["//visibility:public"],
+)

--- a/shims/buildbuddy/cmd/main.go
+++ b/shims/buildbuddy/cmd/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"github.com/enfabrica/enkit/shims/buildbuddy"
+	"github.com/spf13/cobra"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+func main() {
+	var redirectUrlTo string
+	var byteStreamHost string
+	var servePrefix string
+	var port int
+
+	c := cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u, err := url.Parse(redirectUrlTo)
+			if err != nil {
+				return fmt.Errorf("err with parsing %s %v", redirectUrlTo, err)
+			}
+			parsedByteStreamHost, err := url.Parse(byteStreamHost)
+			if err != nil {
+				return fmt.Errorf("err with parsing bytestreamhost %s %v", byteStreamHost, err)
+			}
+			fmt.Printf("Redirecting to %s \n", u.String())
+			fmt.Printf("BytestreamHost is to %s \n", parsedByteStreamHost.Host)
+			proxy := httputil.NewSingleHostReverseProxy(u)
+			h := buildbuddy.NewHandler(servePrefix, parsedByteStreamHost.Host, proxy)
+			fmt.Println("listening and serving with cors")
+			return http.ListenAndServe(fmt.Sprintf(":%d", port), h)
+		},
+	}
+	c.Flags().StringVar(&servePrefix, "prefix", "/file/download", "the prefix of the http handler")
+	c.Flags().StringVar(&redirectUrlTo, "redirect-url", "buildbarn-buildbuddy-svc.buildbarn:8080", "the url of which to reverse proxy to")
+	c.Flags().StringVar(&byteStreamHost, "bytestream-host", "buildbarn-browser-svc.buildbarn", "the url of which to reverse proxy to")
+	c.Flags().IntVar(&port, "port", 8080, "port to serve on")
+
+	log.Fatal(c.Execute())
+}

--- a/shims/buildbuddy/cmd/main.go
+++ b/shims/buildbuddy/cmd/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	c.Flags().StringVar(&servePrefix, "prefix", "/file/download", "the prefix of the http handler")
 	c.Flags().StringVar(&redirectUrlTo, "redirect-url", "buildbarn-buildbuddy-svc.buildbarn:8080", "the url of which to reverse proxy to")
-	c.Flags().StringVar(&byteStreamHost, "bytestream-host", "buildbarn-browser-svc.buildbarn", "the url of which to reverse proxy to")
+	c.Flags().StringVar(&byteStreamHost, "bytestream-host", "buildbarn-browser-svc.buildbarn", "the new host of the byte stream url")
 	c.Flags().IntVar(&port, "port", 8080, "port to serve on")
 
 	log.Fatal(c.Execute())

--- a/shims/buildbuddy/urls.go
+++ b/shims/buildbuddy/urls.go
@@ -1,0 +1,56 @@
+package buildbuddy
+
+import (
+	"fmt"
+	"github.com/rs/cors"
+	"net/http"
+	"net/url"
+)
+
+const ByteStreamUrlQueryParam = "bytestream_url"
+
+func DefaultHandleFunc(proxy http.Handler, host string) func(writer http.ResponseWriter, r *http.Request) {
+	return func(writer http.ResponseWriter, r *http.Request) {
+		rawByteStreamUrl := r.URL.Query().Get(ByteStreamUrlQueryParam)
+		if rawByteStreamUrl == "" {
+			http.Error(writer, "bytestream_url not found in url", http.StatusNotFound)
+			return
+		}
+		fmt.Println("raw bytestream url is ", rawByteStreamUrl)
+		byteStreamUrl, err := url.Parse(rawByteStreamUrl)
+		if err != nil {
+			http.Error(writer, fmt.Errorf("error parsing bytestream url %+v", err).Error(), http.StatusInternalServerError)
+		}
+		byteStreamUrl.Host = host
+
+		fmt.Println("new bytesstream url is ", byteStreamUrl.String())
+		queryValues := r.URL.Query()
+		queryValues.Set(ByteStreamUrlQueryParam, byteStreamUrl.String())
+		r.URL.RawQuery = queryValues.Encode()
+		fmt.Println("reverse serving to ", r.URL.String())
+		proxy.ServeHTTP(writer, r)
+		return
+	}
+}
+
+func NewHandler(prefix string, host string, proxy http.Handler) http.Handler {
+	h := http.NewServeMux()
+	h.HandleFunc(prefix, DefaultHandleFunc(proxy, host))
+	return cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowOriginFunc: func(origin string) bool {
+			return true
+		},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+		Debug:            true,
+	}).Handler(h)
+}

--- a/shims/buildbuddy/urls_test.go
+++ b/shims/buildbuddy/urls_test.go
@@ -1,0 +1,44 @@
+package buildbuddy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+)
+
+type UrlReqResp struct {
+	Pre  string
+	Post string
+}
+
+var TestUrls = []string{
+	"/file/download?filename=model%2Ffunctional%2Fsfa-model%2Flibmodel-queues-memregions.a&bytestream_url=bytestream%3A%2F%2Fbuild.local.enfabrica.net%3A8000%2Fblobs%2Ff16674c20f3a871becfd1e44d343cf2e7afd6fdbb2fc0be5bb4aa58de497ef5d%2F538362&invocation_id=f69b6189-c598-4241-862a-e52125dd12e6",
+	"/file/download?filename=hw%2Fcommon%2Fdv%2Fbase%2Fdv_utils_pkg_elab&bytestream_url=bytestream%3A%2F%2Fbuild.local.enfabrica.net%3A8000%2Fblobs%2Fd083637acce47a592e3a99f329603b8f80d6d96b173ba08997744fc53df081ce%2F3365&invocation_id=d2f85a71-ddff-46f8-bb2b-71db65f8e3c9",
+}
+
+func TestFetchUrls(t *testing.T) {
+	testMux := http.NewServeMux()
+	testMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		_, err := writer.Write([]byte(request.URL.Query().Get(ByteStreamUrlQueryParam)))
+		assert.NoError(t, err)
+	})
+	exampleByteStreamHost := "foo.bar:1337"
+	testServer := httptest.NewServer(testMux)
+	turl, err := url.Parse(testServer.URL)
+	assert.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(turl)
+	for _, tar := range TestUrls {
+		req := httptest.NewRequest(http.MethodGet, tar, nil)
+		resp := httptest.NewRecorder()
+		DefaultHandleFunc(proxy, exampleByteStreamHost)(resp, req)
+		r, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		parsedResp, err := url.Parse(string(r))
+		assert.NoError(t, err)
+		assert.Equal(t, parsedResp.Host, exampleByteStreamHost)
+	}
+}

--- a/shims/buildbuddy/urls_test.go
+++ b/shims/buildbuddy/urls_test.go
@@ -28,13 +28,12 @@ func TestFetchUrls(t *testing.T) {
 	})
 	exampleByteStreamHost := "foo.bar:1337"
 	testServer := httptest.NewServer(testMux)
-	turl, err := url.Parse(testServer.URL)
+	testServerUrl, err := url.Parse(testServer.URL)
 	assert.NoError(t, err)
-	proxy := httputil.NewSingleHostReverseProxy(turl)
-	for _, tar := range TestUrls {
-		req := httptest.NewRequest(http.MethodGet, tar, nil)
+	proxy := httputil.NewSingleHostReverseProxy(testServerUrl)
+	for _, testUrl := range TestUrls {
 		resp := httptest.NewRecorder()
-		DefaultHandleFunc(proxy, exampleByteStreamHost)(resp, req)
+		DefaultHandleFunc(proxy, exampleByteStreamHost)(resp, httptest.NewRequest(http.MethodGet, testUrl, nil))
 		r, err := ioutil.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		parsedResp, err := url.Parse(string(r))

--- a/shims/buildbuddy/urls_test.go
+++ b/shims/buildbuddy/urls_test.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 )
 
-type UrlReqResp struct {
-	Pre  string
-	Post string
-}
-
 var TestUrls = []string{
 	"/file/download?filename=model%2Ffunctional%2Fsfa-model%2Flibmodel-queues-memregions.a&bytestream_url=bytestream%3A%2F%2Fbuild.local.enfabrica.net%3A8000%2Fblobs%2Ff16674c20f3a871becfd1e44d343cf2e7afd6fdbb2fc0be5bb4aa58de497ef5d%2F538362&invocation_id=f69b6189-c598-4241-862a-e52125dd12e6",
 	"/file/download?filename=hw%2Fcommon%2Fdv%2Fbase%2Fdv_utils_pkg_elab&bytestream_url=bytestream%3A%2F%2Fbuild.local.enfabrica.net%3A8000%2Fblobs%2Fd083637acce47a592e3a99f329603b8f80d6d96b173ba08997744fc53df081ce%2F3365&invocation_id=d2f85a71-ddff-46f8-bb2b-71db65f8e3c9",


### PR DESCRIPTION
This is a shim designed to be routed at L7, and captures any /file/download url and rewrites it to have the bytestream url be the intra-cluster url name of the storage section of buildbarn. It then forwards to any url of choice (usually the existing buildbuddy service)

As far as integration tests go, this is installed on staging currently. Seems to work nicely. 

jira: INFRA-683