### PR TITLE
bazel/linux: turn {uml|qemu} test rules into runnable rules.

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,8 +1,9 @@
-load("//bazel/linux:uml.bzl", "kernel_uml_test")
+load("//bazel/linux:uml.bzl", "kernel_uml_run")
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimePackageInfo")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
+load("//bazel/utils:exec_test.bzl", "exec_test")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _kernel_tree_version(ctx):
@@ -977,7 +978,7 @@ and an init script to run them as a kunit test.""",
     },
 )
 
-def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = {}, runner_cfg = {}, runner = kernel_uml_test, **kwargs):
+def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = {}, runner_cfg = {}, runner = kernel_uml_run, **kwargs):
     runtime = mcreate_rule(
         name,
         kernel_test_dir,
@@ -990,4 +991,5 @@ def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = 
     cfg = mconfig(runtime = runtime, kernel_image = kernel_image)
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
-    name_runner = mcreate_rule(name, runner, "", runner_cfg, kwargs, cfg)
+    name_runner = mcreate_rule(name, runner, "emulator", runner_cfg, kwargs, cfg)
+    exec_test(name = name, dep = name_runner)

--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -56,7 +56,7 @@ QEMU_FLAGS+=("${{EMULATOR_OPTS[@]}}")
 
 echo Running qemu: "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"
 if [ -z "$INTERACTIVE" ]; then
-    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" | tee "$OUTPUT_FILE"
+    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" </dev/null | tee "$OUTPUT_FILE"
 else
     "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"
 fi

--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -1,5 +1,5 @@
 load("//bazel/linux:providers.bzl", "KernelImageInfo", "RootfsImageInfo", "RuntimePackageInfo")
-load("//bazel/utils:messaging.bzl", "location")
+load("//bazel/utils:messaging.bzl", "location", "package")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 CREATE_RUNNER_ATTRS = {
@@ -54,6 +54,7 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
 
     runtime = ctx.attr.runtime[RuntimePackageInfo]
     subs = dict({
+        "target": package(ctx.label),
         "kernel": ki.image.short_path,
         "rootfs": rootfs,
         "init": runtime.init,

--- a/bazel/linux/templates/check_kunit.template.sh
+++ b/bazel/linux/templates/check_kunit.template.sh
@@ -2,7 +2,7 @@
 
 test -n "$1" || {
     echo 1>&2 "The first argument to $0 must be the directory containing the"
-    echo 1>&2 "console.log file with the output of qemu/uml/..."
+    echo 1>&2 "console.log file with the output of qemu/uml/... \$1 was empty!"
     exit 1
 }
 

--- a/bazel/linux/templates/init.template.sh
+++ b/bazel/linux/templates/init.template.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
+echo ========= VM KUNIT INIT STARTED ==========
 trap "poweroff -f" EXIT
 
 function load {
-	echo "... loading $KMOD."
+	echo "... loading $@."
 	insmod "$@"
 }
 

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "===== Running target: {target}"
+echo "===== Path: $(realpath $0)"
+
 # REL* are relative bazel paths.
 # RUNTIME points to the root directory.
 # INIT is relative to the root directory, points to the init script.
@@ -9,31 +12,95 @@ RELINIT="{init}"
 RELRUNTIME="{runtime}"
 ROOTFS="{rootfs}"
 KERNEL="{kernel}"
+TARGET="{target}"
 
 # A script in charge of verifying the output of the run.
 CHECKER="{checker}"
+
+function help {
+  cat <<END
+This script executes your target in an emulator.
+Prefer to use as:
+
+  bazel run $TARGET -- [-k kernel option]... [-e emu option]... [-r rootfs] [-s|-x|-h]
+
+or:
+
+  bazel build $TARGET
+  bazel-bin/.../path/to/file [-k option]... [-e option]... [-s|-x|-h]
+
+Accepted options:
+
+  -k [value]   Adds one or more command line options to the kernel.
+
+     For example: "-k ro -k root=/dev/sda -k console=ttyS0"
+     will add "ro root=/dev/sda console=ttyS0" to the kernel command line.
+
+  -e [value]   Adds one or more command line options to the emulator.
+
+     For example: "-e'-f' -e/dev/sda -e'-mem' -e2048"
+     will add "-f /dev/sda -mem 2048" to the emulator command line.
+
+  -r [value]   Overrides the path to the rootfs.
+
+     For example: "-r /tmp/myown.qcow" will ask the emulator to run
+     the specified rootfs.
+
+  -x           Prints info on the paths of the scripts used so you
+               can use your immense wisdom to manually inspect and
+               modify them.
+
+  -h           Prints this astonishingly helpful message.
+
+END
+}
+
+function showstate {
+    echo 1>&2 "CWD: $(realpath "$PWD")"
+    echo 1>&2 "Script: $(realpath "$0")"
+    echo 1>&2 "Kernel: $(realpath "$KERNEL")"
+    echo 1>&2 "Rootfs: $ROOTFS"
+    echo 1>&2 "Runtime: $RUNTIME"
+    echo 1>&2 "Init: $INIT"
+
+    if [ -n "$CHECKER" ]; then
+        echo 1>&2 "Checker: $(realpath $CHECKER)"
+    else
+        echo 1>&2 "Checker: <no checker configured>"
+    fi
+}
+
+declare -a KERNEL_OPTS
+declare -a EMULATOR_OPTS
+INTERACTIVE=""
+
+# Make sure the log file is saved by BES protocol, store it in the
+# UNDECLARED_OUTPUTS_DIR.
+TMPDIR="${TEST_TMPDIR:-$(mktemp -d)}"
+OUTPUT_DIR=${TEST_UNDECLARED_OUTPUTS_DIR:-$(mktemp -d)}
 
 # Variables provided by bazel will point to a directory that only contains the
 # deps for this targets as symlinks. But symlinks don't work if we only mount
 # a subdirectory. This finds the original/underlying location.
 INIT="$(realpath "$RELRUNTIME/$RELINIT")"
 RUNTIME="${INIT%%$RELINIT}"
+OUTPUT_FILE="$OUTPUT_DIR/console.log"
 
-# Make sure the log file is saved by BES protocol, store it in the
-# UNDECLARED_OUTPUTS_DIR.
-OUTPUTFILE="$TEST_UNDECLARED_OUTPUTS_DIR/console.log"
+while getopts "k:e:r:hsx" opt; do
+  case "$opt" in
+    h) help; exit 0;;
+    k) KERNEL_OPTS+=("$OPTARG");;
+    e) EMULATOR_OPTS+=("$OPTARG");;
+    s) INTERACTIVE=True;;
+    r) ROOTFS=("$OPTARG");;
+    x) showstate; exit 0;;
+    ?|*) help 1>&2; exit 1;;
+  esac
+done
+shift $((OPTIND - 1))
 
-echo 1>&2 "Script: $(realpath $0)"
-echo 1>&2 "Kernel: $KERNEL"
-echo 1>&2 "Rootfs: $ROOTFS"
-echo 1>&2 "Runtime: $RUNTIME"
-echo 1>&2 "Init: $INIT"
+showstate
 
-if [ -n "$CHECKER" ]; then
-    echo 1>&2 "Checker: $(realpath $CHECKER)"
-else
-    echo 1>&2 "Checker: <no checker configured>"
-fi
 echo 1>&2 "======================================"
 
 if [ -n "$ROOTFS" ]; then
@@ -45,31 +112,36 @@ fi
 # Contract with the included code:
 # - It is run with 'set -e', any non-zero status causes exit with an error.
 # - Code can only use the following variables:
+#   - TARGET - name of the target running the rule.
 #   - KERNEL - path to the kernel to run.
 #   - INIT - path to the file to start as init/after init.
 #   - ROOTFS - path to the root file system to use.
 #   - RUNTIME - path to the top level directory that needs to be exposed.
 #   - TMPDIR - path to a temporary directory.
 #   - INTERACTIVE - if non-empty value, run the VM in interactive mode (shell).
-#   - OUTPUTFILE - console output must be stored in this file
-#                  (kernel boot log, and any shell output).
-INTERACTIVE="${INTERACTIVE:$BUILD_WORKSPACE_DIRECTORY}"
-TMPDIR="${TEST_TMPDIR}"
+#   - OUTPUT_FILE - console output must be stored in this file
+#                   (kernel boot log, and any shell output).
+#   - OUTPUT_DIR - directory where to store any other output file.
+#
+# - Additionally, they should check for:
+#   - KERNEL_OPTS - array, may have additional kernel arguments.
+#   - EMULATOR_OPTS - array, may have additional arguments for the emulator.
 {code}
 
 test -z "$INTERACTIVE" || exit
 
 test -z "$CHECKER" || {
   echo 1>&2 "===== emulator exited successfully - checking the results with $(realpath $CHECKER) ===="
-  "$CHECKER" "$TEST_UNDECLARED_OUTPUTS_DIR" || {
+  "$CHECKER" "$OUTPUT_DIR" || {
     status="$?"
     echo 1>&2 "====================================="
-    echo 1>&2 "You can also use:"
-    echo 1>&2 "   bazel run ${TEST_TARGET}"
+    echo 1>&2 "Use:"
+    echo 1>&2 "   bazel run ${TARGET} -- -h"
     echo 1>&2
-    echo 1>&2 -e "... to be dropped in a shell. Test is started by $RUNINIT".
-    echo 1>&2 "Additional arguments after 'bazel run ... -- ' are passed unchanged"
-    echo 1>&2 "to the emulator"
+    echo 1>&2 "... to learn how to manually run this target for debugging, and"
+    echo 1>&2 -e "override targets. Once in the VM, the test is started by $RUNINIT"
+    echo 1>&2 "use 'bazel run ${TARGET} -- -x' to see the full paths of scripts, so"
+    echo 1>&2 "you can run them manually to debug."
     exit "$status"
   }
 }

--- a/bazel/utils/exec_test.bzl
+++ b/bazel/utils/exec_test.bzl
@@ -3,7 +3,7 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 def _exec_test(ctx):
     # A test rule must return an executable file, cannot reuse
     # the executable returned by another rule.
-    template = """#!/bin/sh
+    template = """#!/bin/bash
 ARGS={argv}; ARGS+=("$@")
 exec {script} "$ARGS[@]"
 """
