### PR TITLE
astore client: Add debug logs

### DIFF
--- a/astore/client/commands/commands.go
+++ b/astore/client/commands/commands.go
@@ -178,6 +178,8 @@ func (dc *Download) Run(cmd *cobra.Command, args []string) error {
 		ftd = append(ftd, file)
 	}
 
+	dc.root.Log.Debugf("Files to download: %+v", ftd)
+
 	client, err := dc.root.StoreClient()
 	if err != nil {
 		return err


### PR DESCRIPTION
This change adds debug-level log statements for debugging why
downloading by UID doesn't work.

Jira: INFRA-830