### PR TITLE
gee: streamline pr_make/pr_submit

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3322,31 +3322,14 @@ function gee__pr_make() {
   BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
   (
     cat <<'EndOfPrTemplate'
-# Pull request template
-#
-# This template is designed to help you write a good PR description.  This
-# description will be used as the first comment for your pull request, and will
-# ultimately become the squash-merge commit message for your change when you
-# run "gee pr_submit".  Note that all lines that start with a "#" will be
-# deleted.
-#
-# The first line if your PR description should be the PR title.  This
-# description should describe what is being affected, and what the change does.
+# The first line should be the PR title.
 # For example: "scripts/gee: Add new PR template."
 
-
 # In this section, explain why the PR is necessary and what the PR desires to
-# achieve.
-
+# achieve.  List any relevant Jira tickets.
 
 # In this section, describe what testing was done to validate your change.
 Tested:
-
-
-# In this section, list any relevant Jira tickets or other metadata tags.
-#
-# For example:
-# Jira: PROJ-1234,PROJ-5678
 
 # Having second thoughts?  Uncomment one of these two lines:
 # DRAFT   # To mark this PR as a "draft"
@@ -3368,15 +3351,18 @@ EndOfPrTemplate
     #                 PR description.
   ) >"${BODYFILE}"
 
-  _info "PR message body follows:"
-  cat "${BODYFILE}" >&2
-  declare -g RESP=""
-  _choose_one "Do you want to edit this message? ([V]im, [e]macs, [n]o, [a]bort)  " "vVeEnNaA" "v"
-  case "${RESP}" in
-    [vV]*) vim "${BODYFILE}"; ;;
-    [eE]*) emacs "${BODYFILE}"; ;;
-    [aA]*) _fatal "Aborted."; ;;
-  esac
+  if [[ -n "${EDITOR}" ]]; then
+    "${EDITOR}" "${BODYFILE}"
+  else
+    declare -g RESP=""
+    _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
+        "vVeEaA" "v"
+    case "${RESP}" in
+      [vV]*) vim "${BODYFILE}"; ;;
+      [eE]*) emacs "${BODYFILE}"; ;;
+      [aA]*) _fatal "Aborted."; ;;
+    esac
+  fi
 
   # Remove all comments from the description and squeeze multiple blank
   # lines into single blank lines:
@@ -3490,15 +3476,15 @@ function gee__pr_check() {
         if (( WAIT == 0 )); then
           declare -g RESP=""
           _choose_one "Some checks are still pending.  [W]ait, [r]etry, [a]bort, or [c]ontinue without waiting?  " \
-            "rwac" "w"
-          if [[ "${RESP}" == "a" ]]; then
-            _fatal "Aborted."
-          elif [[ "${RESP}" == "c" ]]; then
-            return 1
-          elif [[ "${RESP}" == "w" ]]; then
-            _info "Waiting until all pending tests are complete."
-            WAIT=1
-          fi
+            "rRwWaAcC" "w"
+          case "${RESP}" in
+            [aA]*) _fatal "Aborted."; ;;
+            [cC]*) return 1; ;;
+            [wW]*)
+              _info "Waiting until all pending tests are complete."
+              WAIT=1
+              ;;
+          esac
         fi
         sleep 10
       fi
@@ -3571,6 +3557,9 @@ function gee__pr_submit() {
     _fatal "Will not submit PR."
   fi
 
+  _info "Commit message will be:"
+  cat "${BODYFILE}"
+
   # Presubmit check: Are presubmit checks passing?
   if ! gee__pr_check; then
     if ! _confirm_default_no \
@@ -3599,18 +3588,6 @@ function gee__pr_submit() {
   echo "" >> "${BODYFILE}"
   sed -n '/^--/,$p' "${TEMPFILE}" | tail +2 >> "${BODYFILE}"
   rm "${TEMPFILE}"
-
-  declare -g RESP=""
-  while /bin/true; do
-    _info "Commit message will be:"
-    cat "${BODYFILE}"
-    _choose_one "About to merge.  Confirm? [y]es,[e]dit,[N]o  " "yeN" "n"
-    case "${RESP}" in
-      [eE]*) "${EDITOR:-vim}" "${BODYFILE}"; ;;
-      [nN]*) _fatal  "Aborted."; ;;
-      [yY]*) break; ;;
-    esac
-  done
 
   local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
   if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.28"
