### PR TITLE
enkit ssh: Add --proxy-map arg

### DIFF
--- a/proxy/ptunnel/commands/BUILD.bazel
+++ b/proxy/ptunnel/commands/BUILD.bazel
@@ -28,12 +28,17 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["agent_test.go"],
+    srcs = [
+        "agent_test.go",
+        "ssh_test.go",
+    ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//lib/client:go_default_library",
+        "//lib/errdiff:go_default_library",
         "//lib/kcerts:go_default_library",
         "//lib/kflags:go_default_library",
+        "//lib/logger:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/proxy/ptunnel/commands/ssh.go
+++ b/proxy/ptunnel/commands/ssh.go
@@ -52,7 +52,8 @@ func IsValid(filename string) error {
 	return nil
 }
 
-// parseFlags performs
+// parseFlags performs extra processing/validation on command-line flags as a
+// pre-run step.
 func (r *SSH) parseFlags(cmd *cobra.Command, args []string) error {
 	for _, s := range r.proxyList {
 		pair := strings.SplitN(s, "=", 2)
@@ -197,7 +198,7 @@ func NewSSH(base *client.BaseFlags) *SSH {
 		&root.proxyList,
 		"proxy-map",
 		nil,
-		"Map of suffix=gateway pairs to use for choosing proxy. Overrides --proxy when an entry matches any of the targets. If set, --proxy is used as the default fallback when no entries match. Entries should be non-overlapping/able to be applied in any order.",
+		"Map of suffix=gateway pairs to use for choosing proxy. Overrides --proxy when an entry matches any of the targets. If set, --proxy is used as the default fallback when no entries match.",
 	)
 	root.Command.Flags().StringVarP(&root.SSH, "ssh", "e", "", "Path to the SSH binary to use. If empty, one will be found for you")
 

--- a/proxy/ptunnel/commands/ssh_test.go
+++ b/proxy/ptunnel/commands/ssh_test.go
@@ -14,25 +14,27 @@ func TestSSHParseFlags(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		proxyList    []string
-		wantProxyMap map[string]string
+		wantProxyMap []proxyMapping
 		wantErr      string
 	}{
 		{
 			desc:         "no entries",
 			proxyList:    nil,
-			wantProxyMap: map[string]string{},
+			wantProxyMap: nil,
 		},
 		{
-			desc:         "one entry",
-			proxyList:    []string{".foo=https://foo.example.com./"},
-			wantProxyMap: map[string]string{".foo": "https://foo.example.com./"},
+			desc:      "one entry",
+			proxyList: []string{".foo=https://foo.example.com./"},
+			wantProxyMap: []proxyMapping{
+				proxyMapping{substring: ".foo", proxy: "https://foo.example.com./"},
+			},
 		},
 		{
 			desc:      "multiple entries",
 			proxyList: []string{".foo=https://foo.example.com./", ".bar=https://bar.example.com./"},
-			wantProxyMap: map[string]string{
-				".foo": "https://foo.example.com./",
-				".bar": "https://bar.example.com./",
+			wantProxyMap: []proxyMapping{
+				proxyMapping{substring: ".foo", proxy: "https://foo.example.com./"},
+				proxyMapping{substring: ".bar", proxy: "https://bar.example.com./"},
 			},
 		},
 		{
@@ -58,17 +60,17 @@ func TestSSHParseFlags(t *testing.T) {
 	}
 }
 
-var exampleProxyMap = map[string]string{
-	".foo": "https://foo.example.com./",
-	".bar": "https://bar.example.com./",
-	".baz": "https://baz.example.com./",
+var exampleProxyMap = []proxyMapping{
+	proxyMapping{substring: ".foo", proxy: "https://foo.example.com./"},
+	proxyMapping{substring: ".bar", proxy: "https://bar.example.com./"},
+	proxyMapping{substring: ".baz", proxy: "https://baz.example.com./"},
 }
 
 func TestSSHChooseProxy(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		proxy     string
-		proxyMap  map[string]string
+		proxyMap  []proxyMapping
 		sshArgs   []string // One of these is expected to be the target ($USER@$MACHINE)
 		wantProxy string   // Flag in the form ` --proxy=$PROXY_URL`
 	}{

--- a/proxy/ptunnel/commands/ssh_test.go
+++ b/proxy/ptunnel/commands/ssh_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/enfabrica/enkit/lib/client"
+	"github.com/enfabrica/enkit/lib/errdiff"
+	"github.com/enfabrica/enkit/lib/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHParseFlags(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		proxyList    []string
+		wantProxyMap map[string]string
+		wantErr      string
+	}{
+		{
+			desc:         "no entries",
+			proxyList:    nil,
+			wantProxyMap: map[string]string{},
+		},
+		{
+			desc:         "one entry",
+			proxyList:    []string{".foo=https://foo.example.com./"},
+			wantProxyMap: map[string]string{".foo": "https://foo.example.com./"},
+		},
+		{
+			desc:      "multiple entries",
+			proxyList: []string{".foo=https://foo.example.com./", ".bar=https://bar.example.com./"},
+			wantProxyMap: map[string]string{
+				".foo": "https://foo.example.com./",
+				".bar": "https://bar.example.com./",
+			},
+		},
+		{
+			desc:      "parse error",
+			proxyList: []string{".foo:https://foo.example.com./"},
+			wantErr:   "not a valid proxy mapping",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ssh := &SSH{
+				proxyList: tc.proxyList,
+			}
+
+			gotErr := ssh.parseFlags(nil, nil)
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+			if gotErr != nil {
+				return
+			}
+			assert.Equal(t, ssh.ProxyMap, tc.wantProxyMap)
+		})
+	}
+}
+
+var exampleProxyMap = map[string]string{
+	".foo": "https://foo.example.com./",
+	".bar": "https://bar.example.com./",
+	".baz": "https://baz.example.com./",
+}
+
+func TestSSHChooseProxy(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		proxy     string
+		proxyMap  map[string]string
+		sshArgs   []string // One of these is expected to be the target ($USER@$MACHINE)
+		wantProxy string   // Flag in the form ` --proxy=$PROXY_URL`
+	}{
+		{
+			desc:      "target in proxy map",
+			proxy:     "https://default.example.com./",
+			proxyMap:  exampleProxyMap,
+			sshArgs:   []string{"user@machine-1.bar"},
+			wantProxy: " --proxy=https://bar.example.com./",
+		},
+		{
+			desc:      "target not in proxy map with default proxy",
+			proxy:     "https://default.example.com./",
+			proxyMap:  exampleProxyMap,
+			sshArgs:   []string{"user@machine-1.quux"},
+			wantProxy: " --proxy=https://default.example.com./",
+		},
+		{
+			desc:      "target not in proxy map with no default proxy",
+			proxyMap:  exampleProxyMap,
+			sshArgs:   []string{"user@machine-1.quux"},
+			wantProxy: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ssh := &SSH{
+				Proxy:    tc.proxy,
+				ProxyMap: tc.proxyMap,
+				BaseFlags: &client.BaseFlags{
+					Log: &logger.Proxy{
+						Logger: logger.Nil,
+					},
+				},
+			}
+
+			got := ssh.chooseProxy(tc.sshArgs)
+
+			assert.Equal(t, got, tc.wantProxy)
+		})
+	}
+}


### PR DESCRIPTION
This change adds a `--proxy-map` argument to `enkit ssh`, allowing one
to map bits of a SSH target address to its corresponding proxy. This
will allow us to configure e.g.:

```
--proxy-map=.foo=https://foo.example.com,.bar=https://bar.example.com
```

in the enkit kconfig, so that a bare `enkit ssh user@machine-1.bar` will
resolve to the (potentially non-default) proxy https://bar.example.com.

This is done by matching all of the non-flag SSH args against all
entries in `--proxy-map` via substring lookup until a match is found; if
no match is found, the proxy named by `--proxy` is used as a fallback.

This logic is likely to work most of the time but fall on its face for
unusual invocations of `enkit ssh`, so proxy decisions are logged at at
least the INFO level.

Tested:
* Added unit tests
* Pushed https://github.com/enfabrica/internal/pull/4917 as staging config, tested machines
   in the three different areas listed

Jira: INFRA-868