### PR TITLE
khttp: fix server.go to be more reasonable.

### DIFF
--- a/lib/khttp/BUILD.bazel
+++ b/lib/khttp/BUILD.bazel
@@ -20,7 +20,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["utils_test.go"],
+    srcs = [
+        "server_test.go",
+        "utils_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/lib/khttp/server_test.go
+++ b/lib/khttp/server_test.go
@@ -1,0 +1,34 @@
+package khttp
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAddDefaultPort(t *testing.T) {
+	address, err := addDefaultPort("", 0)
+	assert.Error(t, err)
+
+	address, err = addDefaultPort("", 65536)
+	assert.Error(t, err)
+
+	address, err = addDefaultPort("", 80)
+	assert.NoError(t, err)
+	assert.Equal(t, ":80", address)
+
+	address, err = addDefaultPort("127.0.0.1", 80)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:80", address)
+
+	address, err = addDefaultPort("[::1]", 80)
+	assert.NoError(t, err)
+	assert.Equal(t, "[::1]:80", address)
+
+	address, err = addDefaultPort("127.0.0.1:1234", 80)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:1234", address)
+
+	address, err = addDefaultPort("[::1]:1234", 80)
+	assert.NoError(t, err)
+	assert.Equal(t, "[::1]:1234", address)
+}


### PR DESCRIPTION
Background:
server.go was created out of the proxy in a hurry, turns out it's more
broken than I'd like to admit. In this specific case:
- flags were not prefixed properly
- description were not updated
- semantics were not intuitive

Last point bit me last night: I was assuming the port number to be
a default if not specified in the address, turns out that if an address
is specified at all, the port number is completely ignored.

In this PR:
- fix the prefix
- fix the description
- have the port number behave as a true default port number

Additionally, added small unit test, and go fmt.