### PR TITLE
enproxy: add bytes read/write counters.

### DIFF
--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -53,6 +53,12 @@ type ReadWriterCounters struct {
 	BrowserReaderStarted utils.Counter
 	BrowserReaderStopped utils.Counter
 	BrowserReaderError   utils.Counter
+
+	BrowserBytesRead  utils.Counter
+	BackendBytesWrite utils.Counter
+
+	BackendBytesRead  utils.Counter
+	BrowserBytesWrite utils.Counter
 }
 
 type ExpireCounters struct {
@@ -301,6 +307,29 @@ var (
 		nil, prometheus.Labels{"type": "reader", "action": "error"},
 	)
 
+	descBrowserBytesRead = prometheus.NewDesc(
+		"nasshp_browser_read",
+		"Total amount of bytes read from the browser (this includes rack/wack)",
+		nil, nil,
+	)
+	descBrowserBytesWrite = prometheus.NewDesc(
+		"nasshp_browser_write",
+		"Total amount of bytes written to the browser (this includes rack/wack)",
+		nil, nil,
+	)
+
+	descBackendBytesWrite = prometheus.NewDesc(
+		"nasshp_backend_write",
+		"Total amount of bytes written to the backend",
+		nil, nil,
+	)
+
+	descBackendBytesRead = prometheus.NewDesc(
+		"nasshp_backend_read",
+		"Total amount of bytes read from the backend",
+		nil, nil,
+	)
+
 	descSshProxyStarted = prometheus.NewDesc(
 		"nasshp_browser",
 		helpBrowser,
@@ -473,6 +502,12 @@ func (nc *nasshCollector) Collect(ch chan<- prometheus.Metric) {
 		{descBrowserReaderStarted, counters.BrowserReaderStarted.Get()},
 		{descBrowserReaderStopped, counters.BrowserReaderStopped.Get()},
 		{descBrowserReaderError, counters.BrowserReaderError.Get()},
+
+		{descBrowserBytesRead, counters.BrowserBytesRead.Get()},
+		{descBackendBytesWrite, counters.BackendBytesWrite.Get()},
+
+		{descBackendBytesRead, counters.BackendBytesRead.Get()},
+		{descBrowserBytesWrite, counters.BrowserBytesWrite.Get()},
 
 		{descSshProxyStarted, counters.SshProxyStarted.Get()},
 		{descSshProxyStopped, counters.SshProxyStopped.Get()},

--- a/proxy/nasshp/nassh.go
+++ b/proxy/nasshp/nassh.go
@@ -742,6 +742,7 @@ retry:
 				}
 				continue retry
 			}
+			np.BrowserBytesRead.Add(uint64(read))
 			ackread += read
 		}
 
@@ -761,6 +762,7 @@ retry:
 				}
 				break
 			}
+			np.BrowserBytesRead.Add(uint64(read))
 			wrecv.Fill(read)
 			buffer = buffer[:read]
 
@@ -777,6 +779,7 @@ retry:
 					np.browser.Close(err)
 					return err
 				}
+				np.BackendBytesWrite.Add(uint64(w))
 				wrecv.Empty(w)
 				atomic.StoreUint32(&np.browserReadAck, uint32(wrecv.Emptied)&0xffffff)
 			}
@@ -859,6 +862,7 @@ func (np *readWriter) proxyToBrowser(ssh net.Conn) (err error) {
 			}
 		}
 		wsend.Fill(read)
+		np.BackendBytesRead.Add(uint64(read))
 
 		currentAck := atomic.LoadUint32(&np.browserReadAck)
 		if currentAck != lastWriteAck {
@@ -914,6 +918,7 @@ func (np *readWriter) proxyToBrowser(ssh net.Conn) (err error) {
 				np.browser.Error(wc, err)
 				continue
 			}
+			np.BrowserBytesWrite.Add(uint64(written))
 			if written != 4 {
 				np.browser.Error(wc, fmt.Errorf("short write"))
 				continue
@@ -924,6 +929,8 @@ func (np *readWriter) proxyToBrowser(ssh net.Conn) (err error) {
 				np.browser.Error(wc, err)
 				continue
 			}
+
+			np.BrowserBytesWrite.Add(uint64(written))
 			wsend.Empty(written)
 
 			if err := writer.Close(); err != nil {

--- a/proxy/nasshp/nassh_test.go
+++ b/proxy/nasshp/nassh_test.go
@@ -139,9 +139,10 @@ func TestBasic(t *testing.T) {
 	assert.NotNil(t, c)
 	assert.NotNil(t, r)
 
-	//_, m, err = c.ReadMessage()
-	//assert.Equal(t, len(wisdom)-63+4, len(m), "wisdom is %d, resumed from %d", len(wisdom), 63)
-	//assert.Equal(t, uint32(0xf), binary.BigEndian.Uint32(m[:4]))
+	assert.Equal(t, uint64(864), nassh.counters.BrowserBytesRead.Get())
+	assert.Equal(t, uint64(436), nassh.counters.BrowserBytesWrite.Get())
+	assert.Equal(t, uint64(856), nassh.counters.BackendBytesWrite.Get())
+	assert.Equal(t, uint64(428), nassh.counters.BackendBytesRead.Get())
 }
 
 type FakeTime struct {


### PR DESCRIPTION
This PR adds the most notable missing counters: total amount of bytes
read/written to browser, read/written to the server.