### PR TITLE
appengine: change rules to mandate providing a project attribute.

### DIFF
--- a/astore/server/BUILD.bazel
+++ b/astore/server/BUILD.bazel
@@ -108,6 +108,7 @@ go_appengine_deploy(
     name = "deploy",
     config = "deploy/app.yaml",
     entry = "github.com/enfabrica/enkit/astore/server",
+    project = "astore-284118",
     gomod = "//:go.mod",
     gosum = "//:go.sum",
     deps = [

--- a/bazel/appengine/defs.bzl
+++ b/bazel/appengine/defs.bzl
@@ -21,8 +21,10 @@ def _go_appengine_deploy_path_impl(ctx):
     if ctx.attr.gosum:
         args.append("-gosum=" + ctx.file.gosum.path)
         inputs.append(ctx.file.gosum)
+    extra = "--project={project}".format(project = ctx.attr.project)
     if ctx.attr.extra:
-        args.append("-extra='" + " ".join([s.replace("'", "'\\''") for s in ctx.attr.extra]) + "'")
+        extra = extra + " " + " ".join([s.replace("'", "'\\''") for s in ctx.attr.extra])
+    args.append("-extra='" + extra + "'")
 
     gcloud = ctx.actions.declare_file("gcloud.sh")
     ctx.actions.expand_template(
@@ -58,6 +60,10 @@ go_appengine_deploy_path = rule(
         "entry": attr.string(
             mandatory = True,
             doc = "The entry point where your application is located (eg, github.com/ccontavalli/myapp)",
+        ),
+        "project": attr.string(
+            mandatory = True,
+            doc = "GCP project to push to",
         ),
         "gcloud": attr.string(
             mandatory = False,


### PR DESCRIPTION
Background:
If gcloud is not passed a --project=, it will default to whatever
was configured when gcloud was last run. This is extremely risky.

In this PR:
- make passing a project= attribute mandatory.
- set project= in our BUILD.bazel file.

This rule should probably be moved to the internal repository.
Leaving it as a TODO for the future.