### PR TITLE
bazel/linux: split defs.bzl in multiple files.

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,3 +1,5 @@
+load("//bazel/linux:uml.bzl", "kernel_uml_test")
+load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimePackageInfo")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
@@ -113,40 +115,6 @@ To create a .tar.gz suitable for this rule, you can use the kbuild tool, availab
             default = Label("//bazel/linux:defs.bzl"),
             allow_single_file = True,
         ),
-    },
-)
-
-KernelTreeInfo = provider(
-    doc = """Maintains the information necessary to build a module out of a kernel tree.
-
-In a rule(), you will generally want to create a 'make' command using 'make ... -C $root/$build ...'.
-Note that the kernel tree may depend on tools or ABIs not installed/available on your system,
-a kernel_tree on its own is not expected to be hermetic.
-""",
-    fields = {
-        "name": "Name of the rule that defined this kernel tree. For example, 'carlo-s-favourite-kernel'.",
-        "package": "A string indicating which package this kernel is coming from. For example, 'centos-kernel-5.3.0-1'.",
-        "root": "Bazel directory containing the root of the kernel tree. This is generally the location of the top level BUILD.bazel file. For example, external/@centos-kernel-5.3.0-1.",
-        "build": "Relative path of subdirectory to enter to build a kernel module. It is generally the 'build' parameter passed to the kernel_tree rule. For example, lib/modules/centos-kernel-5.3.0-1/build.",
-    },
-)
-
-KernelModulesInfo = provider(
-    doc = """Maintains the information necessary to represent compiled kernel modules.""",
-    fields = {
-        "label": "The Label() defining this kernel module.",
-        "package": "A string indicating which package this kernel module has been built against. For example, 'centos-kernel-5.3.0-1'.",
-        "arch": "A string describing the architecture this module was built against.",
-        "files": "A list of files representing the compiled .ko files part of this module.",
-        "kdeps": "A list of other KernelModulesInfo Target() objects needed at run time to load this module.",
-        "setup": "A list of strings, each string a shell command needed to prepare the system to load this module.",
-    },
-)
-
-KernelBundleInfo = provider(
-    doc = "Represents a set of the same module compiled for different kernels or arch.",
-    fields = {
-        "modules": "List of targets part of this bundle. Those targets provide a KernelModulesInfo.",
     },
 )
 
@@ -625,19 +593,6 @@ Example:
     },
 )
 
-RootfsImageInfo = provider(
-    doc = """Maintains the information necessary to represent a rootfs image.
-
-A rootfs is a file loadable by kvm/qemu/uml as a root file system. This root
-file system is expected to be able to run a bash script as the init command,
-and have basic tools available necessary for its users.
-""",
-    fields = {
-        "name": "Name of the rule that defined this rootfs image. For example, 'stefano-s-favourite-rootfs'.",
-        "image": "File containing the rootfs image.",
-    },
-)
-
 def _rootfs_image(ctx):
     return [DefaultInfo(files = depset([ctx.file.image])), RootfsImageInfo(
         name = ctx.attr.name,
@@ -736,16 +691,6 @@ and use it as the "test-latest-rootfs" from the repository.
             default = Label("//bazel/linux:defs.bzl"),
             allow_single_file = True,
         ),
-    },
-)
-
-KernelImageInfo = provider(
-    doc = """Maintains the information necessary to represent a kernel executable image.""",
-    fields = {
-        "name": "Name of the rule that defined this kernel executable image. For example, 'stefano-s-favourite-kernel-image'.",
-        "package": "A string indicating which package this kernel executable image is coming from. For example, 'custom-5.9.0-um'.",
-        "arch": "Architecture this linux kernel image was built for.",
-        "image": "Path of the kernel executable image.",
     },
 )
 
@@ -938,14 +883,6 @@ The modules still to expand are:
 
     return result
 
-RuntimePackageInfo = provider(
-    fields = {
-        "init": "string, script to ask init to run - relative to root",
-        "root": "string, directory that should be mounted on the test system",
-        "deps": "list of File objects, set of dependencies necessary for the runtime",
-    },
-)
-
 def _kernel_test_dir(ctx):
     ki = ctx.attr.image[KernelImageInfo]
     mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
