### PR TITLE
enkit bazel: Log error when start query broken

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -120,6 +120,7 @@ func GetAffectedTargets(start string, end string, config *ppb.PresubmitConfig, l
 			// change affects since the build graph was broken in one stage.
 			//
 			// Pass here but emit a warning.
+			log.Warnf("Got error at start point:\n%v\n", startQueryErr)
 			log.Warnf("Broken build graph detected at start point; this change fixes the build graph, but no targets will be tested. This change must be tested manually.")
 			return nil, nil, nil // No changed targets and no error
 		}


### PR DESCRIPTION
When the start query is broken but the end query is not, we may be in a
situation where the build graph is broken on master, and this presubmit
is for a fix PR, so we want to ignore the build graph breakage at the
start point.

However, for PRs that aren't fixing build graph breakage, we are
potentially passing the presubmit without actually testing anything.

This change logs the error that was encountered when evaluating the
build graph, to allow users to see and debug the underlying issue
causing query to fail.

Jira: INFRA-899