### PR TITLE
kunit: Fix BUILD files, imports

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -152,7 +152,7 @@ def _import_kernel_bundle_dep(name, ki, d, inputs, extra_symbols):
       inputs: list of File objects, updated with additional inputs
          required by this dependency.
       extra_symbols: list of File objects, updated with additional
-         Module.symvers files. 
+         Module.symvers files.
 
     Returns:
       Updates inputs and extra_symbols, returns None.
@@ -169,15 +169,16 @@ Module '{module}' is being built for kernel '{kernel}'.
 PROBLEM: it has a dependency on module '{dependency}', but this target is NOT built for the same kernel!
 Probably, you need to change module '{dependency}' so that it is also built for this same kernel.
 """.format(
-  module = name,
-  kernel = ki.package,
-  dependency = d.label.name))
+            module = name,
+            kernel = ki.package,
+            dependency = d.label.name,
+        ))
 
 def _import_kernel_modules_dep(name, ki, d, inputs, extra_symbols):
     """Extract information neessary to import a single kernel dep.
 
     Just like _import_kernel_bundle_dep, but works on a single module.
-    
+
     Returns:
       True, if the module was compiled for the same kernel, and should
       be imported. False otherwise.
@@ -191,7 +192,7 @@ def _import_kernel_modules_dep(name, ki, d, inputs, extra_symbols):
 
     inputs.extend(d.files.to_list())
     return True
- 
+
 def _kernel_modules(ctx):
     modules = ctx.attr.modules
     inputs = ctx.files.srcs + ctx.files.kernel
@@ -206,7 +207,7 @@ def _kernel_modules(ctx):
 
         if KernelModulesInfo in d:
             _import_kernel_modules_dep(ctx.attr.name, ki, d, inputs, extra_symbols)
-   
+
         if CcInfo in d:
             inputs += d[CcInfo].compilation_context.headers.to_list()
         inputs += d.files.to_list()
