### PR TITLE
enkit: Move command building to library

### DIFF
--- a/bazel/dependencies/BUILD.bazel
+++ b/bazel/dependencies/BUILD.bazel
@@ -1,4 +1,4 @@
 exports_files(
     ["*.patch"],
-    visibility=["//visibility:public"],
+    visibility = ["//visibility:public"],
 )

--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -5,18 +5,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/enfabrica/enkit/enkit",
     visibility = ["//visibility:private"],
-    deps = [
-        "//astore/client/commands:go_default_library",
-        "//enkit/outputs:go_default_library",
-        "//lib/bazel/commands:go_default_library",
-        "//lib/client:go_default_library",
-        "//lib/client/commands:go_default_library",
-        "//lib/kflags/kcobra:go_default_library",
-        "//lib/srand:go_default_library",
-        "//proxy/enfuse/fusecmd:go_default_library",
-        "//proxy/ptunnel/commands:go_default_library",
-        "@com_github_spf13_cobra//:go_default_library",
-    ],
+    deps = ["//enkit/cmd:go_default_library"],
 )
 
 go_binary(

--- a/enkit/cmd/BUILD.bazel
+++ b/enkit/cmd/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["command.go"],
+    importpath = "github.com/enfabrica/enkit/enkit/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//astore/client/commands:go_default_library",
+        "//enkit/outputs:go_default_library",
+        "//lib/bazel/commands:go_default_library",
+        "//lib/client:go_default_library",
+        "//lib/client/commands:go_default_library",
+        "//lib/kflags:go_default_library",
+        "//lib/kflags/kcobra:go_default_library",
+        "//lib/srand:go_default_library",
+        "//proxy/enfuse/fusecmd:go_default_library",
+        "//proxy/ptunnel/commands:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@com_github_spf13_cobra//doc:go_default_library",
+    ],
+)

--- a/enkit/cmd/command.go
+++ b/enkit/cmd/command.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"math/rand"
+
+	acommands "github.com/enfabrica/enkit/astore/client/commands"
+	ocommands "github.com/enfabrica/enkit/enkit/outputs"
+	bazelcmds "github.com/enfabrica/enkit/lib/bazel/commands"
+	"github.com/enfabrica/enkit/lib/client"
+	bcommands "github.com/enfabrica/enkit/lib/client/commands"
+	"github.com/enfabrica/enkit/lib/kflags"
+	"github.com/enfabrica/enkit/lib/kflags/kcobra"
+	"github.com/enfabrica/enkit/lib/srand"
+	"github.com/enfabrica/enkit/proxy/enfuse/fusecmd"
+	tcommands "github.com/enfabrica/enkit/proxy/ptunnel/commands"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+type EnkitCommand struct {
+	cmd       *cobra.Command
+	baseFlags *client.BaseFlags
+	flagSet   *kcobra.FlagSet
+	populator kflags.Populator
+	runner    kflags.Runner
+}
+
+func New() (*EnkitCommand, error) {
+	rng := rand.New(srand.Source)
+
+	root := &cobra.Command{
+		Use:           "enkit",
+		Long:          `enkit - a single command for all your corp and build needs`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Example:       `  $ enkit astore push`,
+	}
+
+	base := client.DefaultBaseFlags(root.Name(), "enkit")
+
+	set, populator, runner := kcobra.Runner(root, nil, base.IdentityErrorHandler("enkit login"))
+
+	login := bcommands.NewLogin(base, rng, populator)
+	root.AddCommand(login.Command)
+
+	astore := acommands.New(base)
+	root.AddCommand(astore.Command)
+
+	tunnel := tcommands.NewTunnel(base)
+	root.AddCommand(tunnel.Command)
+
+	ssh := tcommands.NewSSH(base)
+	root.AddCommand(ssh.Command)
+
+	agentCommand := tcommands.NewAgentCommand(base)
+	root.AddCommand(agentCommand)
+
+	bazel := bazelcmds.New(base)
+	root.AddCommand(bazel.Command)
+
+	outputs, err := ocommands.New(base)
+	if err != nil {
+		return nil, err
+	}
+	root.AddCommand(outputs.Command)
+
+	root.AddCommand(fusecmd.New())
+
+	return &EnkitCommand{
+		cmd:       root,
+		baseFlags: base,
+		flagSet:   set,
+		populator: populator,
+		runner:    runner,
+	}, nil
+}
+
+func (c *EnkitCommand) Run() {
+	c.baseFlags.Run(kcobra.HideFlags(c.flagSet), c.populator, c.runner)
+}
+
+func (c *EnkitCommand) GenMarkdownTree(path string) error {
+	return doc.GenMarkdownTree(c.cmd, path)
+}

--- a/enkit/doc_gen/BUILD.bazel
+++ b/enkit/doc_gen/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/enkit/doc_gen",
+    visibility = ["//visibility:private"],
+    deps = ["//enkit/cmd:go_default_library"],
+)
+
+go_binary(
+    name = "doc_gen",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/enkit/doc_gen/main.go
+++ b/enkit/doc_gen/main.go
@@ -1,17 +1,25 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/enfabrica/enkit/enkit/cmd"
 )
 
+var (
+	outDir = flag.String("out-dir", "", "Path to output directory to emit markdown files")
+)
+
 func main() {
+	flag.Parse()
+
 	command, err := cmd.New()
 	exitIf(err)
 
-	command.Run()
+	err = command.GenMarkdownTree(*outDir)
+	exitIf(err)
 }
 
 func exitIf(err error) {

--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -93,7 +93,7 @@ func NewMount(root *Root) *Mount {
 		Command: &cobra.Command{
 			Use:   "mount",
 			Short: "Mount the build outputs of a particular invocation",
-			Example: `  $ enkit outputs mount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
+			Example: `  $ enkit outputs mount -i 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
 	Mounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 to the
 	default location.`,
 		},
@@ -210,7 +210,7 @@ func NewUnmount(root *Root) *Unmount {
 		Command: &cobra.Command{
 			Use:   "unmount",
 			Short: "Unmount the build outputs of a particular invocation",
-			Example: `  $ enkit outputs unmount 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
+			Example: `  $ enkit outputs unmount -i 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07
 	Unmounts outputs from build 73d4a9f0-a0c4-4cb2-80eb-b4b4b9720d07 from the
 	default location.`,
 			Aliases: []string{"umount"},

--- a/machinist/polling/BUILD.bazel
+++ b/machinist/polling/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_uber_go_atomic//:go_default_library",
     ],
 )

--- a/proxy/enproxy/BUILD.bazel
+++ b/proxy/enproxy/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//proxy/httpp:go_default_library",
         "//proxy/nasshp:go_default_library",
         "//proxy/ptunnel:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )


### PR DESCRIPTION
This change moves the command building that happens in `main.go` to a
separate library that returns a struct containing all the pieces with
convenience methods to run the command.

This facilitates writing a binary that emits markdown documentation from
enkit using a built-in cobra library. This documentation can serve as a
reference for users of enkit.

Tested: `bazel run //enkit/doc_gen -- --out-dir=/tmp/docs` works; `bazel
run //enkit -- login` still works.

Jira: INFRA-494