### PR TITLE
gee: fix pr_make failure

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -149,7 +149,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.25"
+readonly VERSION="0.2.26"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3162,7 +3162,8 @@ function gee__pr_make() {
 
   local STATE NUMBER TITLE
   read -r STATE NUMBER TITLE < \
-    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED)
+    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED) \
+    || /bin/true  # don't fail if empty
   if [[ "${STATE}" == "OPEN" ]]; then
     _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \
           "Use \"gee commit\" to update existing PR."

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Release 0.2.26
+
+* Fixed exception in `pr_make` due to empty read error.
+
 ### Release 0.2.25
 
 * Added `pr_push` command.


### PR DESCRIPTION
gee: fix pr_make failure

I introduced a bug in a previous PR.  I use "read" to scan a line of input,
but I forgot to handle the case where there are no open PRs.  This cause
read to exit with a non-zero exit code, causing the bash script to terminate.

The go rewrite can't come soon enough.

Tested: Made this PR using this version of gee.

