### PR TITLE
astore: make github config fully optional.

### DIFF
--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -138,17 +138,18 @@ func Start(targetURL, cookieDomain, oAuthType string, astoreFlags *astore.Flags,
 
 	reqAuth, err := oauth.New(rng, oauth.WithFlags(oauthFlags), auth.FetchCredentialOpts(oAuthType))
 	if err != nil {
-		return fmt.Errorf("could not initialize oauth authenticator - %s", err)
-	}
-	optAuth, err := oauth.New(rng, oauth.WithFlags(optAuthFlags), auth.FetchCredentialOpts("github"))
-	if err != nil {
-		return fmt.Errorf("could not initialize oauth authenticator - %s", err)
+		return fmt.Errorf("could not initialize %s authenticator - %s", oAuthType, err)
 	}
 	var authWeb oauth.IAuthenticator
 	authWeb = reqAuth
 	if useMulti {
-	 	authWeb = oauth.NewMultiOAuth(rng, reqAuth, optAuth)
-	 }
+		optAuth, err := oauth.New(rng, oauth.WithFlags(optAuthFlags), auth.FetchCredentialOpts("github"))
+		if err != nil {
+			return fmt.Errorf("could not initialize github authenticator - %s", err)
+		}
+
+		authWeb = oauth.NewMultiOAuth(rng, reqAuth, optAuth)
+	}
 	grpcs := grpc.NewServer(
 		grpc.StreamInterceptor(ogrpc.StreamInterceptor(reqAuth, "/auth.Auth/")),
 		grpc.UnaryInterceptor(ogrpc.UnaryInterceptor(reqAuth, "/auth.Auth/")),


### PR DESCRIPTION
Background:
astore authentication has support for authenticating via github in
addition to google. We had to roll this back as the github support
for auth certificates was incomplete.
The current implementation still mandates supplying flags for the
optional authenticator, even when disabled.

In this PR:
- when additional authentication is disabled, do not mandate
  supplying github flags.
- make error messages clearer.