### PR TITLE
enproxy: add prefix in config parameters.

### DIFF
--- a/proxy/enproxy/enproxy.go
+++ b/proxy/enproxy/enproxy.go
@@ -138,8 +138,8 @@ func (fl *Flags) Register(set kflags.FlagSet, prefix string) *Flags {
 	fl.Nassh.Register(set, prefix)
 	fl.Prometheus.Register(set, prefix+"prometheus-")
 
-	set.ByteFileVar(&fl.ConfigContent, "config", fl.ConfigName, "Default config file location.", kflags.WithFilename(&fl.ConfigName))
-	set.BoolVar(&fl.DisabledAuthentication, "without-authentication", false, "allow tunneling even without authentication")
+	set.ByteFileVar(&fl.ConfigContent, prefix+"config", fl.ConfigName, "Default config file location.", kflags.WithFilename(&fl.ConfigName))
+	set.BoolVar(&fl.DisabledAuthentication, prefix+"without-authentication", false, "allow tunneling even without authentication")
 
 	return fl
 }


### PR DESCRIPTION
This fixes a small error I just noticed in the code:
we don't prepend prefix in some configuration parameters.