### PR TITLE
Disable presubmits/postsubmits for broken tests

### DIFF
--- a/lib/config/directory/BUILD.bazel
+++ b/lib/config/directory/BUILD.bazel
@@ -12,5 +12,9 @@ go_test(
     name = "go_default_test",
     srcs = ["homedir_test.go"],
     embed = [":go_default_library"],
+    tags = [
+        # TODO(INFRA-927): Fix this test so it runs in Cloud Build
+        "no-cloudbuild",
+    ],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/lib/karchive/BUILD.bazel
+++ b/lib/karchive/BUILD.bazel
@@ -22,6 +22,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    tags = [
+        # TODO(INFRA-927): Fix this test so it runs in Cloud Build
+        "no-cloudbuild",
+    ],
     deps = [
         "//lib/errdiff:go_default_library",
         "//lib/testutil:go_default_library",

--- a/lib/kcerts/BUILD.bazel
+++ b/lib/kcerts/BUILD.bazel
@@ -30,6 +30,10 @@ go_test(
         "signer_test.go",
         "ssh_test.go",
     ],
+    tags = [
+        # TODO(INFRA-927): Fix this test so it runs in Cloud Build
+        "no-cloudbuild",
+    ],
     deps = [
         ":go_default_library",
         "//lib/cache:go_default_library",


### PR DESCRIPTION
This change marks tests that don't run successfully under Cloud Build
`no-cloudbuild`, so that they do not run in presubmits or postsubmits.

Future PRs may fix these tests to work with Cloud Build.

Jira: INFRA-927