### PR TITLE
bazel/utils: update utils with internal changes, publish extra utils.

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//bazel/utils:diff_test.bzl", "diff_test")
+load("//bazel/utils:types.bzl", "escape_and_join")
 load("//bazel/utils:merge_kwargs_test.bzl", "merge_kwargs_test_suite")
+load("//bazel/utils:files.bzl", "write_to_file")
 
 exports_files(["run_clang_format.template.sh"])
 
@@ -13,6 +15,23 @@ diff_test(
     name = "foobar.txt-diff_test",
     actual = "foobar.txt",
     expected = "testdata/expected.foobar.txt",
+)
+
+write_to_file(
+    name = "escape_and_join1",
+    content = "%s\n" % escape_and_join([
+        "foo bar",
+        "contains\"quote",
+        "contains\'singlequot",
+        "contains;semicolon",
+    ]),
+    output = "escape_and_join1.actual",
+)
+
+diff_test(
+    name = "escape_and_join1_test",
+    actual = "escape_and_join1.actual",
+    expected = "testdata/escape_and_join1.expected",
 )
 
 merge_kwargs_test_suite(

--- a/bazel/utils/build_test.bzl
+++ b/bazel/utils/build_test.bzl
@@ -1,0 +1,25 @@
+def _test_wrapper(ctx):
+    """Turns a build target into a test target.
+
+    The test_suite() rule only accepts bazel test targets, but
+    sometimes it is useful to include a build target as a test
+    for infrastructure changes.
+    """
+    runfiles = ctx.runfiles(files = ctx.attr.dep.files.to_list())
+    script = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
+
+    # By bazel convention, the test rule must return an executable script,
+    # even if the script doesn't run anything.
+    ctx.actions.write(script, "")
+    return [DefaultInfo(runfiles = runfiles, executable = script)]
+
+build_test = rule(
+    implementation = _test_wrapper,
+    test = True,
+    attrs = {
+        "dep": attr.label(
+            doc = "Build target to be converted into a test target",
+            mandatory = True,
+        ),
+    },
+)

--- a/bazel/utils/diff_test.bzl
+++ b/bazel/utils/diff_test.bzl
@@ -77,21 +77,28 @@ def _diff_test_impl(ctx):
         if [[ ! -e "${{exp}}" ]]; then echo "Missing file: ${{exp}}"; exit 1; fi
         diff -u "${{exp}}" "${{act}}" ; RC=$?
         while [ "${{1:-}}" != "" ]; do
-          if [[ ${{RC}} -ne 0 ]] && [[ "$1" == "--update_goldens" ]]; then
-            b="$(readlink -f "${{exp}}")"
-            echo "Updating ${{b}}"
-            cp -vf "${{act}}" "${{b}}"
+          if [[ "$1" == "--update_goldens" ]]; then
+            echo "--update_goldens specified."
+            if [[ ${{RC}} -ne 0 ]]; then
+              b="$(readlink -f "${{exp}}")"
+              echo "Updating ${{b}} from ${{act}}"
+              cp -vf "${{act}}" "${{b}}"
+              RC=0
+            else
+              echo "${{act}} is already up-to-date."
+            fi
           fi
           shift
         done
         if [[ ${{RC}} != 0 ]]; then
           echo "Error: Generated file did not match ${{exp}}."
           echo ""
-          echo "To automatically update your expected data files, run:"
+          echo "To automatically update your expected data file, run:"
           echo ""
-          echo "  ./tools/update_goldens //path/to:your-diff_test  # a target"
-          echo "  ./tools/update_goldens //path/to:all             # a dir"
-          echo "  ./tools/update_goldens //path/to/...             # a tree"
+          echo "  bazel run ${{TEST_TARGET}} -- --update_goldens"
+          echo ""
+          echo "Or use the \"update_goldens\" script to update many expected"
+          echo "data files at once."
           echo ""
         fi
         exit ${{RC}}
@@ -109,30 +116,25 @@ def _diff_test_impl(ctx):
 diff_test = rule(
     doc = """
       A test that compares the contents of two files to ensure they are
-      identical.
+      identical.  Typically, this would be used to compare the output of a
+      file-generating rule against an expected data file.
 
-      Typically, this would be used to compare the contents of a generated file
-      against an expected data file.
+      To update the expected data file to match that actual data file, run your
+      test (using `bazel run`, not `bazel test`) with the `--update_goldens`
+      flag specified.  For example:
 
-      The easiest way to update the golden (expected) data files for your
-      `diff_test` rules is to use the `update_goldens` utility in //tools.
-      Some examples of use:
+          bazel run //path/to:your-diff_test -- --update_goldens
 
-          ./tools/update_goldens //some/path/to:test  # one test
-          ./tools/update_goldens //some/path/to:all   # all tests in a dir
-          ./tools/update_goldens //some/path/to/...   # all tests in a tree
-
-      Internally, this is what `update_goldens` is doing for each failing
-      test:
-
-          bazel run :some_diff_test -- --update_goldens
-
+      Alternately, consider using the provided `update_goldens` python script
+      as a quick way to identify and regenerate a large number of expected data
+      files at once.
     """,
     implementation = _diff_test_impl,
     attrs = {
         "expected": attr.label(
             doc = "A label indicating the file containing the expected data.",
             allow_files = True,
+            mandatory = True,
         ),
         "actual": attr.label(
             doc = "A label indicating the file containing the actual data to check.",

--- a/bazel/utils/diff_test.bzl
+++ b/bazel/utils/diff_test.bzl
@@ -1,17 +1,72 @@
-"""A set of rules to compare generated output against an expected data file.
+"""A set of rules to compare generated output against an expected data file."""
 
-Example of use:
+def _zipdiff_test_impl(ctx):
+    # Note: in python format strings, {{ and }} render as { and }.
+    script = """
+        err=0
+        act="{actual}"
+        exp="{expected}"
+        if [[ ! -e "${{act}}" ]]; then echo "Missing file: ${{act}}"; exit 1; fi
+        if [[ ! -e "${{exp}}" ]]; then echo "Missing file: ${{exp}}"; exit 1; fi
+        actdir="$(mktemp -d -p ${{TEST_TMPDIR}})"
+        unzip "${{act}}" -d "${{actdir}}"
+        expdir="$(mktemp -d -p ${{TEST_TMPDIR}})"
+        unzip "${{exp}}" -d "${{expdir}}"
+        diff -r -u "${{actdir}}" "${{expdir}}"; RC=$?
+        while [ "${{1:-}}" != "" ]; do
+          if [[ ${{RC}} -ne 0 ]] && [[ "$1" == "--update_goldens" ]]; then
+            b="$(readlink -f "${{exp}}")"
+            echo "Updating ${{b}}"
+            cp -vf "${{act}}" "${{b}}"
+          fi
+          shift
+        done
+        exit ${{RC}}
+        """.format(
+        actual = ctx.files.actual[0].short_path,
+        expected = ctx.files.expected[0].short_path,
+    )
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = script,
+    )
+    runfiles = ctx.runfiles(files = ctx.files.actual + ctx.files.expected)
+    return [DefaultInfo(runfiles = runfiles)]
 
-  genrule(
-     name = "foobar.txt-gen",
+zipdiff_test = rule(
+    doc = """
+      A test that compares the contents of two zip files to ensure the contents
+      are identical.
 
+      Typically, this would be used to compare the contents of a generated file
+      against an expected data file.
 
-"""
+      A quick way to update expected data files:
+
+          blaze run :some_diff_test -- --update_goldens
+
+    """,
+    implementation = _zipdiff_test_impl,
+    attrs = {
+        "expected": attr.label(
+            doc = "A label indicating the file containing the expected data.",
+            allow_files = True,
+        ),
+        "actual": attr.label(
+            doc = "A label indicating the file containing the actual data to check.",
+            allow_files = True,
+        ),
+    },
+    test = True,
+)
 
 def _diff_test_impl(ctx):
-    if len(ctx.files.actual) > 1:
-        fail("`actual` must specify a single file.")
-    actual = ctx.files.actual[0].short_path
+    if ctx.attr.output_within_actual:
+        actual = ctx.attr.output_within_actual
+    else:
+        if len(ctx.files.actual) > 1:
+            fail("`output_within_actual` must be specified when `actual` target has multiple outputs")
+        actual = ctx.files.actual[0].short_path
 
     # Note: in python format strings, {{ and }} render as { and }.
     script = """
@@ -22,28 +77,21 @@ def _diff_test_impl(ctx):
         if [[ ! -e "${{exp}}" ]]; then echo "Missing file: ${{exp}}"; exit 1; fi
         diff -u "${{exp}}" "${{act}}" ; RC=$?
         while [ "${{1:-}}" != "" ]; do
-          if [[ "$1" == "--update_goldens" ]]; then
-            echo "--update_goldens specified."
-            if [[ ${{RC}} -ne 0 ]]; then
-              b="$(readlink -f "${{exp}}")"
-              echo "Updating ${{b}} from ${{act}}"
-              cp -vf "${{act}}" "${{b}}"
-              RC=0
-            else
-              echo "${{act}} is already up-to-date."
-            fi
+          if [[ ${{RC}} -ne 0 ]] && [[ "$1" == "--update_goldens" ]]; then
+            b="$(readlink -f "${{exp}}")"
+            echo "Updating ${{b}}"
+            cp -vf "${{act}}" "${{b}}"
           fi
           shift
         done
         if [[ ${{RC}} != 0 ]]; then
           echo "Error: Generated file did not match ${{exp}}."
           echo ""
-          echo "To automatically update your expected data file, run:"
+          echo "To automatically update your expected data files, run:"
           echo ""
-          echo "  bazel run ${{TEST_TARGET}} -- --update_goldens"
-          echo ""
-          echo "Or use the \"update_goldens\" script to update many expected"
-          echo "data files at once."
+          echo "  ./tools/update_goldens //path/to:your-diff_test  # a target"
+          echo "  ./tools/update_goldens //path/to:all             # a dir"
+          echo "  ./tools/update_goldens //path/to/...             # a tree"
           echo ""
         fi
         exit ${{RC}}
@@ -61,32 +109,38 @@ def _diff_test_impl(ctx):
 diff_test = rule(
     doc = """
       A test that compares the contents of two files to ensure they are
-      identical.  Typically, this would be used to compare the output of a
-      file-generating rule against an expected data file.
+      identical.
 
-      To update the expected data file to match that actual data file, run your
-      test (using `bazel run`, not `bazel test`) with the `--update_goldens`
-      flag specified.  For example:
+      Typically, this would be used to compare the contents of a generated file
+      against an expected data file.
 
-          bazel run //path/to:your-diff_test -- --update_goldens
+      The easiest way to update the golden (expected) data files for your
+      `diff_test` rules is to use the `update_goldens` utility in //tools.
+      Some examples of use:
 
-      Alternately, consider using the provided `update_goldens` python script
-      as a quick way to identify and regenerate a large number of expected data
-      files at once.
+          ./tools/update_goldens //some/path/to:test  # one test
+          ./tools/update_goldens //some/path/to:all   # all tests in a dir
+          ./tools/update_goldens //some/path/to/...   # all tests in a tree
+
+      Internally, this is what `update_goldens` is doing for each failing
+      test:
+
+          bazel run :some_diff_test -- --update_goldens
+
     """,
     implementation = _diff_test_impl,
     attrs = {
         "expected": attr.label(
             doc = "A label indicating the file containing the expected data.",
             allow_files = True,
-            mandatory = True,
         ),
         "actual": attr.label(
             doc = "A label indicating the file containing the actual data to check.",
             allow_files = True,
-            mandatory = True,
+        ),
+        "output_within_actual": attr.string(
+            doc = "If actual is a target with multiple implicit outputs, the path to a specific output to test",
         ),
     },
     test = True,
 )
-

--- a/bazel/utils/files.bzl
+++ b/bazel/utils/files.bzl
@@ -1,5 +1,30 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
+def _write_to_file_impl(ctx):
+    ctx.actions.write(
+        output = ctx.outputs.output,
+        content = ctx.attr.content,
+    )
+    return [DefaultInfo(files = depset([ctx.outputs.output]))]
+
+write_to_file = rule(
+    doc = """
+      Writes a string to a file.
+
+      This method is mostly used in conjunction with diff_test to test bazel
+      utility functions.
+    """,
+    implementation = _write_to_file_impl,
+    attrs = {
+        "output": attr.output(
+            doc = "The file to write to.",
+        ),
+        "content": attr.string(
+            doc = "The contents of the file.",
+        ),
+    },
+)
+
 def rebase_path(path, prefix, base):
     """Changes a path at a specified keyword to another path, appending the remaining onto it.
 

--- a/bazel/utils/testdata/escape_and_join1.expected
+++ b/bazel/utils/testdata/escape_and_join1.expected
@@ -1,0 +1,1 @@
+'foo bar' 'contains"quote' 'contains'\''singlequot' 'contains;semicolon'

--- a/bazel/utils/types.bzl
+++ b/bazel/utils/types.bzl
@@ -1,0 +1,59 @@
+"""Functions to manipulate complex data types to assist in writing bzl rules."""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def escape_and_join(args):
+    """Creates a shell-escaped string from a list of arguments."""
+    escaped = []
+    for x in args:
+        if x.startswith("$"):
+            # This is a hack because a rule in //fpga/defs.bzl wants to pass
+            # $XCELIUM_PATH as an argument, and have the shell expand it correctly.
+            escaped.append(x)
+        else:
+            escaped.append(shell.quote(x))
+    cmd = " ".join(escaped)
+    return cmd
+
+def uniquify(iterable):
+    """Uniquify the elements of an iterable."""
+    elements = {element: None for element in iterable}
+    return list(elements.keys())
+
+def invert_label_keyed_string_dict(dictionary):
+    """Returns a dictionary where keys are bazel label objects and values are strings.
+
+    Bazel does not currently support a dictionary attr where keys are strings
+    and values are a list of labels.
+
+    Example:
+    {"-y": [":abc", ":def"], "-x": [":abc"]} --> {":abc": "-x -y", ":def": "-y"}
+    """
+    result = dict()
+    for key, val in dictionary.items():
+        for label in val:
+            if label in result:
+                result[label] += " {}".format(key)
+            else:
+                result[label] = key
+    return result
+
+def expand_label_keyed_string_dict(target, args, short_path = False):
+    """Returns a list of strings that contain arguments to file paths.
+
+    This is helpful for tools that need to support generic command line
+    arguments that reference multiple file targets in their bazel rule
+    implementation. Each key could be a filegroup() that contains multiple
+    bazel file objects.
+
+    Example:
+    {":abc": "-y", ":def": "-y"} --> ["-y", "abc", "-y", "def"]
+    """
+    result = []
+    for f in target.files.to_list():
+        for arg in args.split(" "):
+            if short_path:
+                result += [arg, f.short_path]
+            else:
+                result += [arg, f.path]
+    return result


### PR DESCRIPTION
Background:
A few utilities have been duplicated across repositories. A few extra
utilities were added. I have a need to use a couple of those utilities
(mainly, merge_kwargs and some friends) in enkit. Rather than track
the full set of deps, I added most utilities in the enkit repository.

It would be good to have a few more utilities, but for future PRs.

I will follow up this PR with a cleanup of other repositories to
re-use the now published utilities.