### PR TITLE
repo wide: run buildifier through the repository.

### DIFF
--- a/astore/server/BUILD.bazel
+++ b/astore/server/BUILD.bazel
@@ -108,9 +108,9 @@ go_appengine_deploy(
     name = "deploy",
     config = "deploy/app.yaml",
     entry = "github.com/enfabrica/enkit/astore/server",
-    project = "astore-284118",
     gomod = "//:go.mod",
     gosum = "//:go.sum",
+    project = "astore-284118",
     deps = [
         ":server",
     ],

--- a/bazel/dependencies/BUILD.bats.bazel
+++ b/bazel/dependencies/BUILD.bats.bazel
@@ -3,17 +3,20 @@
 
 sh_library(
     name = "bats_lib",
-    srcs = glob(["lib/**", "libexec/**"]),
+    srcs = glob([
+        "lib/**",
+        "libexec/**",
+    ]),
 )
 
 sh_binary(
     name = "bats",
     srcs = ["bin/bats"],
+    visibility = ["//visibility:public"],
     deps = [
         ":bats_lib",
         "@bats_assert//:bats_assert_lib",
-        "@bats_support//:bats_support_lib",
         "@bats_file//:bats_file_lib",
+        "@bats_support//:bats_support_lib",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/bazel/shellutils.bzl
+++ b/bazel/shellutils.bzl
@@ -2,35 +2,35 @@
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
-EXEC_TEST_TEMPLATE= """
+EXEC_TEST_TEMPLATE = """
 #!/usr/bin/env bash
 set -e
 "{command}" {args} {srcs}
 """
 
 def _exec_test_impl(ctx):
-  # Generic test that runs an executable.  Right now, this is only
-  # used for bats_test, but this might be used in the future for
-  # shellcheck_test and others.
-  runfiles = ctx.runfiles(
-      files = ctx.files.srcs + ctx.files.deps,
-      collect_data = True,
-  )
-  runfiles = runfiles.merge(ctx.attr._command.default_runfiles)
-  srcs = [f.short_path for f in ctx.files.srcs]
-  script = EXEC_TEST_TEMPLATE.format(
-          command = ctx.executable._command.short_path,
-          args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
-          srcs = " ".join([shell.quote(x) for x in srcs]),
-  )
-  ctx.actions.write(
-      output = ctx.outputs.executable,
-      is_executable = True,
-      content = script,
-  )
-  return DefaultInfo(
-      runfiles = runfiles,
-  )
+    # Generic test that runs an executable.  Right now, this is only
+    # used for bats_test, but this might be used in the future for
+    # shellcheck_test and others.
+    runfiles = ctx.runfiles(
+        files = ctx.files.srcs + ctx.files.deps,
+        collect_data = True,
+    )
+    runfiles = runfiles.merge(ctx.attr._command.default_runfiles)
+    srcs = [f.short_path for f in ctx.files.srcs]
+    script = EXEC_TEST_TEMPLATE.format(
+        command = ctx.executable._command.short_path,
+        args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
+        srcs = " ".join([shell.quote(x) for x in srcs]),
+    )
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        is_executable = True,
+        content = script,
+    )
+    return DefaultInfo(
+        runfiles = runfiles,
+    )
 
 bats_test = rule(
     doc = """
@@ -41,13 +41,13 @@ bats_test = rule(
     attrs = {
         "srcs": attr.label_list(
             allow_files = [".bats"],
-            doc="\"bats\" tests to run.",
+            doc = "\"bats\" tests to run.",
         ),
         "extra_args": attr.string_list(
-            doc="Extra arguments to pass to the command.",
+            doc = "Extra arguments to pass to the command.",
         ),
         "deps": attr.label_list(
-            doc="Extra dependencies to make available when test runs.",
+            doc = "Extra dependencies to make available when test runs.",
         ),
         "_command": attr.label(
             default = Label("@bats_core//:bats"),
@@ -60,27 +60,27 @@ bats_test = rule(
 )
 
 def _external_exec_test_impl(ctx):
-  # Generic test that runs an external executable.  Right now, this is only
-  # used for shellcheck_test (shellcheck requires cabal to build, and so bazel
-  # integration is non-trivial).
-  runfiles = ctx.runfiles(
-      files = ctx.files.srcs + ctx.files.deps,
-      collect_data = True,
-  )
-  srcs = [f.short_path for f in ctx.files.srcs]
-  script = EXEC_TEST_TEMPLATE.format(
-          command = ctx.attr._command,
-          args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
-          srcs = " ".join([shell.quote(x) for x in srcs]),
-  )
-  ctx.actions.write(
-      output = ctx.outputs.executable,
-      is_executable = True,
-      content = script,
-  )
-  return DefaultInfo(
-      runfiles = runfiles,
-  )
+    # Generic test that runs an external executable.  Right now, this is only
+    # used for shellcheck_test (shellcheck requires cabal to build, and so bazel
+    # integration is non-trivial).
+    runfiles = ctx.runfiles(
+        files = ctx.files.srcs + ctx.files.deps,
+        collect_data = True,
+    )
+    srcs = [f.short_path for f in ctx.files.srcs]
+    script = EXEC_TEST_TEMPLATE.format(
+        command = ctx.attr._command,
+        args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
+        srcs = " ".join([shell.quote(x) for x in srcs]),
+    )
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        is_executable = True,
+        content = script,
+    )
+    return DefaultInfo(
+        runfiles = runfiles,
+    )
 
 shellcheck_test = rule(
     doc = """
@@ -89,17 +89,17 @@ shellcheck_test = rule(
     attrs = {
         "srcs": attr.label_list(
             allow_files = True,
-            doc="Shell scripts to check."
+            doc = "Shell scripts to check.",
         ),
         "extra_args": attr.string_list(
-            doc="Extra arguments to pass to shellcheck.",
+            doc = "Extra arguments to pass to shellcheck.",
         ),
         "deps": attr.label_list(
-            doc="Extra dependencies to make available when shellcheck runs.",
+            doc = "Extra dependencies to make available when shellcheck runs.",
         ),
         "_command": attr.string(
             default = "/usr/bin/shellcheck",  # available in dev container.
-            doc="Path to external shellcheck command.",
+            doc = "Path to external shellcheck command.",
         ),
     },
     test = True,

--- a/bazel/ui/react.bzl
+++ b/bazel/ui/react.bzl
@@ -8,6 +8,7 @@ load("//bazel/utils:binary.bzl", "declare_binary")
 load("@npm//poi:index.bzl", "poi")
 load("@npm//webpack:index.bzl", "webpack")
 load("@npm//jest:index.bzl", "jest")
+
 """Creates a react project after running create-react-app.
 
 Args:

--- a/bazel/utils/merge_kwargs_test.bzl
+++ b/bazel/utils/merge_kwargs_test.bzl
@@ -31,7 +31,7 @@ def _create_test_data():
     d3 = {
         "alpha": 300,
         "beta": [9],
-        "gamma": {"g3": 7}
+        "gamma": {"g3": 7},
     }
     merged1 = merge_kwargs(d1, d2)
     merged2 = merge_kwargs(d1, d3)

--- a/bestie/proto/BUILD.bazel
+++ b/bestie/proto/BUILD.bazel
@@ -15,8 +15,8 @@ proto_library(
 
 cc_proto_library(
     name = "bestie_cc_proto",
-    deps = [":test_metrics_proto"],
     visibility = ["//visibility:public"],
+    deps = [":test_metrics_proto"],
 )
 
 go_proto_library(
@@ -31,7 +31,7 @@ go_proto_library(
 go_library(
     name = "go_default_library",
     embed = [
-        ":bestie_go_proto"
+        ":bestie_go_proto",
     ],
     importpath = "github.com/enfabrica/enkit/bestie/proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
PR containing the files modified by:

    bazel run //:buildifier

no other change, only style fixes. bazel/linux was excluded from
the PR due to work dedicated to it coming in dedicated PRs.
