### PR TITLE
bestie: Add 'name' and 'created' metrics tags support

### DIFF
--- a/bestie/server/bigquery_metrics.go
+++ b/bestie/server/bigquery_metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,25 +137,29 @@ func (t *bigQueryTable) normalizeTableRef() {
 }
 
 // Translate protobuf metric to BigQuery metric.
-// TODO: Decide whether to override client metric time with BES server current time.
 func translateMetric(stream *bazelStream, m *testMetric) (*bigQueryMetric, error) {
-	// Process the map of key/value pairs representing individual metric tags.
+	// Create a map to hold key/value pairs for various properties.
 	dat := make(map[string]string)
+
+	// Store the metric name as a tag in addition to the BigQuery table 'metricname'
+	// column so that it can be displayed in Grafana dashboard tables.
+	dat["name"] = m.metricName
+
+	// Process the map of key/value pairs representing individual metric tags.
 	for k, v := range m.tags {
 		dat[k] = v
 	}
-	// Insert additional tags using information that is only available
-	// to the BES endpoint through the Bazel event message itself.
-	//
-	// Storing both the invocationId and the invocationSha in the database,
-	// the former being useful to match up with build log references, etc.
-	dat["invocation_id"] = stream.invocationId
-	dat["invocation_sha"] = stream.invocationSha
-	dat["run"] = stream.run
-	dat["test_target"] = stream.testTarget
-	tags, err := json.Marshal(dat)
-	if err != nil {
-		return nil, fmt.Errorf("Error converting JSON to string: %w", err)
+
+	// If a "created" tag was provided (nanoseconds since epoch),
+	// use it in place of the original metric timestamp value.
+	timestamp := m.timestamp
+	if val, ok := dat["created"]; ok {
+		ts, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			debugPrintf("Error converting string %s to int64: %q (value ignored)\n", val, err)
+		} else {
+			timestamp = ts
+		}
 	}
 
 	// Change the metric timestamp from integer to formatted string,
@@ -170,7 +175,28 @@ func translateMetric(stream *bazelStream, m *testMetric) (*bigQueryMetric, error
 	// at the end of the string, which is the default format emitted by UnixMicro().String().
 	// See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
 	// for details.
-	tsf := UnixMicro(m.timestamp / 1e3).Format(timestampFormat)
+	tsf := UnixMicro(timestamp / 1e3).Format(timestampFormat)
+
+	// Store the formatted timestamp string as a "created" tag for the metrics
+	// to facilitate defining Grafana metric queries by time of run, since
+	// Prometheus supplies its scrape time, which is not what we want.
+	// This is in addition to using it for the BigQuery table timestamp column.
+	// Overwrite the original value, which is not a formatted datetime string.
+	dat["created"] = tsf
+
+	// Insert additional tags using information that is only available
+	// to the BES endpoint through the Bazel event message itself.
+	//
+	// Storing both the invocationId and the invocationSha in the database,
+	// the former being useful to match up with build log references, etc.
+	dat["invocation_id"] = stream.invocationId
+	dat["invocation_sha"] = stream.invocationSha
+	dat["run"] = stream.run
+	dat["test_target"] = stream.testTarget
+	tags, err := json.Marshal(dat)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting JSON to string: %w", err)
+	}
 
 	return &bigQueryMetric{
 		metricName: m.metricName,

--- a/bestie/server/bigquery_metrics.go
+++ b/bestie/server/bigquery_metrics.go
@@ -143,7 +143,7 @@ func translateMetric(stream *bazelStream, m *testMetric) (*bigQueryMetric, error
 
 	// Store the metric name as a tag in addition to the BigQuery table 'metricname'
 	// column so that it can be displayed in Grafana dashboard tables.
-	dat["name"] = m.metricName
+	dat["metric_name"] = m.metricName
 
 	// Process the map of key/value pairs representing individual metric tags.
 	for k, v := range m.tags {

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -153,16 +153,23 @@ func getTestMetricsFromXmlData(pbmsg []byte) (*metricTestResult, error) {
 			// Note that the metric name and creation datetime are also being stored
 			// in the metric tags to facilitate Grafana queries and displays,
 			// since Prometheus supplies its scrape time, which is not what we want.
+			//
+			// Note: To avoid potential tag name conflicts with tags created by the
+			// test application, the tags uniquely inserted by the BES Endpoint all
+			// begin with a leading underscore, by convention.
+			//
+			// Exception: Since the "type" tag normally comes from the test application,
+			// use the same tag name here for consistency in the database.
 			var m testMetric = testMetric{
 				metricName: metricName,
 				tags: map[string]string{
-					"duration":    xr.duration,
-					"metric_name": metricName,
-					"result":      xr.result,
-					"test_case":   xr.tcTestCase,
-					"test_class":  xr.tcClass,
-					"test_file":   xr.tcFile,
-					"type":        "summary",
+					"_duration":    xr.duration,
+					"_metric_name": metricName,
+					"_result":      xr.result,
+					"_test_case":   xr.tcTestCase,
+					"_test_class":  xr.tcClass,
+					"_test_file":   xr.tcFile,
+					"type":         "summary",
 				},
 				// Setting value to 1.0 so each test case result has same weight
 				// for PromQL count() and sum() operations.

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -147,13 +147,18 @@ func getTestMetricsFromXmlData(pbmsg []byte) (*metricTestResult, error) {
 			return nil, nil
 		}
 
+		metricName := "testresult"
 		for _, xr := range xmlResults {
 			// Construct the BigQuery metric from the XML results provided.
+			// Note that the metric name and creation datetime are also being stored
+			// in the metric tags to facilitate Grafana queries and displays,
+			// since Prometheus supplies its scrape time, which is not what we want.
 			var m testMetric = testMetric{
-				metricName: "testresult",
+				metricName: metricName,
 				tags: map[string]string{
-					"result":     xr.result,
 					"duration":   xr.duration,
+					"name":       metricName,
+					"result":     xr.result,
 					"test_case":  xr.tcTestCase,
 					"test_class": xr.tcClass,
 					"test_file":  xr.tcFile,

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -156,13 +156,13 @@ func getTestMetricsFromXmlData(pbmsg []byte) (*metricTestResult, error) {
 			var m testMetric = testMetric{
 				metricName: metricName,
 				tags: map[string]string{
-					"duration":   xr.duration,
-					"name":       metricName,
-					"result":     xr.result,
-					"test_case":  xr.tcTestCase,
-					"test_class": xr.tcClass,
-					"test_file":  xr.tcFile,
-					"type":       "summary",
+					"duration":    xr.duration,
+					"metric_name": metricName,
+					"result":      xr.result,
+					"test_case":   xr.tcTestCase,
+					"test_class":  xr.tcClass,
+					"test_file":   xr.tcFile,
+					"type":        "summary",
 				},
 				// Setting value to 1.0 so each test case result has same weight
 				// for PromQL count() and sum() operations.


### PR DESCRIPTION
To facilitate Grafana dashboard table displays, copy the
metricname into a new 'name' tag so that it appears among
the list of displayable entities for Grafana.

Support a new 'created' tag that contains a timestamp to
be used for the metric instead of the one defined as the
original timestamp field. This allows the test application
to define a single value timestamp that is stored in the
'created' tag for both the pass/fail testresult metric and
any associated data metrics generated by the test cases
during the same run. Grafana can then use the 'created'
tag (instead of the Prometheus scrape timestamp) as a
consistent way to filter all metrics for a given time
selection.

Tested: Ran `bazel test --cache_test_results=no --test_output=streamed \
--bes_backend=grpc://localhost:6433 //systest/src/demo:test_sample_metrics'
to produce some sample metrics and verified the existence of
the new tags. Was able to set up Grafana queries using the
'created' tag to display both the test result and related
data metrics using various timestamp selections.

Jira: INFRA-744