### PR TITLE
enproxy: add basic prometheus metrics and plumbing.

### DIFF
--- a/proxy/enproxy/BUILD.bazel
+++ b/proxy/enproxy/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "//proxy/httpp:go_default_library",
         "//proxy/nasshp:go_default_library",
         "//proxy/utils:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
     ],
 )
 

--- a/proxy/enproxy/enproxy.go
+++ b/proxy/enproxy/enproxy.go
@@ -106,9 +106,9 @@ func (config *Config) Parse() (utils.PatternList, Warnings, error) {
 
 // Flags represents command line flags necessary to define a proxy.
 type Flags struct {
-	Http  *khttp.Flags
-	Oauth *oauth.RedirectorFlags
-	Nassh *nasshp.Flags
+	Http       *khttp.Flags
+	Oauth      *oauth.RedirectorFlags
+	Nassh      *nasshp.Flags
 	Prometheus *khttp.Flags
 
 	ConfigContent          []byte
@@ -136,7 +136,7 @@ func (fl *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
 	fl.Http.Register(set, prefix)
 	fl.Oauth.Register(set, prefix)
 	fl.Nassh.Register(set, prefix)
-	fl.Prometheus.Register(set, prefix + "prometheus-")
+	fl.Prometheus.Register(set, prefix+"prometheus-")
 
 	set.ByteFileVar(&fl.ConfigContent, "config", fl.ConfigName, "Default config file location.", kflags.WithFilename(&fl.ConfigName))
 	set.BoolVar(&fl.DisabledAuthentication, "without-authentication", false, "allow tunneling even without authentication")
@@ -151,7 +151,7 @@ func (fl *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
 type Starter func(log logger.Printer, handler http.Handler, domains ...string) error
 
 type Options struct {
-	log     logger.Logger
+	log logger.Logger
 
 	proxy   Starter
 	metrics Starter
@@ -324,7 +324,7 @@ type Enproxy struct {
 	domains []string
 
 	register prometheus.Registerer
-        gatherer prometheus.Gatherer
+	gatherer prometheus.Gatherer
 
 	proxy   Starter
 	metrics Starter
@@ -332,7 +332,7 @@ type Enproxy struct {
 
 func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
 	op := &Options{
-		log:     &logger.DefaultLogger{Printer: log.Printf},
+		log:   &logger.DefaultLogger{Printer: log.Printf},
 		proxy: khttp.DefaultServer().Run,
 	}
 	if err := Modifiers(mods).Apply(op); err != nil {
@@ -390,11 +390,11 @@ func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
 	}
 
 	return &Enproxy{
-		log: op.log,
-		mux: mux,
-		domains: append(append([]string{}, op.config.Domains...), hproxy.Domains...),
-		proxy: op.proxy,
-		metrics: op.metrics,
+		log:      op.log,
+		mux:      mux,
+		domains:  append(append([]string{}, op.config.Domains...), hproxy.Domains...),
+		proxy:    op.proxy,
+		metrics:  op.metrics,
 		gatherer: op.gatherer,
 		register: op.register,
 	}, nil

--- a/proxy/enproxy/enproxy.go
+++ b/proxy/enproxy/enproxy.go
@@ -47,6 +47,8 @@ import (
 	"github.com/enfabrica/enkit/proxy/httpp"
 	"github.com/enfabrica/enkit/proxy/nasshp"
 	"github.com/enfabrica/enkit/proxy/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"math/rand"
 	"net/http"
@@ -107,6 +109,7 @@ type Flags struct {
 	Http  *khttp.Flags
 	Oauth *oauth.RedirectorFlags
 	Nassh *nasshp.Flags
+	Prometheus *khttp.Flags
 
 	ConfigContent          []byte
 	ConfigName             string
@@ -122,6 +125,8 @@ func DefaultFlags() *Flags {
 		Http:  khttp.DefaultFlags(),
 		Oauth: oauth.DefaultRedirectorFlags(),
 		Nassh: nasshp.DefaultFlags(),
+		// A khttp server that has no ip/port and is disabled by default.
+		Prometheus: &khttp.Flags{Cache: khttp.DefaultCache},
 	}
 	return fl
 }
@@ -131,6 +136,7 @@ func (fl *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
 	fl.Http.Register(set, prefix)
 	fl.Oauth.Register(set, prefix)
 	fl.Nassh.Register(set, prefix)
+	fl.Prometheus.Register(set, prefix + "prometheus-")
 
 	set.ByteFileVar(&fl.ConfigContent, "config", fl.ConfigName, "Default config file location.", kflags.WithFilename(&fl.ConfigName))
 	set.BoolVar(&fl.DisabledAuthentication, "without-authentication", false, "allow tunneling even without authentication")
@@ -146,7 +152,12 @@ type Starter func(log logger.Printer, handler http.Handler, domains ...string) e
 
 type Options struct {
 	log     logger.Logger
-	starter Starter
+
+	proxy   Starter
+	metrics Starter
+
+	gatherer prometheus.Gatherer
+	register prometheus.Registerer
 
 	config Config
 
@@ -192,7 +203,14 @@ func WithAuthenticator(auth oauth.Authenticate) Modifier {
 
 func WithHttpStarter(starter Starter) Modifier {
 	return func(op *Options) error {
-		op.starter = starter
+		op.proxy = starter
+		return nil
+	}
+}
+
+func WithMetricsStarter(starter Starter) Modifier {
+	return func(op *Options) error {
+		op.metrics = starter
 		return nil
 	}
 }
@@ -205,6 +223,27 @@ func WithHttpFlags(flags *khttp.Flags) Modifier {
 		}
 
 		return WithHttpStarter(server.Run)(op)
+	}
+}
+
+func WithMetricsFlags(flags *khttp.Flags) Modifier {
+	return func(op *Options) error {
+		if flags.HttpPort == 0 && flags.HttpsPort == 0 {
+			return nil
+		}
+		server, err := khttp.FromFlags(flags)
+		if err != nil {
+			return err
+		}
+		return WithMetricsStarter(server.Run)(op)
+	}
+}
+
+func WithPrometheus(gatherer prometheus.Gatherer, register prometheus.Registerer) Modifier {
+	return func(op *Options) error {
+		op.gatherer = gatherer
+		op.register = register
+		return nil
 	}
 }
 
@@ -270,6 +309,9 @@ func FromFlags(flags *Flags) Modifier {
 		if err := WithHttpFlags(flags.Http)(op); err != nil {
 			return err
 		}
+		if err := WithMetricsFlags(flags.Prometheus)(op); err != nil {
+			return err
+		}
 
 		return WithConfig(config)(op)
 	}
@@ -280,13 +322,18 @@ type Enproxy struct {
 
 	mux     http.Handler
 	domains []string
-	starter Starter
+
+	register prometheus.Registerer
+        gatherer prometheus.Gatherer
+
+	proxy   Starter
+	metrics Starter
 }
 
 func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
 	op := &Options{
 		log:     &logger.DefaultLogger{Printer: log.Printf},
-		starter: khttp.DefaultServer().Run,
+		proxy: khttp.DefaultServer().Run,
 	}
 	if err := Modifiers(mods).Apply(op); err != nil {
 		return nil, err
@@ -301,10 +348,12 @@ func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
 	mux := amuxie.New()
 
 	pmods := []httpp.Modifier{httpp.WithLogging(op.log), httpp.WithAuthenticator(op.authenticate)}
-	if _, err = httpp.New(mux, op.config.Mapping, append(pmods, op.pmods...)...); err != nil {
+	hproxy, err := httpp.New(mux, op.config.Mapping, append(pmods, op.pmods...)...)
+	if err != nil {
 		return nil, err
 	}
 
+	var nproxy *nasshp.NasshProxy
 	if op.authenticate == nil && !op.withoutNasshAuthentication {
 		op.log.Warnf("ssh gateway disabled as no authentication was configured")
 	} else {
@@ -314,23 +363,56 @@ func New(rng *rand.Rand, mods ...Modifier) (*Enproxy, error) {
 			authenticate = nil
 		}
 
-		nasshp, err := nasshp.New(rng, authenticate, append([]nasshp.Modifier{nasshp.WithFilter(wl.Allow), nasshp.WithLogging(op.log)}, op.nmods...)...)
+		nproxy, err = nasshp.New(rng, authenticate, append([]nasshp.Modifier{nasshp.WithFilter(wl.Allow), nasshp.WithLogging(op.log)}, op.nmods...)...)
 		if err != nil {
 			return nil, err
 		}
 
-		rhost := nasshp.RelayHost()
+		rhost := nproxy.RelayHost()
 		root := amux.Mux(mux)
 		if rhost != "" {
 			root = mux.Host(rhost)
 		}
 
-		nasshp.Register(root.Handle)
+		nproxy.Register(root.Handle)
 	}
 
-	return &Enproxy{log: op.log, mux: mux, domains: op.config.Domains, starter: op.starter}, nil
+	if op.metrics != nil {
+		if op.gatherer == nil || op.register == nil {
+			op.gatherer = prometheus.DefaultGatherer
+			op.register = prometheus.DefaultRegisterer
+		}
+		if nproxy != nil {
+			if err := nproxy.ExportMetrics(op.register); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &Enproxy{
+		log: op.log,
+		mux: mux,
+		domains: append(append([]string{}, op.config.Domains...), hproxy.Domains...),
+		proxy: op.proxy,
+		metrics: op.metrics,
+		gatherer: op.gatherer,
+		register: op.register,
+	}, nil
+}
+
+func (ep *Enproxy) RunMetrics() error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(ep.gatherer, promhttp.HandlerOpts{}))
+	return ep.metrics(ep.log.Infof, mux)
+}
+
+func (ep *Enproxy) RunProxy() error {
+	return ep.proxy(ep.log.Infof, &khttp.Dumper{Real: ep.mux, Log: log.Printf}, ep.domains...)
 }
 
 func (ep *Enproxy) Run() error {
-	return ep.starter(ep.log.Infof, &khttp.Dumper{Real: ep.mux, Log: log.Printf}, ep.domains...)
+	if ep.metrics != nil {
+		go ep.RunMetrics()
+	}
+	return ep.RunProxy()
 }

--- a/proxy/enproxy/enproxy_test.go
+++ b/proxy/enproxy/enproxy_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/enfabrica/enkit/proxy/httpp"
 	"github.com/enfabrica/enkit/proxy/nasshp"
 	"github.com/enfabrica/enkit/proxy/ptunnel"
-	"github.com/stretchr/testify/assert"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
-	"testing"
 	"sync"
+	"testing"
 )
 
 // Deny returns an authenticator that either denies a request, or returns a constant cookie.

--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -5,8 +5,8 @@ go_library(
     srcs = [
         "blocking.go",
         "browser.go",
+        "counters.go",
         "nassh.go",
-        "types.go",
         "window.go",
     ],
     importpath = "github.com/enfabrica/enkit/proxy/nasshp",
@@ -16,7 +16,9 @@ go_library(
         "//lib/logger:go_default_library",
         "//lib/oauth:go_default_library",
         "//lib/token:go_default_library",
+        "//proxy/utils:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )
 

--- a/proxy/nasshp/browser.go
+++ b/proxy/nasshp/browser.go
@@ -23,8 +23,8 @@ type ReplaceableBrowser struct {
 
 	notifier chan error
 
-	wc       *websocket.Conn  // Protected by lock.
-	err      error            // Protected by lock.
+	wc   *websocket.Conn // Protected by lock.
+	err  error           // Protected by lock.
 	lock sync.RWMutex
 	cond *sync.Cond
 

--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -1,0 +1,358 @@
+package nasshp
+
+import (
+	"github.com/enfabrica/enkit/proxy/utils"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type AllowErrors struct { // DONE
+	InvalidCookie     utils.Counter
+	InvalidHostFormat utils.Counter
+	InvalidHostName   utils.Counter
+	Unauthorized      utils.Counter
+}
+
+type ProxyErrors struct { // DONE
+	CookieInvalidParameters utils.Counter
+	CookieInvalidAuth       utils.Counter
+
+	ProxyInvalidAuth     utils.Counter
+	ProxyInvalidPort     utils.Counter
+	ProxyInvalidHost     utils.Counter
+	ProxyCouldNotEncrypt utils.Counter
+	ProxyAllow           AllowErrors
+
+	ConnectInvalidSID utils.Counter
+	ConnectInvalidAck utils.Counter
+	ConnectInvalidPos utils.Counter
+	ConnectAllow      AllowErrors
+
+	SshFailedUpgrade utils.Counter
+	SshResumeNoSID   utils.Counter
+	SshCreateExists  utils.Counter
+	SshDialFailed    utils.Counter
+}
+
+type ReadWriterCounters struct { // DONE
+	BrowserWriterStarted utils.Counter
+	BrowserWriterStopped utils.Counter
+	BrowserWriterError   utils.Counter
+
+	BrowserReaderStarted utils.Counter
+	BrowserReaderStopped utils.Counter
+	BrowserReaderError   utils.Counter
+}
+
+type ProxyCounters struct {
+	ReadWriterCounters
+
+	SshProxyStarted utils.Counter
+	SshProxyStopped utils.Counter
+}
+
+type SessionCounters struct {
+	Resumed utils.Counter
+	Invalid utils.Counter
+	Created utils.Counter
+
+	Orphaned utils.Counter
+	Deleted  utils.Counter
+}
+
+var (
+	descPoolGets = prometheus.NewDesc(
+		"nasshp_pool_gets",
+		"Number of buffers retrieved from the pool",
+		nil, nil,
+	)
+	descPoolPuts = prometheus.NewDesc(
+		"nasshp_pool_puts",
+		"Number of buffers returned to the pool",
+		nil, nil,
+	)
+	descPoolNews = prometheus.NewDesc(
+		"nasshp_pool_news",
+		"Number of buffers created for the pool",
+		nil, nil,
+	)
+
+	descSessionResumed = prometheus.NewDesc(
+		"nasshp_sessions_resumed",
+		"Number of times SIDs were found in the sessions table already",
+		nil, nil,
+	)
+
+	descSessionInvalid = prometheus.NewDesc(
+		"nasshp_sessions_invalid",
+		"Number of times the state of a SID was found, but invalid - file a BUG!",
+		nil, nil,
+	)
+
+	descSessionCreated = prometheus.NewDesc(
+		"nasshp_sessions_created",
+		"Number of times SIDs were not found in the session table, causing a new session to be created",
+		nil, nil,
+	)
+
+	descSessionOrphaned = prometheus.NewDesc(
+		"nasshp_sessions_orphaned",
+		"Number of times SIDs were left in the session table for the browser to reconnect",
+		nil, nil,
+	)
+
+	descSessionDeleted = prometheus.NewDesc(
+		"nasshp_sessions_deleted",
+		"Number of times SIDs were deleted from the session table as the connection terminated",
+		nil, nil,
+	)
+
+	helpError = "Number of times the request to the url resulted in the specified error"
+
+	descCookieInvalidParameters = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/cookie", "error": "invalid parameters", "type": "bad client"},
+	)
+
+	descCookieInvalidAuth = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/cookie", "error": "invalid auth", "type": "unauthorized"},
+	)
+
+	descProxyInvalidAuth = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid auth", "type": "unauthorized"},
+	)
+
+	descProxyInvalidPort = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid port", "type": "bad client"},
+	)
+
+	descProxyInvalidHost = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid host", "type": "bad client"},
+	)
+
+	descProxyCouldNotEncrypt = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "could not encrypt", "type": "internal"},
+	)
+
+	descProxyInvalidCookie = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid cookie", "type": "auth"},
+	)
+
+	descProxyInvalidHostFormat = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid host split", "type": "bad client"},
+	)
+
+	descProxyInvalidHostName = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid host name", "type": "dns"},
+	)
+
+	descProxyUnauthorized = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/proxy", "error": "unauthorized user", "type": "auth"},
+	)
+
+	descConnectInvalidSID = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid sid", "type": "bad client"},
+	)
+
+	descConnectInvalidAck = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid ack", "type": "bad client"},
+	)
+
+	descConnectInvalidPos = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid pos", "type": "bad client"},
+	)
+
+	descConnectInvalidCookie = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid cookie", "type": "auth"},
+	)
+
+	descConnectInvalidHostFormat = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid host split", "type": "bad client"},
+	)
+
+	descConnectInvalidHostName = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "invalid host name", "type": "dns"},
+	)
+
+	descConnectUnauthorized = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "unauthorized user", "type": "auth"},
+	)
+
+	descSshFailedUpgrade = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "failed upgrade", "type": "bad client"},
+	)
+
+	descSshResumeNoSID = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "failed resume", "type": "bad client"},
+	)
+
+	descSshCreateExists = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "create existing", "type": "bad client"},
+	)
+
+	descSshDialFailed = prometheus.NewDesc(
+		"nasshp_url_errors",
+		helpError,
+		nil, prometheus.Labels{"url": "/connect", "error": "dial failed", "type": "endpoint"},
+	)
+
+	helpBrowser = "Number of times a goroutine of the specified type was started/stopped/errored out"
+
+	descBrowserWriterStarted = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "writer", "action": "started"},
+	)
+
+	descBrowserWriterStopped = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "writer", "action": "stopped"},
+	)
+
+	descBrowserWriterError = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "writer", "action": "error"},
+	)
+
+	descBrowserReaderStarted = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "reader", "action": "started"},
+	)
+
+	descBrowserReaderStopped = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "reader", "action": "stopped"},
+	)
+
+	descBrowserReaderError = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "reader", "action": "error"},
+	)
+
+	descSshProxyStarted = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "proxy", "action": "started"},
+	)
+
+	descSshProxyStopped = prometheus.NewDesc(
+		"nasshp_browser",
+		helpBrowser,
+		nil, prometheus.Labels{"type": "proxy", "action": "stopped"},
+	)
+)
+
+type nasshCollector NasshProxy
+
+func (nc *nasshCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(nc, ch)
+}
+
+func (nc *nasshCollector) Collect(ch chan<- prometheus.Metric) {
+	np := (*NasshProxy)(nc)
+
+	gets, puts, news := np.pool.Stats()
+	errors := &np.errors
+	counters := &np.counters
+	sessions := &np.sessions
+
+	metrics := []struct {
+		desc  *prometheus.Desc
+		value uint64
+	}{
+
+		{descPoolGets, gets},
+		{descPoolPuts, puts},
+		{descPoolNews, news},
+
+		{descCookieInvalidParameters, errors.CookieInvalidParameters.Get()},
+		{descCookieInvalidAuth, errors.CookieInvalidAuth.Get()},
+		{descProxyInvalidAuth, errors.ProxyInvalidAuth.Get()},
+		{descProxyInvalidPort, errors.ProxyInvalidPort.Get()},
+		{descProxyInvalidHost, errors.ProxyInvalidHost.Get()},
+		{descProxyCouldNotEncrypt, errors.ProxyCouldNotEncrypt.Get()},
+
+		{descProxyInvalidCookie, errors.ProxyAllow.InvalidCookie.Get()},
+		{descProxyInvalidHostFormat, errors.ProxyAllow.InvalidHostFormat.Get()},
+		{descProxyInvalidHostName, errors.ProxyAllow.InvalidHostName.Get()},
+		{descProxyUnauthorized, errors.ProxyAllow.Unauthorized.Get()},
+
+		{descConnectInvalidSID, errors.ConnectInvalidSID.Get()},
+		{descConnectInvalidAck, errors.ConnectInvalidAck.Get()},
+		{descConnectInvalidPos, errors.ConnectInvalidPos.Get()},
+
+		{descConnectInvalidCookie, errors.ConnectAllow.InvalidCookie.Get()},
+		{descConnectInvalidHostFormat, errors.ConnectAllow.InvalidHostFormat.Get()},
+		{descConnectInvalidHostName, errors.ConnectAllow.InvalidHostName.Get()},
+		{descConnectUnauthorized, errors.ConnectAllow.Unauthorized.Get()},
+
+		{descSshFailedUpgrade, errors.SshFailedUpgrade.Get()},
+		{descSshResumeNoSID, errors.SshResumeNoSID.Get()},
+		{descSshCreateExists, errors.SshCreateExists.Get()},
+		{descSshDialFailed, errors.SshDialFailed.Get()},
+
+		{descBrowserWriterStarted, counters.BrowserWriterStarted.Get()},
+		{descBrowserWriterStopped, counters.BrowserWriterStopped.Get()},
+		{descBrowserWriterError, counters.BrowserWriterError.Get()},
+
+		{descBrowserReaderStarted, counters.BrowserReaderStarted.Get()},
+		{descBrowserReaderStopped, counters.BrowserReaderStopped.Get()},
+		{descBrowserReaderError, counters.BrowserReaderError.Get()},
+
+		{descSshProxyStarted, counters.SshProxyStarted.Get()},
+		{descSshProxyStopped, counters.SshProxyStopped.Get()},
+
+		{descSessionResumed, sessions.Resumed.Get()},
+		{descSessionInvalid, sessions.Invalid.Get()},
+		{descSessionCreated, sessions.Created.Get()},
+		{descSessionOrphaned, sessions.Orphaned.Get()},
+		{descSessionDeleted, sessions.Deleted.Get()},
+	}
+
+	for _, metric := range metrics {
+		ch <- prometheus.MustNewConstMetric(metric.desc, prometheus.CounterValue, float64(metric.value))
+	}
+}

