### PR TITLE
kbuild: Setup public URL to access all versions of an artifact

### DIFF
--- a/kbuild/v2/upload.sh
+++ b/kbuild/v2/upload.sh
@@ -46,7 +46,7 @@ upload_artifact() {
     enkit astore public del "$astore_path" > /dev/null 2>&1 || true
 
     if [ "$public" = "public" ] ; then
-        enkit astore public add "$astore_path" -a $arch
+        enkit astore public add "$astore_path" -a $arch --all
     fi
 
     echo "Upload sha256sum:"


### PR DESCRIPTION
When publishing a URL to an artifact that already exists, the query
defaults to `uid=latest`, which breaks existing WORKSPACE rules that use
older UIDs. With --all, the query allows access to any version of an
artifact at that path.

Jira: INFRA-794

Signed-off-by: Raghu Raja <raghu@enfabrica.net>