### PR TITLE
astore: Remove Created sorting on some Retrieve queries

### DIFF
--- a/astore/server/astore/retrieve.go
+++ b/astore/server/astore/retrieve.go
@@ -76,7 +76,7 @@ func (s *Server) Retrieve(ctx context.Context, req *astore.RetrieveRequest) (*as
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid path - %s", err)
 		}
 	} else {
-		query = datastore.NewQuery(KindArtifact).Order("-Created")
+		query = datastore.NewQuery(KindArtifact)
 	}
 	query = query.Limit(1)
 


### PR DESCRIPTION
This change removes the sorting when querying by UID only, as it seems
that the Datastore indexes are not properly configured to handle this
case. Unit tests are updated, and for all affected cases, corresponding
GQL is documented in a comment and tested manually in the Cloud Console
to ensure there are no index issues.

Additional testcases are added to document the behavior of the TagSet
field as it exists (tri-state, different behavior when an empty set is
present vs. no set) but no behavioral changes are made to this case.

`rpc/astore` import is renamed to `apb` in the unit tests to make it
clear that this package is protobuf generated code.

Tested: See above

Jira: INFRA-830