### PR TITLE
bazel/appengine: remove incompatible default parameter.

### DIFF
--- a/bazel/appengine/config.bzl
+++ b/bazel/appengine/config.bzl
@@ -64,7 +64,6 @@ def _appengine_config_merge(ctx):
 DEFAULT_BASE = struct(
     runtime = "python27",
     api_version = 1,
-    app_engine_apis = True,
     threadsafe = True,
 )
 


### PR DESCRIPTION
Background:
push target for web targets works locally, but fails from cloudbuild.
For some reason, it seems like it is performing stricter checks when
the push is from cloudbuild? could be I'm using an older version of
the dev container (and gcloud tools).

Either way, the 'app_engine_apis' parameter in app.yaml is only
supported by a subset of the appengine environments, not the one
used by those rules. The parameter has to go.

Tested: modified BUILD.bazel file in our docs directory to override the
defaults, see PR4504, and it works.

See also the https://cloud.google.com/appengine/docs/standard/python/config/appref,
that does not have the parameter.