+readonly VERSION="0.2.29"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3292,6 +3292,8 @@ function gee__pr_make() {
     fi
   fi
 
+  echo "bar"
+
   local UNCOMMITTED
   UNCOMMITTED="$("${GIT}" status --short -uall | wc -l)"
   if [[ "${UNCOMMITTED}" -gt 0 ]]; then
@@ -3301,11 +3303,15 @@ function gee__pr_make() {
     _fatal Aborted.
   fi
 
+  echo "foo"
+
   NUM_COMMITS="$("${GIT}" log --oneline "${DEST_BRANCH}..${CURRENT_BRANCH}" | wc -l)"
   if [[ "${NUM_COMMITS}" -eq 0 ]]; then
     _debug "command: ${GIT} log --oneline ${DEST_BRANCH}..${CURRENT_BRANCH}"
     _fatal "No changes in this branch."
   fi
+
+  echo "bum"
 
   local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
   if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -3557,9 +3557,6 @@ function gee__pr_submit() {
     _fatal "Will not submit PR."
   fi
 
-  _info "Commit message will be:"
-  cat "${BODYFILE}"
-
   # Presubmit check: Are presubmit checks passing?
   if ! gee__pr_check; then
     if ! _confirm_default_no \
@@ -3588,6 +3585,9 @@ function gee__pr_submit() {
   echo "" >> "${BODYFILE}"
   sed -n '/^--/,$p' "${TEMPFILE}" | tail +2 >> "${BODYFILE}"
   rm "${TEMPFILE}"
+
+  _info "Commit message will be:"
+  cat "${BODYFILE}"
 
   local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
   if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -3379,9 +3379,10 @@ EndOfPrTemplate
   # Parse metadata from PR description.
   local TITLE
   TITLE="$(head -1 "${BODYFILE}")"
+  # We remove the title from the body file to avoid "stuttering" the
+  # title when we eventually submit the PR:
+  sed -i '1{d};2{/^$/d}' "${BODYFILE}"
 
-  # Note: we must label origin as the upstream branch for "gh pr create" to
-  # automatically pick the branch to use for the PR request.
   _push_to_origin "${CURRENT_BRANCH}"
   # gh pr is arcane and confusing, but this works:
   #  -R specifies the repo that we are pushing changes into.

--- a/scripts/gee
+++ b/scripts/gee
@@ -3292,8 +3292,6 @@ function gee__pr_make() {
     fi
   fi
 
-  echo "bar"
-
   local UNCOMMITTED
   UNCOMMITTED="$("${GIT}" status --short -uall | wc -l)"
   if [[ "${UNCOMMITTED}" -gt 0 ]]; then
@@ -3303,15 +3301,11 @@ function gee__pr_make() {
     _fatal Aborted.
   fi
 
-  echo "foo"
-
   NUM_COMMITS="$("${GIT}" log --oneline "${DEST_BRANCH}..${CURRENT_BRANCH}" | wc -l)"
   if [[ "${NUM_COMMITS}" -eq 0 ]]; then
     _debug "command: ${GIT} log --oneline ${DEST_BRANCH}..${CURRENT_BRANCH}"
     _fatal "No changes in this branch."
   fi
-
-  echo "bum"
 
   local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
   if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
@@ -3349,7 +3343,7 @@ EndOfPrTemplate
       printf "      easier to read.\n\n"
     fi
     printf "\n# The following files were modified in this PR:\n"
-    "${GIT}" diff --name_only "${PARENT}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
+    "${GIT}" diff --name-only "${PARENT}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
     printf "#\n# Here is your commit log:\n"
     "${GIT}" log --reverse "${PARENT}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
 

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,9 +2,21 @@
 
 ## Releases
 
+### Release 0.2.29
+
+* Streamling PR submission, and make the PR description template more terse.
+* Fix a malformed `git diff` command used during PR description template creation.
+* #565: Disable the unreliable diff test after `gee pr_submit`.
+* #576: `gee pr_submit` now checks PR status before attemping to submit.  gee
+  will no longer attempt to submit a PR that has already been merged.
+* #561: disable --autostash on all `git rebase` operations.  The user must
+  commit all changes before updated.
+* #560: `gee version` now checks if a newer version of gee is available.
+* #551: fix `gee cleanup`'s handling of `pr_NNN` branches created using `gee pr_checkout`.
+
 ### Release 0.2.28
 
-* Fix formatting of date when creating a shallow clone of the git repo.
+* #550: Fix formatting of date when creating a shallow clone of the git repo.
 * Fix `gee cleanup`: fix diff'ing of `pr_checkout` branches
 
 ### Release 0.2.27

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.28
+gee version: 0.2.29
 
 gee is a wrapper around the "git" and "gh-cli" tools.  "gee" captures all
 tribal knowledge about how to use git the right way (for us), implementing one


### PR DESCRIPTION
This PR addresses two annoyance-level issues:

1. The PR description template was unnecessarily verbose.  The new version is
   shorter and thus easier to edit.

2. Instead of asking the user if they want to edit the PR description, we just
   ask them how (previously, if they decided not to edit the PR description,
   they would win the booby prize of pr_make erroring out).  Additionally, if
   the user specifies the EDITOR environment variable, just use that editor.

3. The common use chase for `pr_submit` is "wait for all presubmits to pass
   and then submit".  Previously, after all presubmits passed, we would wait
   for user confirmation before submitting.  This PR removes that extra
   confirmation, so that pr_submit can be more "fire and forget" after
   waiting for presubmits to succeed.

4. Fixed malformed "git diff" command that was being invoked during PR
   description generation (harmless but cosmetic fix).

Tested: Used this version of gee to run pr_make, and will use it to run pr_submit.

