### PR TITLE
bazel: Fix `load` import string

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@//bazel/utils:diff_test.bzl", "diff_test")
+load("//bazel/utils:diff_test.bzl", "diff_test")
 
 exports_files(["run_clang_format.template.sh"])
 


### PR DESCRIPTION
This change fixes an import string that causes an issue when importing
enkit into other repositories. Because a `BUILD` file contains a
`load()` that starts with `@//`, this gets resolved relative to the
other repository, rather than relative to enkit.

This change removes the leading `@` so that the import is always
resolved relative to enkit.

Tested: `bazel query --override_repository=enkit=/home/scott/dev/enkit
'deps(//:cc_format)'` which shows the issue with enkit on master and
doesn't show the issue with this fix.

Jira: INFRA-494