### PR TITLE
gee: add pr_push command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2822,6 +2822,7 @@ Usage: gee pr_checkout <PR>
 
 Creates a new branch containing the specified pull request.
 EOT
+
 function gee__pr_checkout() {
   _check_gh_auth
   _set_main
@@ -2845,6 +2846,81 @@ function gee__pr_checkout() {
   _checkout_or_die "${BRANCH}"
   _push_to_origin "${BRANCH}"
   _info "Pulled PR #${PRNUM} into branch \"${BRANCH}\""
+}
+
+##########################################################################
+# pr_push command
+##########################################################################
+_register_help "pr_push" \
+  "Push commits into another user's PR branch." <<'EOT'
+Usage: gee pr_push
+
+`gee pr_push` must be executed from within a branch created by `gee pr_checkout`.
+
+`gee commit` will create a local commit, and push that commit to `origin`, the
+remote repository owned by you.  `gee pr_push` can then be used to also push
+your commits into another user's remote pull request branch.
+
+`gee pr_push` will refuse to proceed unless all changes from the remote pull
+request branch are already integrated in your local branch, so you might need
+to `gee update` before `gee pr_push`.
+
+After pushing your changes into another user's PR branch, be sure to directly
+notify that user, so they know to pull your changes into their local branch.
+Otherwise, the other user might accidentally lose your commits entirely if they
+force-push.  Remote users can integrate your changes using the `gee update`
+command, or `git rebase --autostash origin/<branch>` if they aren't a gee user.
+
+EOT
+
+function gee__pr_push() {
+  # Check that we are in a PR branch
+  local BRANCH
+  BRANCH="$(_get_current_branch)"
+  _read_parents_file
+  local PRNUM=""
+  if [[ "${PARENTS["${BRANCH}"]}" == "upstream/refs/pull/*/head" ]]; then
+    PRNUM="$(cut -d '/' -f4)"
+  else
+    _fatal "This branch does not appear to have been made with \"gee pr_checkout\"."
+  fi
+  _info "This branch appears to be associated with PR #${PRNUM}."
+
+  # Identify remote branch
+  local -a DATA=()
+  _read_cmd DATA "${GH}" pr view \
+    --json author,headRefName,state \
+    --jq '.author["login"],.headRefName,.state'
+  local REMOTE_USER REMOTE_BRANCH REMOTE_STATE
+  REMOTE_USER="${DATA[0]}"
+  REMOTE_BRANCH="${DATA[1]}"
+  REMOTE_STATE="${DATA[2]}"
+
+  # Check that the remote branch hasn't already been merged.
+  if [[ "${REMOTE_STATE}" == "MERGED" ]]; then
+    _fatal "PR${PRNUM} has already been merged, refusing to proceed."
+  fi
+
+  # Fetch from remote branch.
+  if ! "${GIT}" remote get-url "${REMOTE_USER}" >/dev/null 2>&1; then
+    _git remote add "${REMOTE_USER}" "${GIT_AT_GITHUB}:${REMOTE_USER}/${REPO}.git" >&2
+  fi
+  _git fetch "${REMOTE_USER}" "${REMOTE_BRANCH}"
+
+  # Check if we are behind remote branch
+  local -a COUNTS
+  _read_cmd COUNTS "${GIT}" rev-list --left-right --count "${BRANCH}...FETCH_HEAD"
+  if [[ "${COUNTS[1]}" -gt 0 ]]; then
+    _warn "Remote branch ${REMOTE_USER}/${REMOTE_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${BRANCH}."
+    _fatal "You must \"gee update\" before trying to \"gee pr_push\"."
+  fi
+
+  # Push our changes to the remote branch
+  _git push "${REMOTE_USER}" "HEAD:${REMOTE_BRANCH}"
+  _info "Successfully pushed to PR#${PRNUM} (${REMOTE_USER}/${REMOTE_BRANCH})."
+
+  _warn "Please notify ${REMOTE_USER} that they should pull from their remote branch, " \
+        "otherwise they might accidentally force-commit over your changes."
 }
 
 ##########################################################################

--- a/scripts/gee
+++ b/scripts/gee
@@ -149,7 +149,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.24"
+readonly VERSION="0.2.25"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file
@@ -3126,7 +3126,7 @@ function gee__pr_view() {
 
 _register_help "pr_make" \
   "Creates a pull request from this branch." \
-  "mail" "send" "make_pr" "mkpr" "prmk" <<'EOT'
+  "mail" "send" "pr_create" "create_pr" "make_pr" "mkpr" "prmk" <<'EOT'
 Usage: gee make_pr <gh-options>
 
 Creates a new pull request from this branch.  The user will be asked to
@@ -4405,7 +4405,7 @@ The "usage" option produces gee's manual.
 
 The "commands" option shows a summary of all available commands.
 
-The "html" option produce's gee's manual, in html format.
+The "markdown" option produce's gee's manual, in markdown format.
 EOT
 
 function _render_markdown_manual() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -2263,13 +2263,22 @@ function gee__update() {
     read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
     if [[ "${COUNTS[1]}" -gt 0 ]]; then
       _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}."
-      _info "This could be caused by commiting changes to this branch from a different machine, " \
-            "or possibly you rebased your branch without pushing the updated branch to origin."
+      _info \
+        "There are two likely causes.  Either:" \
+        "" \
+        "* If you or another user pushed commits into this branch from another branch" \
+        "  or machine, in which case you probably want to integrate these changes, or" \
+        "" \
+        "* If you manually rebased your local branch, but forgot to force-push the" \
+        "  updated branch to origin, in which case you should do a force-push instead" \
+        "  of integrating."
       if _confirm_default_yes "Do you want to integrate changes from origin/${CURRENT_BRANCH}? (Y/n)  "; then
         _info "Pulling in changes from origin/${CURRENT_BRANCH}"
         HEAD="$("${GIT}" rev-parse HEAD)"
         _info "Old head commit before rebase: ${HEAD}"
         _git rebase --autostash "origin/${CURRENT_BRANCH}"
+      else
+        _info "You may need to \"git push -u origin --force\" to fix your origin remote."
       fi
     fi
   fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -2879,8 +2879,8 @@ function gee__pr_push() {
   BRANCH="$(_get_current_branch)"
   _read_parents_file
   local PRNUM=""
-  if [[ "${PARENTS["${BRANCH}"]}" == "upstream/refs/pull/*/head" ]]; then
-    PRNUM="$(cut -d '/' -f4)"
+  if [[ "${PARENTS[${BRANCH}]}" == upstream/refs/pull/*/head ]]; then
+    PRNUM="$(cut -d '/' -f4 <<< "${PARENTS[${BRANCH}]}")"
   else
     _fatal "This branch does not appear to have been made with \"gee pr_checkout\"."
   fi
@@ -2888,7 +2888,7 @@ function gee__pr_push() {
 
   # Identify remote branch
   local -a DATA=()
-  _read_cmd DATA "${GH}" pr view \
+  _read_cmd DATA "${GH}" pr view "${PRNUM}" \
     --json author,headRefName,state \
     --jq '.author["login"],.headRefName,.state'
   local REMOTE_USER REMOTE_BRANCH REMOTE_STATE
@@ -2909,10 +2909,15 @@ function gee__pr_push() {
 
   # Check if we are behind remote branch
   local -a COUNTS
-  _read_cmd COUNTS "${GIT}" rev-list --left-right --count "${BRANCH}...FETCH_HEAD"
+  read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${BRANCH}...FETCH_HEAD")
+  _info "Local has ${COUNTS[0]} more commit(s) than remote ${REMOTE_USER}/${REMOTE_BRANCH}."
+  _info "Remote has ${COUNTS[1]} more commit(s) than local."
+  if [[ "${COUNTS[0]}" -eq 0 ]]; then
+    _fatal "No local commits to push.  Perhaps you need to \"gee commit\" first?"
+  fi
   if [[ "${COUNTS[1]}" -gt 0 ]]; then
     _warn "Remote branch ${REMOTE_USER}/${REMOTE_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${BRANCH}."
-    _fatal "You must \"gee update\" before trying to \"gee pr_push\"."
+    _fatal "You must run \"gee update\" and then try again."
   fi
 
   # Push our changes to the remote branch

--- a/scripts/gee
+++ b/scripts/gee
@@ -2716,13 +2716,24 @@ _register_help "commit" \
   "push" "c" <<'EOT'
 Usage: gee commit [<git commit options>]
 
-Commits all outstanding changes (to the local branch, not the upstream branch),
-and uploads that commit to the user's private github repo.  "commit" can be
-used to checkpoint and back up work in progress.
+Commits all outstanding changes to your local branch, and then immediately
+pushes your commits to `origin` (your private, remote github repository).
+
+"commit" can be used to checkpoint and back up work in progress.
+
+Note that if you are working in a PR-associated branch created with `gee
+pr_checkout`, your commits will be pushed to your `origin` remote, and the
+remote PR branch.  To contribute your changes back to another user's PR branch,
+use the `gee pr_push` command.
 
 Example:
 
     gee commit -m "Added \"gee commit\" command."
+
+See also:
+
+* pr_push
+
 EOT
 
 function gee__push() { gee__commit "$@"; }
@@ -2821,6 +2832,18 @@ _register_help "pr_checkout" \
 Usage: gee pr_checkout <PR>
 
 Creates a new branch containing the specified pull request.
+
+Note that the new will be configured so that `gee update` will update that
+branch by integrating changes from the original pull request.  However,
+`gee commit` will still only push commits to your own local and `origin`
+repositories.  If you want to push commits back into the original PR,
+use the `pr_push` command.
+
+See also:
+
+* commit
+* pr_push
+
 EOT
 
 function gee__pr_checkout() {
@@ -2871,10 +2894,18 @@ Otherwise, the other user might accidentally lose your commits entirely if they
 force-push.  Remote users can integrate your changes using the `gee update`
 command, or `git rebase --autostash origin/<branch>` if they aren't a gee user.
 
+See also:
+
+* commit
+* pr_checkout
+
 EOT
 
 function gee__pr_push() {
-  # Check that we are in a PR branch
+  # Check that we are in a PR branch (a branch created with pr_checkout).  This
+  # is somewhat inflexible, but since "pushing to another user's branch" is a
+  # bit of a risky activity, we should be extra careful here and only support
+  # one well-tested way of doing things.
   local BRANCH
   BRANCH="$(_get_current_branch)"
   _read_parents_file

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Release 0.2.25
+
+* Added `pr_push` command.
+
 ### Release 0.2.24
 
 * Added `restore_all_branches` command.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.24
+gee version: 0.2.25
 
 gee is a wrapper around the "git" and "gh-cli" tools.  "gee" captures all
 tribal knowledge about how to use git the right way (for us), implementing one
@@ -413,7 +413,7 @@ View an outstanding pull request.
 
 ### pr_make
 
-Aliases: mail send make_pr mkpr prmk
+Aliases: mail send pr_create create_pr make_pr mkpr prmk
 
 Usage: `gee make_pr <gh-options>`
 
@@ -606,5 +606,5 @@ The "usage" option produces gee's manual.
 
 The "commands" option shows a summary of all available commands.
 
-The "html" option produce's gee's manual, in html format.
+The "markdown" option produce's gee's manual, in markdown format.
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -111,6 +111,7 @@ review.
 | <a href="#pr_edit">`pr_edit`</a> | Edit an existing pull request. |
 | <a href="#pr_list">`pr_list`</a> | List outstanding PRs |
 | <a href="#pr_make">`pr_make`</a> | Creates a pull request from this branch. |
+| <a href="#pr_push">`pr_push`</a> | Push commits into another user's PR branch. |
 | <a href="#pr_submit">`pr_submit`</a> | Merge the approved PR into the parent branch. |
 | <a href="#pr_view">`pr_view`</a> | View an existing pull request. |
 | <a href="#remove_branch">`remove_branch`</a> | Remove a branch. |
@@ -293,13 +294,23 @@ Aliases: push c
 
 Usage: `gee commit [<git commit options>]`
 
-Commits all outstanding changes (to the local branch, not the upstream branch),
-and uploads that commit to the user's private github repo.  "commit" can be
-used to checkpoint and back up work in progress.
+Commits all outstanding changes to your local branch, and then immediately
+pushes your commits to `origin` (your private, remote github repository).
+
+"commit" can be used to checkpoint and back up work in progress.
+
+Note that if you are working in a PR-associated branch created with `gee
+pr_checkout`, your commits will be pushed to your `origin` remote, and the
+remote PR branch.  To contribute your changes back to another user's PR branch,
+use the `gee pr_push` command.
 
 Example:
 
     gee commit -m "Added \"gee commit\" command."
+
+See also:
+
+* pr_push
 
 ### revert
 
@@ -318,6 +329,42 @@ Example:
 Usage: `gee pr_checkout <PR>`
 
 Creates a new branch containing the specified pull request.
+
+Note that the new will be configured so that `gee update` will update that
+branch by integrating changes from the original pull request.  However,
+`gee commit` will still only push commits to your own local and `origin`
+repositories.  If you want to push commits back into the original PR,
+use the `pr_push` command.
+
+See also:
+
+* commit
+* pr_push
+
+### pr_push
+
+Usage: `gee pr_push`
+
+`gee pr_push` must be executed from within a branch created by `gee pr_checkout`.
+
+`gee commit` will create a local commit, and push that commit to `origin`, the
+remote repository owned by you.  `gee pr_push` can then be used to also push
+your commits into another user's remote pull request branch.
+
+`gee pr_push` will refuse to proceed unless all changes from the remote pull
+request branch are already integrated in your local branch, so you might need
+to `gee update` before `gee pr_push`.
+
+After pushing your changes into another user's PR branch, be sure to directly
+notify that user, so they know to pull your changes into their local branch.
+Otherwise, the other user might accidentally lose your commits entirely if they
+force-push.  Remote users can integrate your changes using the `gee update`
+command, or `git rebase --autostash origin/<branch>` if they aren't a gee user.
+
+See also:
+
+* commit
+* pr_checkout
 
 ### pr_list
 


### PR DESCRIPTION
gee: add pr_push command

The pr_push command is a command for explicitly pushing commits from a
branch created with `gee pr_checkout` back into the author's PR branch.

Tested: Checked out a PR with `gee pr_checkout`, and then pushed a commit
into it user `gee pr_push`.  Remote user then ran "gee update" to pull
that change into their local branch.

