### PR TITLE
linux/defs.bzl: fix the outputs of kernel_module

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -271,7 +271,7 @@ def _kernel_modules(ctx):
         use_default_shell_env = True,
     )
 
-    return [DefaultInfo(files = depset([output])), KernelModulesInfo(
+    return [DefaultInfo(files = depset(outputs)), KernelModulesInfo(
         name = ctx.attr.name,
         package = ki.package,
         modules = outputs,


### PR DESCRIPTION
kernel_module returned as an output only the symvers file and not the ko
file.

Example run before this commit:
$ bazel build driver/core:enf
Target //driver/core:enf up-to-date:
  bazel-bin/driver/core/enf-ubuntu-impish-minimal/enf.ko.symvers
  bazel-bin/driver/core/enf-ubuntu-impish-generic/enf.ko.symvers

Example run with this commit:
$ bazel build driver/core:enf
Target //driver/core:enf up-to-date:
  bazel-bin/driver/core/enf-ubuntu-impish-minimal/enf.ko
  bazel-bin/driver/core/enf-ubuntu-impish-minimal/enf.ko.symvers
  bazel-bin/driver/core/enf-ubuntu-impish-generic/enf.ko
  bazel-bin/driver/core/enf-ubuntu-impish-generic/enf.ko.symvers

Signed-off-by: George Prekas <george@enfabrica.net>