### PR TITLE
gazelle: Run on entire repo

### DIFF
--- a/tools/bzldoc/BUILD.bazel
+++ b/tools/bzldoc/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
 load("@python_dependencies//:requirements.bzl", "requirement")
 load(
     "//bazel/utils:diff_test.bzl",

--- a/tools/codegen/BUILD.bazel
+++ b/tools/codegen/BUILD.bazel
@@ -4,10 +4,10 @@ load("@python_dependencies//:requirements.bzl", "requirement")
 bzl_library(
     name = "codegen_bzl",
     srcs = ["codegen.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
         "//bazel/utils:diff_test_bzl",
     ],
-    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -56,4 +56,3 @@ py_binary(
         requirement("absl-py"),
     ],
 )
-

--- a/tools/codegen/tests/BUILD.bazel
+++ b/tools/codegen/tests/BUILD.bazel
@@ -2,8 +2,11 @@ load("//tools/codegen:codegen.bzl", "codegen_test")
 
 codegen_test(
     name = "gen-test",
-    expected = "gen-test.expected",
-    data = ["data.yaml"],
     srcs = ["test.template"],
-    overrides = ["over=rides", "zoo=zebra"],
+    data = ["data.yaml"],
+    expected = "gen-test.expected",
+    overrides = [
+        "over=rides",
+        "zoo=zebra",
+    ],
 )


### PR DESCRIPTION
This change runs `bazel run //:gazelle` to update BUILD files where
necessary, minimizing diffs in future changes.