@@ -1012,82 +949,6 @@ and an init script to run them as a kunit test.""",
             doc = "The template to generate the bash script used to run the tests.",
         ),
     },
-)
-
-def _kernel_uml_test(ctx):
-    ki = ctx.attr.kernel_image[KernelImageInfo]
-
-    inputs = depset(transitive = [
-        ctx.attr.kernel_image.files,
-        ctx.attr.runtime.files,
-        ctx.attr._parser.files,
-    ])
-
-    rootfs = ""
-    if ctx.attr.rootfs_image:
-        rootfs = ctx.attr.rootfs_image[RootfsImageInfo].image.short_path
-        inputs = depset(transitive = [inputs, ctx.attr.rootfs_image.files])
-
-    runtime = ctx.attr.runtime[RuntimePackageInfo]
-    executable = ctx.actions.declare_file(ctx.attr.name + "-start.sh")
-    ctx.actions.expand_template(
-        template = ctx.file._template,
-        output = executable,
-        substitutions = {
-            "{kernel}": ki.image.short_path,
-            "{rootfs}": rootfs,
-            "{parser}": ctx.executable._parser.short_path,
-            "{init}": runtime.init,
-            "{runtime}": runtime.root,
-            "{files}": shell.array_literal([d.short_path for d in runtime.deps]),
-        },
-        is_executable = True,
-    )
-    runfiles = ctx.runfiles(files = inputs.to_list())
-    runfiles = runfiles.merge(ctx.attr._parser.default_runfiles)
-    return [DefaultInfo(runfiles = runfiles, executable = executable)]
-
-kernel_uml_test = rule(
-    doc = """Runs a test using the kunit framework.
-
-kernel_test will retrieve the elements needed to setup a linux kernel test environment, and then execute the test.
-The test will run locally inside a user-mode linux process.
-""",
-    implementation = _kernel_uml_test,
-    attrs = {
-        "kernel_image": attr.label(
-            mandatory = True,
-            providers = [DefaultInfo, KernelImageInfo],
-            doc = "The kernel image that will be used to execute this test. A string like @stefano-s-favourite-kernel-image, referencing a kernel_image(name = 'stefano-s-favourite-kernel-image', ...",
-        ),
-        "rootfs_image": attr.label(
-            mandatory = False,
-            providers = [RootfsImageInfo],
-            doc = """\
-The rootfs image that will be used to execute this test.
-
-A string like @stefano-s-favourite-rootfs-image, referencing a rootfs_image(name = 'stefano-s-favourite-rootfs-image', ...).
-If not specified, the current root of the filesystem will be used as rootfs.
-""",
-        ),
-        "runtime": attr.label(
-            mandatory = True,
-            providers = [RuntimePackageInfo],
-            doc = "A target returning a RuntimePackageInfo, with tests to run in uml",
-        ),
-        "_template": attr.label(
-            allow_single_file = True,
-            default = Label("//bazel/linux:templates/run_um_kunit_tests.template.sh"),
-            doc = "The template to generate the bash script used to run the tests.",
-        ),
-        "_parser": attr.label(
-            default = Label("//bazel/linux/kunit:kunit_zip"),
-            doc = "KUnit TAP output parser.",
-            executable = True,
-            cfg = "host",
-        ),
-    },
-    test = True,
 )
 
 def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = {}, runner_cfg = {}, runner = kernel_uml_test, **kwargs):

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -1,0 +1,64 @@
+KernelTreeInfo = provider(
+    doc = """Maintains the information necessary to build a module out of a kernel tree.
+
+In a rule(), you will generally want to create a 'make' command using 'make ... -C $root/$build ...'.
+Note that the kernel tree may depend on tools or ABIs not installed/available on your system,
+a kernel_tree on its own is not expected to be hermetic.
+""",
+    fields = {
+        "name": "Name of the rule that defined this kernel tree. For example, 'carlo-s-favourite-kernel'.",
+        "package": "A string indicating which package this kernel is coming from. For example, 'centos-kernel-5.3.0-1'.",
+        "root": "Bazel directory containing the root of the kernel tree. This is generally the location of the top level BUILD.bazel file. For example, external/@centos-kernel-5.3.0-1.",
+        "build": "Relative path of subdirectory to enter to build a kernel module. It is generally the 'build' parameter passed to the kernel_tree rule. For example, lib/modules/centos-kernel-5.3.0-1/build.",
+    },
+)
+
+KernelModulesInfo = provider(
+    doc = """Maintains the information necessary to represent compiled kernel modules.""",
+    fields = {
+        "label": "The Label() defining this kernel module.",
+        "package": "A string indicating which package this kernel module has been built against. For example, 'centos-kernel-5.3.0-1'.",
+        "arch": "A string describing the architecture this module was built against.",
+        "files": "A list of files representing the compiled .ko files part of this module.",
+        "kdeps": "A list of other KernelModulesInfo Target() objects needed at run time to load this module.",
+        "setup": "A list of strings, each string a shell command needed to prepare the system to load this module.",
+    },
+)
+
+KernelBundleInfo = provider(
+    doc = "Represents a set of the same module compiled for different kernels or arch.",
+    fields = {
+        "modules": "List of targets part of this bundle. Those targets provide a KernelModulesInfo.",
+    },
+)
+
+KernelImageInfo = provider(
+    doc = """Maintains the information necessary to represent a kernel executable image.""",
+    fields = {
+        "name": "Name of the rule that defined this kernel executable image. For example, 'stefano-s-favourite-kernel-image'.",
+        "package": "A string indicating which package this kernel executable image is coming from. For example, 'custom-5.9.0-um'.",
+        "arch": "Architecture this linux kernel image was built for.",
+        "image": "Path of the kernel executable image.",
+    },
+)
+
+RootfsImageInfo = provider(
+    doc = """Maintains the information necessary to represent a rootfs image.
+
+A rootfs is a file loadable by kvm/qemu/uml as a root file system. This root
+file system is expected to be able to run a bash script as the init command,
+and have basic tools available necessary for its users.
+""",
+    fields = {
+        "name": "Name of the rule that defined this rootfs image. For example, 'stefano-s-favourite-rootfs'.",
+        "image": "File containing the rootfs image.",
+    },
+)
+
+RuntimePackageInfo = provider(
+    fields = {
+        "init": "string, script to ask init to run - relative to root",
+        "root": "string, directory that should be mounted on the test system",
+        "deps": "list of File objects, set of dependencies necessary for the runtime",
+    },
+)

--- a/bazel/linux/uml.bzl
+++ b/bazel/linux/uml.bzl
@@ -1,0 +1,78 @@
+load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimePackageInfo")
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _kernel_uml_test(ctx):
+    ki = ctx.attr.kernel_image[KernelImageInfo]
+
+    inputs = depset(transitive = [
+        ctx.attr.kernel_image.files,
+        ctx.attr.runtime.files,
+        ctx.attr._parser.files,
+    ])
+
+    rootfs = ""
+    if ctx.attr.rootfs_image:
+        rootfs = ctx.attr.rootfs_image[RootfsImageInfo].image.short_path
+        inputs = depset(transitive = [inputs, ctx.attr.rootfs_image.files])
+
+    runtime = ctx.attr.runtime[RuntimePackageInfo]
+    executable = ctx.actions.declare_file(ctx.attr.name + "-start.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = executable,
+        substitutions = {
+            "{kernel}": ki.image.short_path,
+            "{rootfs}": rootfs,
+            "{parser}": ctx.executable._parser.short_path,
+            "{init}": runtime.init,
+            "{runtime}": runtime.root,
+            "{files}": shell.array_literal([d.short_path for d in runtime.deps]),
+        },
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(files = inputs.to_list())
+    runfiles = runfiles.merge(ctx.attr._parser.default_runfiles)
+    return [DefaultInfo(runfiles = runfiles, executable = executable)]
+
+kernel_uml_test = rule(
+    doc = """Runs a test using the kunit framework.
+
+kernel_test will retrieve the elements needed to setup a linux kernel test environment, and then execute the test.
+The test will run locally inside a user-mode linux process.
+""",
+    implementation = _kernel_uml_test,
+    attrs = {
+        "kernel_image": attr.label(
+            mandatory = True,
+            providers = [DefaultInfo, KernelImageInfo],
+            doc = "The kernel image that will be used to execute this test. A string like @stefano-s-favourite-kernel-image, referencing a kernel_image(name = 'stefano-s-favourite-kernel-image', ...",
+        ),
+        "rootfs_image": attr.label(
+            mandatory = False,
+            providers = [RootfsImageInfo],
+            doc = """\
+The rootfs image that will be used to execute this test.
+
+A string like @stefano-s-favourite-rootfs-image, referencing a rootfs_image(name = 'stefano-s-favourite-rootfs-image', ...).
+If not specified, the current root of the filesystem will be used as rootfs.
+""",
+        ),
+        "runtime": attr.label(
+            mandatory = True,
+            providers = [RuntimePackageInfo],
+            doc = "A target returning a RuntimePackageInfo, with tests to run in uml",
+        ),
+        "_template": attr.label(
+            allow_single_file = True,
+            default = Label("//bazel/linux:templates/run_um_kunit_tests.template.sh"),
+            doc = "The template to generate the bash script used to run the tests.",
+        ),
+        "_parser": attr.label(
+            default = Label("//bazel/linux/kunit:kunit_zip"),
+            doc = "KUnit TAP output parser.",
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    test = True,
+)


### PR DESCRIPTION
Background:
defs.bzl has grown too large. Upcoming changes are adding support
for kvm, which will make it even larger.

In this PR:
- create a providers.bzl - must to avoid circular dependencies.
- moved uml specific code into dedicated file - uml.bzl.

This change is a noop: no code has been harmed in the process.

Tested:
bazel test with --override_repository in internal shows no
regression in the tests.