### PR TITLE
linux/defs.bzl: compile device drivers with -O1 for debug builds

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -259,6 +259,16 @@ def _kernel_modules(ctx):
         modules = " ".join(modules),
     )
 
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    if compilation_mode == "fastbuild":
+        cflags = ""
+    elif compilation_mode == "opt":
+        cflags = ""
+    elif compilation_mode == "dbg":
+        cflags = "-O1 -fno-inline-functions-called-once"
+
+    extra += " BAZEL_CFLAGS+='%s'" % cflags
+
     ctx.actions.run_shell(
         mnemonic = "KernelBuild",
         progress_message = message,

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -261,13 +261,17 @@ def _kernel_modules(ctx):
 
     compilation_mode = ctx.var["COMPILATION_MODE"]
     if compilation_mode == "fastbuild":
-        cflags = ""
+        cflags = "-g"
     elif compilation_mode == "opt":
         cflags = ""
     elif compilation_mode == "dbg":
-        cflags = "-O1 -fno-inline-functions-called-once"
+        cflags = "-g -O1 -fno-inline-functions-called-once"
+    else:
+        fail("compilation mode '{compilation_mode}' not supported".format(
+            compilation_mode=compilation_mode,
+        ))
 
-    extra += " BAZEL_CFLAGS+='%s'" % cflags
+    extra += " EXTRA_CFLAGS='%s'" % cflags
 
     ctx.actions.run_shell(
         mnemonic = "KernelBuild",


### PR DESCRIPTION
When debugging, it is sometimes more convenient if compile optimizations
are disabled. It is not possible to compile kernel modules with -O0 but
-O1 seems to work. Also, disable function inlining.

Tested:

for i in "" "-c fastbuild" "-c opt" "-c dbg"; do
    echo -ne "$i: "
    bazel build driver/ib/enf_ib-swtest $i 2> /dev/null
    nm bazel-bin/driver/ib/enf-ubuntu-impish-minimal/enf_ib-swtest.ko | grep ' [Tt] ' | wc -l
done

: 229
-c fastbuild: 229
-c opt: 229
-c dbg: 243

Signed-off-by: George Prekas <george@enfabrica.net>