### PR TITLE
kbuild/utils/buildroot: add init.sh support to run_kunit_tests.sh.

### DIFF
--- a/kbuild/utils/README.md
+++ b/kbuild/utils/README.md
@@ -51,6 +51,18 @@ In the directory, you can find:
    * `make`
 5. The image can be found in `output/images`
 
+## Editing or tweaking the image
+
+To make simple changes to the image:
+
+1. `enkit astore get $uid` or `enkit astore get $path` to download the image.
+2. `apt-get install fuse2fs` if not already installed on your machine.
+3. `fuse2fs ./rootfs.img /mnt/tmp`
+4. Edit edit edit 
+5. `sync` and `umount /mnt/tmp` or `fusermount -u /mnt/tmp` (IMPORTANT, otherwise you corrupt the image)
+6. And then push as a new image to astore. If you do so, make sure to use:
+   `enkit astore annotate $uid "message message message"` to annotate the image with a message.
+
 # Releasing a tagged kernel release to astore
 
 The Enfabrica kernel artifacts in astore are used by multiple developers and


### PR DESCRIPTION
Background:
I'm changing how uml tests are run. Specifically, in the next PR
bazel will generate a "runtime package" - a directory with data and
an init.sh script to "run the test" (or really, anything) in a
generic VM (or UML).

In this PR:
- update run_kunit_tests.sh so that it checks for the presence
  of an init.sh script in the mounted directory, and if it is there,
  runs it.

- while at it, various improvements, specifically:
  - make the script `shellcheck` clean. This required a lot of
    style improvements: error handling, " in places we did not
    have before, etc.

  - exit calls required invoking poweroff reliably, so moved
    to a trap event, and moved to `poweroff -f`, as to avoid
    going through systemd/init (faster, more reliable)

  - removed some obsolete / incorrect comments, added some
    new ones.

- Additionally, added instructions on how to edit an existing
  image without having root or `mount -o loop` available.

Tested:
I actually released a new version of the image with the improved
script as the only change in the rootfs. All tests in internal
are passing.
