### PR TITLE
WORKSPACE: Bump rules_pkg version to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,9 +54,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "85ffff62a4c22a74dbd98d05da6cf40f497344b3dbf1e1ab0a37ab2a1a6ca014",
+    strip_prefix = "rules_docker-0.23.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.23.0/rules_docker-v0.23.0.tar.gz"],
 )
 
 load(
@@ -76,10 +76,6 @@ _go_image_repos()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
-
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
 
 load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -79,10 +79,6 @@ def enkit_deps():
             build_file = "@enkit//bazel/dependencies:BUILD.bats.bazel",
         )
 
-    # rules_docker 0.14.4 is incompatible with rules_pkg 0.3.0 as of Oct/2020.
-    #
-    # When you update this dependency, please make sure rules_docker has been updated as well,
-    # and do run a docker build to ensure that there is no breakage.
     if "rules_pkg" not in excludes:
         http_archive(
             name = "rules_pkg",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -87,10 +87,10 @@ def enkit_deps():
         http_archive(
             name = "rules_pkg",
             urls = [
-                "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.6/rules_pkg-0.2.6.tar.gz",
+                "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
             ],
-            sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
+            sha256 = "62eeb544ff1ef41d786e329e1536c1d541bb9bcad27ae984d57f18f314018e66",
         )
 
     if "com_github_atlassian_bazel_tools" not in excludes:


### PR DESCRIPTION
This change updates rules_pkg to the latest version, which allows debs
to be included as data dependencies without crazy filegroup/output_group
hacks.

rules_docker is updated as well to be compatible with the new rules_pkg.

Tested: 
* Against internal via `--override_repository` to confirm that deb
  data dependencies work as expected, via test PR
  https://github.com/enfabrica/internal/pull/3501 modified to not use filegroup
* `bazel run //machinist/mserver/cmd:upload-image to check that Docker rules
   still work as expected

Jira: INFRA-687