### PR TITLE
enproxy: add automated session expiration.

### DIFF
--- a/proxy/enproxy/enproxy_test.go
+++ b/proxy/enproxy/enproxy_test.go
@@ -407,7 +407,7 @@ func TestBandwidth(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 
 	accumulator := logger.NewAccumulator()
-	ep, err := New(rng, WithHttpStarter(Server(&fe)), WithConfig(config),
+	ep, err := New(rng, WithHttpStarter(Server(&sync.WaitGroup{}, &fe)), WithConfig(config),
 		WithLogging(accumulator), WithAuthenticator(Allow(cookie)),
 		WithNasshpMods(nasshp.WithSymmetricOptions(token.WithGeneratedSymmetricKey(0))))
 	assert.NoError(t, err)

--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//lib/logger:go_default_library",
         "//lib/srand:go_default_library",
         "//lib/token:go_default_library",
+        "//proxy/utils:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],

--- a/proxy/nasshp/nassh.go
+++ b/proxy/nasshp/nassh.go
@@ -235,11 +235,11 @@ func (ep *ExpirationPolicy) Expire(ctx context.Context, clock utils.Clock, sessi
 				counters.ExpireRuthlessClosed.Increment()
 			}
 
-			counters.ExpireLifetimeTotal.Add(uint64(pausedfor / 1e9))
+			counters.ExpireLifetimeTotal.Add(uint64(pausedfor) / uint64(time.Second))
 			counters.ExpireYoungest.SetIfGreatest(uint64(pausedon))
 
 			rw.browser.Close(fmt.Errorf(
-				"session expired after %s of inactivity", time.Duration(pausedfor)*time.Nanosecond))
+				"session expired after %s of inactivity", time.Duration(pausedfor)))
 		}
 	}
 }

--- a/proxy/ptunnel/tunnel.go
+++ b/proxy/ptunnel/tunnel.go
@@ -377,7 +377,7 @@ func NewTunnel(pool *nasshp.BufferPool, mods ...Modifier) (*Tunnel, error) {
 
 		SendWin:    nasshp.NewBlockingSendWindow(pool, uint64(options.MaxSendWindow)),
 		ReceiveWin: nasshp.NewBlockingReceiveWindow(pool, uint64(options.MaxReceiveWindow)),
-		browser:    nasshp.NewReplaceableBrowser(options.Logger)}
+		browser:    nasshp.NewReplaceableBrowser(options.Logger, nil)}
 
 	go tl.BrowserReceive()
 	go tl.BrowserSend()

--- a/proxy/utils/BUILD.bazel
+++ b/proxy/utils/BUILD.bazel
@@ -1,8 +1,10 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "atomictime.go",
+        "clock.go",
         "counter.go",
         "types.go",
         "whitelist.go",
@@ -10,4 +12,14 @@ go_library(
     importpath = "github.com/enfabrica/enkit/proxy/utils",
     visibility = ["//visibility:public"],
     deps = ["//lib/oauth:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "atomictime_test.go",
+        "counter_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/proxy/utils/atomictime.go
+++ b/proxy/utils/atomictime.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// AtomicTime represents a unix time in nanoseconds.
+//
+// It provides methods to access and update this time atomically.
+type AtomicTime int64
+
+// Set will set the atomic time to the value supplied.
+func (at *AtomicTime) Set(t time.Time) {
+	nano := t.UnixNano()
+	atomic.StoreInt64((*int64)(at), nano)
+}
+
+// Reset will reset the time to 0.
+//
+// Note that 0 is actually a valid time: January 1st, 1970.
+// This may or may not be ok depending on the use of AtomicTime.
+func (at *AtomicTime) Reset() {
+	atomic.StoreInt64((*int64)(at), 0)
+}
+
+// Returns the AtomicTime as unix time in nanoseconds.
+//
+// The value returned is comparable with time.Now().UnixNano().
+func (at *AtomicTime) Nano() int64 {
+	return atomic.LoadInt64((*int64)(at))
+}

--- a/proxy/utils/atomictime_test.go
+++ b/proxy/utils/atomictime_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestBasicAtomicTime(t *testing.T) {
+	var a AtomicTime
+	assert.Equal(t, int64(0), a.Nano())
+	a.Reset()
+	assert.Equal(t, int64(0), a.Nano())
+
+	now := time.Now()
+	a.Set(now)
+	assert.Equal(t, now.UnixNano(), a.Nano())
+	a.Reset()
+	assert.Equal(t, int64(0), a.Nano())
+}

--- a/proxy/utils/clock.go
+++ b/proxy/utils/clock.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"time"
+)
+
+// TimeSource is a function returning the current time.
+//
+// This is useful to allow mocking time with functions using time.Now().
+type TimeSource func() time.Time
+
+// Clock is an object capable of returning time.
+//
+// This is useful to allow mocking time with functions using time.After()
+// as well as time.Now().
+type Clock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+}
+
+// SystemClock is a Clock that returns the real system time.
+type SystemClock struct {
+}
+
+func (SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+func (SystemClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}

--- a/proxy/utils/counter.go
+++ b/proxy/utils/counter.go
@@ -4,12 +4,36 @@ import (
 	"sync/atomic"
 )
 
+// Counter is a wrapper around an uint64 using atomic operations to update it.
 type Counter uint64
 
+// Increment increments the counter by 1.
 func (c *Counter) Increment() {
 	atomic.AddUint64((*uint64)(c), 1)
 }
 
+// Add increments the counter by the value specified.
+func (c *Counter) Add(value uint64) {
+	atomic.AddUint64((*uint64)(c), value)
+}
+
+// Get returns the value of the counter.
 func (c *Counter) Get() uint64 {
 	return atomic.LoadUint64((*uint64)(c))
+}
+
+// SetIfGreatest saves value in the counter if it is the greates value seen so far.
+func (c *Counter) SetIfGreatest(value uint64) {
+	// This loop will break once the value is either successfully swapped
+	// because it is the greatest, or if it's no longer the greatest.
+	for {
+		current := atomic.LoadUint64((*uint64)(c))
+		if value <= current {
+			break
+		}
+
+		if atomic.CompareAndSwapUint64((*uint64)(c), current, value) {
+			return
+		}
+	}
 }

--- a/proxy/utils/counter_test.go
+++ b/proxy/utils/counter_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBasicCounter(t *testing.T) {
+	var c Counter
+	assert.Equal(t, uint64(0), c.Get())
+
+	c.Increment()
+	assert.Equal(t, uint64(1), c.Get())
+
+	c.Add(10)
+	assert.Equal(t, uint64(11), c.Get())
+
+	c.SetIfGreatest(9)
+	assert.Equal(t, uint64(11), c.Get())
+
+	c.SetIfGreatest(13)
+	assert.Equal(t, uint64(13), c.Get())
+}


### PR DESCRIPTION
Background:
When a client disconnects, enproxy does not close the session between
the proxy and the backend, so if the client comes back, the session
can be resumed.

This causes connections to build up over time, and pretty much leak
memory until the connections naturally die.

In this PR:
- add a few counters to keep track of orphaned connections, export
  them to prometheus for monitoring.
- use those counters to periodically and automatically expire sessions.

Additionally, a few support classes were needed (and added):
- atomic time, to keep track of time atomically.
- a mock clock implementation, to abstract time.After.

It's a large PR, it could probably have been broken in two,
but it's hard to do after the fact.

Tested: written unit tests, will need to stage the change.