### PR TITLE
gee: implement pr_rollback command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -149,7 +149,7 @@ function _fix_pwd() {
 _fix_pwd
 
 # Globals:
-readonly VERSION="0.2.26"
+readonly VERSION="0.2.27"
 declare -a HELP=()
 declare -A LONGHELP
 declare -A PARENTS     # initialized by _load_parents_file

--- a/scripts/gee
+++ b/scripts/gee
@@ -3577,6 +3577,91 @@ function gee__pr_submit() {
 }
 
 ##########################################################################
+# pr_rollback command
+##########################################################################
+
+_register_help "pr_rollback" \
+  "Create a rollback PR for a specified PR." <<'EOT'
+Usage: gee pr_rollback <PR>
+
+Creates a branch named `rollback_<PR>`, attempts to revert the commit
+associated with that PR, and if successful, creates a new PR that rolls
+back the specified PR.
+
+Example:
+
+    gee pr_rollback 1234
+EOT
+function gee__pr_rollback() {
+  _check_cwd
+  _check_gh_auth
+
+  local PR="$1"
+  if [[ -z "${PR}" ]]; then
+    _fatal "Must specify a PR number to roll back."
+  fi
+
+  _set_main
+  _checkout_or_die "${MAIN}"
+  local BR="rollback_${PR}"
+  gee__mkbr "rollback_${PR}"
+
+  local -a LOGLINES=()
+  local RE='\(#'"${PR}"'\)$'
+  mapfile -t LOGLINES < \
+    <( "${GIT}" log --pretty=format:"%h %s" | grep -E "${RE}" )
+  if (( "${#LOGLINES[@]}" == 0 )); then
+    _fatal "Could not find any commits labelled \"${RE}\""
+  fi
+  if (( "${#LOGLINES[@]}" > 1 )); then
+    _fatal "When searching for \"${RE}\", found multiple possible commits:" \
+      "${LOGLINES[@]}"
+  fi
+
+  local COMMIT DESC
+  read -r COMMIT DESC <<< "${LOGLINES[0]}"
+  _info "Identified commit \"${COMMIT}\": ${DESC}"
+
+  _git revert "${COMMIT}"  # creates a new commit
+
+  local BODYFILE
+  BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
+  (
+    printf "gee-generated rollback of PR #%s (was commit %s).\n" "${PR}" "${COMMIT}"
+    printf "\n"
+    printf "Reason for rollback:\n"
+    printf "\n"
+    printf "Original commit message:\n"
+    printf "========================\n"
+    printf "\n"
+    git log --format=%B -n 1 "${COMMIT}"
+  ) >"${BODYFILE}"
+
+  _choose_one "Which editor do you want to use?  ([V]im, [e]macs, [a]bort)  " "VvEeAa" "v"
+  case "${RESP}" in
+    [vV]*) vim "${BODYFILE}"; ;;
+    [eE]*) emacs "${BODYFILE}"; ;;
+    [aA]*) _fatal "Aborted."; ;;
+  esac
+
+  local TITLE
+  TITLE="Rollback of PR #${PR}"
+
+  local -a PR_ARGS
+  PR_ARGS+=(
+    --repo "${UPSTREAM}/${REPO}"
+    --title "${TITLE}"
+    -H "${GHUSER}:${BR}"
+    --body-file "${BODYFILE}"
+  )
+
+  _gh pr create "${PR_ARGS[@]}"
+  gee__codeowners --comment
+  _gh_pr_view
+  rm "${BODYFILE}"
+}
+
+##########################################################################
 # remove_branch command
 ##########################################################################
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3604,7 +3604,11 @@ function gee__pr_rollback() {
   _set_main
   _checkout_or_die "${MAIN}"
   local BR="rollback_${PR}"
-  gee__mkbr "rollback_${PR}"
+  if _local_branch_exists "${BR}"; then
+    _fatal "Branch ${BR} already exists, remove and try again?"
+  fi
+  gee__mkbr "${BR}"
+  _checkout_or_die "${BR}"
 
   local -a LOGLINES=()
   local RE='\(#'"${PR}"'\)$'
@@ -3622,7 +3626,9 @@ function gee__pr_rollback() {
   read -r COMMIT DESC <<< "${LOGLINES[0]}"
   _info "Identified commit \"${COMMIT}\": ${DESC}"
 
-  _git revert "${COMMIT}"  # creates a new commit
+  _git revert --no-edit "${COMMIT}"  # creates a new commit
+  _git push --quiet -u origin "${BR}"
+  printf >&2 "\n"
 
   local BODYFILE
   BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
@@ -3637,7 +3643,9 @@ function gee__pr_rollback() {
     git log --format=%B -n 1 "${COMMIT}"
   ) >"${BODYFILE}"
 
-  _choose_one "Which editor do you want to use?  ([V]im, [e]macs, [a]bort)  " "VvEeAa" "v"
+  _choose_one \
+    "Which editor do you want to use to edit the PR description? ([V]im, [e]macs, [a]bort)  " \
+    "VvEeAa" "v"
   case "${RESP}" in
     [vV]*) vim "${BODYFILE}"; ;;
     [eE]*) emacs "${BODYFILE}"; ;;

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Unreleased
+
+* Add `pr_rollback` command.
+
 ### Release 0.2.26
 
 * Fixed exception in `pr_make` due to empty read error.

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,7 +2,7 @@
 
 ## Releases
 
-### Unreleased
+### Release 0.2.27
 
 * Add `pr_rollback` command.
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.26
+gee version: 0.2.27
 
 gee is a wrapper around the "git" and "gh-cli" tools.  "gee" captures all
 tribal knowledge about how to use git the right way (for us), implementing one

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -112,6 +112,7 @@ review.
 | <a href="#pr_list">`pr_list`</a> | List outstanding PRs |
 | <a href="#pr_make">`pr_make`</a> | Creates a pull request from this branch. |
 | <a href="#pr_push">`pr_push`</a> | Push commits into another user's PR branch. |
+| <a href="#pr_rollback">`pr_rollback`</a> | Create a rollback PR for a specified PR. |
 | <a href="#pr_submit">`pr_submit`</a> | Merge the approved PR into the parent branch. |
 | <a href="#pr_view">`pr_view`</a> | View an existing pull request. |
 | <a href="#remove_branch">`remove_branch`</a> | Remove a branch. |
@@ -441,6 +442,18 @@ Aliases: merge submit_pr
 Usage: `gee submit_pr`
 
 Merges an approved pull request.
+
+### pr_rollback
+
+Usage: `gee pr_rollback <PR>`
+
+Creates a branch named `rollback_<PR>`, attempts to revert the commit
+associated with that PR, and if successful, creates a new PR that rolls
+back the specified PR.
+
+Example:
+
+    gee pr_rollback 1234
 
 ### remove_branch
 


### PR DESCRIPTION
gee: implement pr_rollback command

This PR makes it easier to rollback a PR.  It generates the rollback branch,
rolls back the commit associated with the specified PR, and generates the
associated PR.

Tested:

    DRYRUN=1 ./gee pr_rollback 444  # inspected commands
    ./gee pr_rollback 444  # generated a test rollback

