### PR TITLE
gee cleanup: fix handling of pr_NNN branches.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2645,6 +2645,10 @@ function gee__cleanup() {
     if [[ "${br}" != "${MAIN}" ]]; then
       local parent
       parent="$(_get_parent_branch "${br}")"
+      if [[ "${parent}" == upstream/* ]]; then
+        _git fetch upstream "${parent#upstream/}"
+        parent="FETCH_HEAD"
+      fi
       local -a  counts=()
       read -r -a counts < <("${GIT}" rev-list --left-right --count "${parent}...${br}")
       _checkout_or_die "${br}"

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -5,6 +5,7 @@
 ### Release 0.2.28
 
 * Fix formatting of date when creating a shallow clone of the git repo.
+* Fix `gee cleanup`: fix diff'ing of `pr_checkout` branches
 
 ### Release 0.2.27
 


### PR DESCRIPTION
gee cleanup: fix handling of pr_NNN branches.

pr_NNN branches are created by the `gee pr_checkout` command.  Unlike regular
branches, their parent is the upstream branch referring to the PR that was
checked out.  However, this causes naive diffing against parent branch
to fail because this is illegal syntax for git:

    git diff upstream/refs/pull/4628/head...HEAD

`gee diff` already contains the correct workaround for this issue.  This PR
applies the same workaround to `gee cleanup`.

Tested: Ran `gee cleanup` in a branch with a pr_NNNN branch.