--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -5,14 +5,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type AllowErrors struct { // DONE
+type AllowErrors struct {
 	InvalidCookie     utils.Counter
 	InvalidHostFormat utils.Counter
 	InvalidHostName   utils.Counter
 	Unauthorized      utils.Counter
 }
 
-type ProxyErrors struct { // DONE
+type ProxyErrors struct {
 	CookieInvalidParameters utils.Counter
 	CookieInvalidAuth       utils.Counter
 
@@ -33,7 +33,7 @@ type ProxyErrors struct { // DONE
 	SshDialFailed    utils.Counter
 }
 
-type ReadWriterCounters struct { // DONE
+type ReadWriterCounters struct {
 	BrowserWriterStarted utils.Counter
 	BrowserWriterStopped utils.Counter
 	BrowserWriterError   utils.Counter

--- a/proxy/utils/BUILD.bazel
+++ b/proxy/utils/BUILD.bazel
@@ -2,11 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["whitelist.go"],
+    srcs = [
+        "counter.go",
+        "types.go",
+        "whitelist.go",
+    ],
     importpath = "github.com/enfabrica/enkit/proxy/utils",
     visibility = ["//visibility:public"],
-    deps = [
-        "//lib/oauth:go_default_library",
-        "//proxy/nasshp:go_default_library",
-    ],
+    deps = ["//lib/oauth:go_default_library"],
 )

--- a/proxy/utils/counter.go
+++ b/proxy/utils/counter.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"sync/atomic"
+)
+
+type Counter uint64
+
+func (c *Counter) Increment() {
+	atomic.AddUint64((*uint64)(c), 1)
+}
+
+func (c *Counter) Get() uint64 {
+	return atomic.LoadUint64((*uint64)(c))
+}

--- a/proxy/utils/types.go
+++ b/proxy/utils/types.go
@@ -13,8 +13,10 @@ const (
 
 func (v Verdict) MergeOnlyAcceptAllow(vv Verdict) Verdict {
 	switch vv {
-	case VerdictDrop: return VerdictDrop // no doubt, we have to drop.
-	case VerdictUnknown: return v // whatever we decided before, is still valid.
+	case VerdictDrop:
+		return VerdictDrop // no doubt, we have to drop.
+	case VerdictUnknown:
+		return v // whatever we decided before, is still valid.
 	case VerdictAllow:
 		if v == VerdictUnknown {
 			return VerdictAllow

--- a/proxy/utils/types.go
+++ b/proxy/utils/types.go
@@ -1,4 +1,4 @@
-package nasshp
+package utils
 
 type Verdict int
 

--- a/proxy/utils/whitelist.go
+++ b/proxy/utils/whitelist.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"github.com/enfabrica/enkit/lib/oauth"
-	"github.com/enfabrica/enkit/proxy/nasshp"
 	"path/filepath"
 )
 
@@ -37,13 +36,13 @@ func NewPatternList(allowed []string) (PatternList, error) {
 // Allow is a nasshp.Filter function that returns nasshp.VerdictAllow if the proto and hostport
 // string specified match any pattern in the list created with NewPatternList.
 // proto is one word.
-func (pl PatternList) Allow(proto string, ipport string, creds *oauth.CredentialsCookie) nasshp.Verdict {
+func (pl PatternList) Allow(proto string, ipport string, creds *oauth.CredentialsCookie) Verdict {
 	key := proto + "|" + ipport
 	for _, pattern := range pl {
 		match, err := filepath.Match(pattern, key)
 		if err == nil && match {
-			return nasshp.VerdictAllow
+			return VerdictAllow
 		}
 	}
-	return nasshp.VerdictDrop
+	return VerdictDrop
 }


### PR DESCRIPTION
Background on some design decisions:
1) a separate http server is started on a different port just
   to export metrics. This simplifies authentication, https, and
   simplifies the main mux used for proxying and ssh.

2) some objects that need to export metrics are instantiated
   multiple times. This makes it hard to use the simple/default
   globals.

3) some counters already exist in the code, and are used
   internally for the engine to work.

4) some counters are in really hot paths, eg, per read/write
   performed.

The design uses simple per-object counters, paired with
an object implementing the prometheus.Collector() interface
just like recommended in the docs when reading "legacy counters",
counters that already exist in code.

This also allows multiple instances of objects by using
things like prometheus.WrapRegistererWithPrefix().