### PR TITLE
machinist: return NXDOMAIN if there are no records for a query.

### DIFF
--- a/lib/knetwork/kdns/dns.go
+++ b/lib/knetwork/kdns/dns.go
@@ -164,5 +164,10 @@ func (s *DnsServer) ParseDNS(m *dns.Msg) {
 				m.Answer = append(m.Answer, txt)
 			}
 		}
+
+	}
+
+	if len(m.Answer) <= 0 {
+		m.Rcode = dns.RcodeNameError
 	}
 }


### PR DESCRIPTION
Background:
Without NXDOMAIN, the query is marked successful even without results.
This can cause some clients to stop querying other dns names (when
implementing a resolv.conf 'search' walk, for example).

Fix is very simple:
- return NXDOMAIN status if there are no results.