### PR TITLE
flextape: Raise and parameterize timeouts

### DIFF
--- a/flextape/client/client.go
+++ b/flextape/client/client.go
@@ -113,7 +113,7 @@ func (c *LicenseClient) acquire(ctx context.Context) error {
 			req.GetInvocation().Id = r.Queued.GetInvocationId()
 			reqID.Store(req.GetInvocation().GetId())
 			atomic.StoreUint32(&queuePos, r.Queued.GetQueuePosition())
-			sleepTime := min(time.Until(r.Queued.GetNextPollTime().AsTime())*4/5, time.Second)
+			sleepTime := min(time.Until(r.Queued.GetNextPollTime().AsTime())*3/5, 5*time.Second)
 			time.Sleep(sleepTime)
 			continue
 		default:
@@ -151,7 +151,7 @@ func (c *LicenseClient) refresh(ctx context.Context) {
 			c.licenseErr <- fmt.Errorf("Refresh() failure: %w", err)
 		}
 
-		sleepTime := min(time.Until(res.GetLicenseRefreshDeadline().AsTime())*4/5, time.Second)
+		sleepTime := min(time.Until(res.GetLicenseRefreshDeadline().AsTime())*3/5, 5*time.Second)
 
 		select {
 		case <-time.After(sleepTime):

--- a/flextape/proto/config.proto
+++ b/flextape/proto/config.proto
@@ -11,18 +11,18 @@ message Config {
   // One LicenseConfig for each vendor::feature tuple.
   // This should be configured from the license file the vendor provides.
   repeated LicenseConfig license_configs = 1;
+
+  ServerConfig server = 2;
 }
 
 // Default prioritizer. Licenses are allocated in the order they are requested.
-message FIFOPrioritizer {
-}
+message FIFOPrioritizer {}
 
 // Allocates licenses so that they are spread evenly across users.
 //
 // This means that users can jump ahead of the line, or be bumped after new
 // requests.
-message EvenOwnersPrioritizer {
-}
+message EvenOwnersPrioritizer {}
 
 message LicenseConfig {
   // vendor::feature tuple
@@ -32,7 +32,34 @@ message LicenseConfig {
 
   // Strategy to distribute licenses.
   oneof prioritizer {
-	FIFOPrioritizer fifo = 3;
-	EvenOwnersPrioritizer even_owners = 4;
+    FIFOPrioritizer fifo = 3;
+    EvenOwnersPrioritizer even_owners = 4;
   }
+}
+
+// General options for the entire instance
+message ServerConfig {
+  // Interval on which actions should refresh their queue position while in
+  // queue for an allocation.
+  // Default: 15s
+  uint32 queue_refresh_duration_seconds = 1;
+
+  // Interval on which actions should refresh their allocation while the action
+  // is executing.
+  // Default: 30s
+  uint32 allocation_refresh_duration_seconds = 2;
+
+  // Interval on which to clean up expired/released allocations and queue
+  // entries, and promote queued entries to allocations.
+  // Default: 1s
+  uint32 janitor_interval_seconds = 3;
+
+  // When the service first starts, for this period of time it holds off on
+  // allocating any new licenses, and instead listens for and "adopts"
+  // allocations that it hears about via the "Refresh" RPC. This duration should
+  // be >= allocation_refresh_duration_seconds, to guarantee that all clients
+  // Refresh() their allocation before the server moves into the normal
+  // operating state.
+  // Default: 45s
+  uint32 adoption_duration_seconds = 4;
 }

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -64,7 +64,8 @@ func main() {
 	exitIf(err)
 
 	grpcs := grpc.NewServer()
-	s := service.New(config)
+	s, err := service.New(config)
+	exitIf(err)
 	fpb.RegisterFlextapeServer(grpcs, s)
 
 	fe := frontend.New(template, s)


### PR DESCRIPTION
All durations that the service uses are moved to a "server" config
section, so that they are no longer hard-coded. At the same time,
timeouts are greatly raised to reduce the number of expirations that
happen because the client is too slow to refresh an active allocation.

The client is modified to attempt a refresh earlier into the
server-specified duration, but given the raised timeouts its minimum
refresh duration is raised from 1s to 5s.

Jira: INFRA-607