### PR TITLE
Update flextape hash

### DIFF
--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:cfcbab46556f1048d10c4fd0994c63d6903726f2844d09bf294d5612d2f57b9c"
+  "gcr.io/devops-284019/infra/flextape@sha256:3b087115012cc4872e85a7f720685e360ddd917d59e28ed7ca7f8ccf2c667ba5"


### PR DESCRIPTION
Innovus license counts were recently updated so this is the new official flextape.

Testing:
- Already deployed on infra-00