@@ -255,7 +256,8 @@ def _kernel_modules(ctx):
     make_args = ctx.attr.make_format_str.format(
         src_dir = srcdir,
         kernel_build_dir = kernel_build_dir,
-        modules = " ".join(modules))
+        modules = " ".join(modules),
+    )
 
     ctx.actions.run_shell(
         mnemonic = "KernelBuild",
@@ -356,7 +358,7 @@ KernelBundleInfo = provider(
 )
 
 def _kernel_modules_bundle(ctx):
-    return [DefaultInfo(files=depset(ctx.files.modules)), KernelBundleInfo(modules = ctx.attr.modules)]
+    return [DefaultInfo(files = depset(ctx.files.modules)), KernelBundleInfo(modules = ctx.attr.modules)]
 
 kernel_modules_bundle = rule(
     doc = """Creates a bundle of kernel modules.
@@ -390,7 +392,7 @@ For example:
     attrs = {
         "modules": attr.label_list(
             mandatory = True,
-            providers = [KernelModulesInfo], 
+            providers = [KernelModulesInfo],
             doc = "List of kernel modules part of this bundle",
         ),
     },
@@ -506,7 +508,7 @@ def nv_driver(*args, **kwargs):
         kwargs["srcs"] = native.glob(include = include, exclude = BUILD_LEFTOVERS, allow_empty = False)
 
     if "make_format_str" not in kwargs:
-        kwargs["make_format_str"] = "-C $PWD/{src_dir} SYSSRC=$PWD/{kernel_build_dir} SYSOUT=$PWD/{kernel_build_dir} -j modules" 
+        kwargs["make_format_str"] = "-C $PWD/{src_dir} SYSSRC=$PWD/{kernel_build_dir} SYSOUT=$PWD/{kernel_build_dir} -j modules"
 
     return _kernel_module_targets(*args, **kwargs)
 
@@ -865,7 +867,7 @@ The test will run locally inside a user-mode linux process.
             doc = "The template to generate the bash script used to run the tests.",
         ),
         "_parser": attr.label(
-            default = Label("//bazel/linux/kunit:kunit"),
+            default = Label("//bazel/linux/kunit:kunit_zip"),
             doc = "KUnit TAP output parser.",
         ),
     },

--- a/bazel/linux/kunit/BUILD.bazel
+++ b/bazel/linux/kunit/BUILD.bazel
@@ -1,12 +1,33 @@
 py_binary(
     name = "kunit",
     srcs = ["kunit.py"],
-    visibility = ["//visibility:public"],
     deps = [
-        ":kunit_config",
+        ":kunit_json",
         ":kunit_kernel",
         ":kunit_parser",
     ],
+)
+
+py_library(
+    name = "kunit_json",
+    srcs = ["kunit_json.py"],
+    deps = [
+        ":kunit_parser",
+    ],
+)
+
+py_library(
+    name = "kunit_kernel",
+    srcs = ["kunit_kernel.py"],
+    deps = [
+        ":kunit_config",
+        ":kunit_parser",
+    ],
+)
+
+py_library(
+    name = "kunit_parser",
+    srcs = ["kunit_parser.py"],
 )
 
 py_library(
@@ -14,12 +35,24 @@ py_library(
     srcs = ["kunit_config.py"],
 )
 
-py_library(
-    name = "kunit_kernel",
-    srcs = ["kunit_kernel.py"],
-)
+# TODO: This test requires testdata that is not checked in. Check in testdata,
+# fix the test, uncomment this target.
+#py_test(
+#    name = "kunit_test",
+#    srcs = ["kunit_tool_test.py"],
+#    main = "kunit_tool_test.py",
+#    deps = [
+#        ":kunit_config",
+#        ":kunit_parser",
+#        ":kunit_kernel",
+#        ":kunit_json",
+#        ":kunit",
+#    ],
+#)
 
-py_library(
-    name = "kunit_parser",
-    srcs = ["kunit_parser.py"],
+filegroup(
+    name = "kunit_zip",
+    srcs = [":kunit"],
+    output_group = "python_zip_file",
+    visibility = ["//visibility:public"],
 )

--- a/bazel/linux/kunit/kunit.py
+++ b/bazel/linux/kunit/kunit.py
@@ -15,10 +15,9 @@ import time
 from collections import namedtuple
 from enum import Enum, auto
 
-import kunit_config
-import kunit_json
-import kunit_kernel
-import kunit_parser
+from bazel.linux.kunit import kunit_json
+from bazel.linux.kunit import kunit_kernel
+from bazel.linux.kunit import kunit_parser
 
 KunitResult = namedtuple('KunitResult', ['status','result','elapsed_time'])
 

--- a/bazel/linux/kunit/kunit_json.py
+++ b/bazel/linux/kunit/kunit_json.py
@@ -11,7 +11,7 @@ import os
 
 import kunit_parser
 
-from kunit_parser import TestStatus
+from bazel.linux.kunit.kunit_parser import TestStatus
 
 def get_json_result(test_result, def_config, build_dir, json_path) -> str:
 	sub_groups = []

--- a/bazel/linux/kunit/kunit_kernel.py
+++ b/bazel/linux/kunit/kunit_kernel.py
@@ -6,6 +6,7 @@
 # Author: Felix Guo <felixguoxiuping@gmail.com>
 # Author: Brendan Higgins <brendanhiggins@google.com>
 
+import contextlib
 import logging
 import subprocess
 import os
@@ -13,10 +14,8 @@ import shutil
 import signal
 from typing import Iterator
 
-from contextlib import ExitStack
-
-import kunit_config
-import kunit_parser
+from bazel.linux.kunit import kunit_config
+from bazel.linux.kunit import kunit_parser
 
 KCONFIG_PATH = '.config'
 KUNITCONFIG_PATH = '.kunitconfig'
@@ -76,7 +75,7 @@ class LinuxSourceTreeOperations(object):
 		process.wait()
 		kunit_parser.print_with_timestamp(
 			'Disabling broken configs to run KUnit tests...')
-		with ExitStack() as es:
+		with contextlib.ExitStack() as es:
 			config = open(get_kconfig_path(build_dir), 'a')
 			disable = open(BROKEN_ALLCONFIG_PATH, 'r').read()
 			config.write(disable)

--- a/bazel/linux/kunit/kunit_tool_test.py
+++ b/bazel/linux/kunit/kunit_tool_test.py
@@ -15,11 +15,11 @@ import json
 import signal
 import os
 
-import kunit_config
-import kunit_parser
-import kunit_kernel
-import kunit_json
-import kunit
+from bazel.linux.kunit import kunit_config
+from bazel.linux.kunit import kunit_parser
+from bazel.linux.kunit import kunit_kernel
+from bazel.linux.kunit import kunit_json
+from bazel.linux.kunit import kunit
 
 test_tmpdir = ''
 abs_test_data_dir = ''

--- a/bazel/linux/run_um_kunit_tests.template
+++ b/bazel/linux/run_um_kunit_tests.template
@@ -22,4 +22,4 @@ if egrep -q '^1..0' $TMPOUTPUT ; then
     sed -i -e "s/^1..0/1..$N_TESTS/" $TMPOUTPUT
 fi
 
-{parser} parse < $TMPOUTPUT
+python3 {parser} parse < $TMPOUTPUT


### PR DESCRIPTION
This change fixes Python import paths and BUILD files for the kunit
binary/library to make it Bazel compliant.

An extra target is also defined to build a Python hermetic zip; this zip
file is ran instead of the script, so that we don't have to worry as
much about runfiles issues. The script template is modified to pass the
zip to python3, as the zip is not itself executable.

Tested: `BAZEL_PROFILE=buildbarn bazel test
//driver/farmem:enf_rma_unit_test
--override_repository=enkit=/home/bminor/dev/enkit` with internal PR
1656 works