### PR TITLE
bzldoc.bzl: added missing visibility attribute.

### DIFF
--- a/tools/bzldoc/BUILD.bazel
+++ b/tools/bzldoc/BUILD.bazel
@@ -15,6 +15,7 @@ bzl_library(
     deps = [
         # "//codegen:codegen_bzl",
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(


### PR DESCRIPTION
bzldoc.bzl: added missing visibility attribute.

I think this is why I'm having difficulty loading this bzl file from internal.

Tested:

