### PR TITLE
linux/defs.bzl: fix no inlining for debug kernel module builds

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -265,7 +265,7 @@ def _kernel_modules(ctx):
     elif compilation_mode == "opt":
         cflags = ""
     elif compilation_mode == "dbg":
-        cflags = "-g -O1 -fno-inline-functions-called-once"
+        cflags = "-g -O1 -fno-inline"
     else:
         fail("compilation mode '{compilation_mode}' not supported".format(
             compilation_mode=compilation_mode,


### PR DESCRIPTION
Use -fno-inline as it prevents inlining for more functions than the
previous setting. The number of functions in enf_ib-swtest.ko increase
from 228 in the optimized build to 502 in the debug build.

Signed-off-by: George Prekas <george@enfabrica.net>