### PR TITLE
postsubmits: Add more necessary fields

### DIFF
--- a/infra/postsubmit/proto/postsubmit.proto
+++ b/infra/postsubmit/proto/postsubmit.proto
@@ -28,6 +28,15 @@ message Build {
   // include_patterns.
   repeated string exclude_patterns = 5;
 
+  // Tags to include in the build.
+  // If specified, targets will only be built if they contain at least one of
+  // the specified tags.
+  //
+  // exclude_tags (below) takes precedence: targets with tags that match any of
+  // exclude_tags (if specified) will still not be built, even if they are
+  // included via this mechanism.
+  repeated string include_tags = 9;
+
   // Tags to exclude from the build; build will not build targets that:
   // * are tagged with at least one of the specified tags
   // * depend on a target tagged with at least one of the specified tags
@@ -46,4 +55,12 @@ message Build {
   // the build (as opposed to any warmup steps that need to take place); if this
   // is not possible, it will be applied to the entire build.
   string timeout = 8;
+
+  // List of bazel arguments that are passed directly to the `bazel test`
+  // commandline.
+  //
+  // This field serves as an escape hatch for custom bazel behavior not covered
+  // by the above fields; popular bazel options may be replaced by an applicable
+  // field in the future.
+  repeated string bazel_args = 10;
 }


### PR DESCRIPTION
This change adds fields to the Build message that are necessary in order
to migrate the two existing HW nightly regressions:
* `fpga-fullchip` passes a bunch of arguments to `bazel test` that we
  need to preserve
* `fpv-nightly` makes use of positive tags in
  `build_tag_filters`/`test_tag_filters`, and currently the proto
  message only handles negative tags.

Jira: INFRA-875