### PR TITLE
faketree: send SIGTERM to children after the main command dies.

### DIFF
--- a/faketree/faketree_test.go
+++ b/faketree/faketree_test.go
@@ -84,6 +84,7 @@ func TestParseFlags(t *testing.T) {
 		"--uid=12", "--mount", ":/tmp/proc:ro,type=proc,data=foo", "--", "no pig",
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, []string{"no pig"}, left)
 
 	args = fl.Args()
 	assert.Equal(t, []string{"--uid", "12", "--gid", u.Gid, "--faketree", fl.Faketree, "--mount", ":/tmp/proc:ro,type=proc,data=foo"}, args)
@@ -100,7 +101,16 @@ func TestParseFlags(t *testing.T) {
 	fl = NewFlags()
 	left, err = fl.Parse([]string{"--wait-timeout=1h53m17s"})
 	assert.NoError(t, err)
+	assert.Equal(t, []string{}, left)
 
 	args = fl.Args()
 	assert.Equal(t, []string{"--uid", u.Uid, "--gid", u.Gid, "--faketree", fl.Faketree, "--wait-timeout", "1h53m17s"}, args)
+
+	fl = NewFlags()
+	left, err = fl.Parse([]string{"--wait-term=false"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{}, left)
+
+	args = fl.Args()
+	assert.Equal(t, []string{"--uid", u.Uid, "--gid", u.Gid, "--faketree", fl.Faketree, "--wait-term=false"}, args)
 }


### PR DESCRIPTION
Background:
All works well when Ctl+c is used, or when the job control system
sends SIGTERM (or later, SIGKILL). Signals are propagated, faketree
waits for all children to die.

But when the "main command" run by faketree (eg, the direct child)
completes (successfully, or crash), faketree now waits for all its
children to complete, assuming the "main command" is taking care
of all its children directly (on successful completion, or on exit,
when the job control system does not have to intervene).

For commands that don't clean up after themselves, this will cause
faketree to wait until --wait-timeout, and then SIGKILL all children
(which is risky, as it could cause once again license leak, and
could cause long waits).

In this PR:
- If the "main process" spawned by faketree completes, send
  a friendly SIGTERM to all leftover children by default.
- Then, keep waiting until --wait-timeout to send a SIGKILL.

This addresses the case of the "main process" exiting of its
own volition.

The main drawback is that this could cause a third (sigh) SIGTERM
to be sent to child processes when the JOB control system
itself sends a SIGTERM (sequence: parent faketree receives SIGTERM,
propagates to all children (1), namespace faketree receives SIGTERM,
propagates to all children (2), main process exits, another SIGTERM
is sent to all children (3)). Spurious signals are "normal", and
probably harmless. Further, I'd claim that if all children were
well behaving (eg, waiting for their children before exiting),
we'd have at most 2 SIGTERMs, like today, and possibly 1.

Tested:
- it's hard to predict the side effects, but there's good coverage
  in unit tests. One unit test specifically started failing (good!)
  catching the change in behavior.
- made the feature flag controlled, so we can disable it if
  necessary.

This should help with issues like INFRA-793.