### PR TITLE
Rollback of PR #444

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1775,7 +1775,7 @@ function _print_codeowners() {
           O="${VAL}"
         fi
       else
-        if [[ "/$F" == *"/${EXP}" ]]; then
+        if [[ "/$F" == "${EXP}" ]]; then
           O="${VAL}"
         fi
       fi
@@ -2508,11 +2508,11 @@ function gee__codeowners() {
     if [[ "${#OWNERS[@]}" -eq 0 ]]; then
       printf "This PR can be submitted with approval from any repo owner.\n\n"
     elif [[ "${#OWNERS[@]}" -eq 1 ]]; then
-      printf "This PR requires approval from at least one of these reviewers:\n\n"
-      printf "* %s\n" "${OWNERS[@]}"
+      printf "This PR requires approval from at least one of these reviewers:\n"
+      printf "  %s\n" "${OWNERS[@]}"
     else
-      printf "This PR requires approval from at least one reviewer from each line:\n\n"
-      printf "* %s\n" "${OWNERS[@]}"
+      printf "This PR requires approval from at least one reviewer from each line:\n"
+      printf "  %s\n" "${OWNERS[@]}"
     fi
     printf "\n"
   ) || /bin/true


### PR DESCRIPTION
gee-generated rollback of PR #444 (was commit c36b90b).

Reason for rollback: testing gee pr_rollback command.

DO NOT SUBMIT

Original commit message:
========================

gee codeowners: fix for "WORKSPACES" (tiny PR) (#444)

gee codeowners: fix for "WORKSPACES" (tiny PR)

gee codeowners: fix for "WORKSPACES" (tiny PR)

I noticed that `gee codeowners` wasn't reporting the right codeowners for
changes to WORKSPACES.  Turns out this was an edge-condition in my rules
processing code that only affects rules that aren't wildcards, and the
file in question happens to be in the root directory of the repo.

While I'm in here, I also snuck in a purely cosmetic improvement to
the markdown format of the generated codeowners comment.

Tested:

- made a test branch and only changed the WORKSPACES file
- verified that "gee codeowners" reported the right owners.