@@ -15,14 +15,15 @@ exec {script} "$ARGS[@]"
 exec_test = rule(
     doc = """Turns an executable target into a test target.
 
-This is so that any executable target can be used as a test, including
+This is so that any executable target can be used as a test, including in
 test_suite(), with a specific set of parameters. But also so that test targets
-can be broken out of being marked as a test rule.
+can be broken out into separate executable and test phases.
 
 This is convenient as when a target is marked as 'test = True', it must be
 named _test, and is always run under a different environment (wrapped in a
-test-setup.sh, which changes the terminal behavior, backgrounds tasks, and
-affects the --run_under flag).
+test-setup.sh), which changes the terminal behavior, backgrounds tasks, and
+affects the --run_under flag - which can make some targets very hard to
+work with for debugging purposes.
 
 Example:
 

--- a/bazel/utils/exec_test.bzl
+++ b/bazel/utils/exec_test.bzl
@@ -1,0 +1,59 @@
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _exec_test(ctx):
+    # A test rule must return an executable file, cannot reuse
+    # the executable returned by another rule.
+    template = """#!/bin/sh
+ARGS={argv}; ARGS+=("$@")
+exec {script} "$ARGS[@]"
+"""
+    script = ctx.actions.declare_file("{}_test.sh".format(ctx.attr.name))
+    ctx.actions.write(script, template.format(argv = shell.array_literal(ctx.attr.argv), script = ctx.executable.dep.short_path))
+    runfiles = ctx.runfiles(ctx.files.dep).merge(ctx.attr.dep[DefaultInfo].default_runfiles)
+    return [DefaultInfo(files = depset(ctx.files.dep), runfiles = runfiles, executable = script)]
+
+exec_test = rule(
+    doc = """Turns an executable target into a test target.
+
+This is so that any executable target can be used as a test, including
+test_suite(), with a specific set of parameters. But also so that test targets
+can be broken out of being marked as a test rule.
+
+This is convenient as when a target is marked as 'test = True', it must be
+named _test, and is always run under a different environment (wrapped in a
+test-setup.sh, which changes the terminal behavior, backgrounds tasks, and
+affects the --run_under flag).
+
+Example:
+
+1) Let's say you have a rule like:
+
+    sh_binary(
+        name = "compute-valid.sh",
+        srcs = [ ... ],
+    )
+
+2) You can turn it into a test by using:
+
+    exec_test(
+        name = "compute-valid-delta",
+        args = ["-delta", "1799"],
+    )
+
+The target "compute-valid-delta" will be a test, that will succeed
+if "compute-valid.sh -delta 1799" exits with status 0.
+""",
+    implementation = _exec_test,
+    test = True,
+    attrs = {
+        "dep": attr.label(
+            doc = "Executable target to be converted into a test target",
+            mandatory = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "argv": attr.string_list(
+            doc = "Additional arguments to pass to the executable target",
+        ),
+    },
+)


### PR DESCRIPTION
Background:
So far, all the uml_|qemu_ virtualization rules were for testing
only. Now we want to use them just to run an emulator.

This PR changes the rules from "test = True" to "executable = True",
with all that it implies.

Specifically:
- refactor the .sh scripts - they can no longer rely on TEST_
  environment variables being set.

- introduce an exec_test.bzl utility - that can turn any executable
  rule into a test rule.

- use said rule in existing definitions so to maintain backward
  compatibility with the existing ruleset.

- have the shell scripts in the rules be more useful. Specifically:
  - it is now possible to override emulator/kernel/rootfs parameters
    directly from the command line.

  - paths and runtime info is clearly displayed on the screen, removing
    sandboxing parameters, so it's very easy to debug those scripts
    manually.

Tested:
Existing regression tests are still passing in internal/. An example
PR in qemu is failing exactly as it was before :) needs the module
loading plumbing to be useful.
