### PR TITLE
flextape: Fix crash on Allocate()

### DIFF
--- a/flextape/service/service.go
+++ b/flextape/service/service.go
@@ -66,6 +66,8 @@ func licensesFromConfig(config *fpb.Config) map[string]*license {
 			prioritizer = &FIFOPrioritizer{}
 		case *fpb.LicenseConfig_EvenOwners:
 			prioritizer = NewEvenOwnersPrioritizer()
+		default:
+			prioritizer = &FIFOPrioritizer{}
 		}
 
 		licenses[name] = &license{


### PR DESCRIPTION
This change fixes a nil pointer dereference by ensuring that a
prioritizer is set if the config doesn't specify a prioritizer.

Tested: Added unit test

Jira: INFRA-772