### PR TITLE
postsubmit: Generate Python stub

### DIFF
--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -1,11 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "postsubmit_proto",
     srcs = ["postsubmit.proto"],
     visibility = ["//visibility:private"],
+)
+
+py_proto_library(
+    name = "postsubmit_py_proto",
+    srcs = ["postsubmit.proto"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(


### PR DESCRIPTION
This change adds a BUILD rule to generate Python code from
postsubmit.proto, in preparation for a Python conversion tool in
internal.