### PR TITLE
bzldoc: handle missing attrs

### DIFF
--- a/tools/bzldoc/md.template
+++ b/tools/bzldoc/md.template
@@ -25,13 +25,15 @@ Source code: https://github.com/enfabrica/internal/{{ short_path }}
 {{ v.kwargs.doc }}
 {%-   endif %}
 
+{%-   if "attrs" in v.kwargs %}
+{# blank line #}
 <table><thead><tr>
 <th> Attribute </th><th> Type </th><th> Description </th>
 </tr></thead><tbody>
-{%-   for ak, av in v.kwargs.attrs.items() %}
-{%-     set attrparts = av.name.split(".") %}
-{%-     set attrlib = attrparts[0] %}
-{%-     set attrtype = attrparts[1] %}
+{%-     for ak, av in v.kwargs.attrs.items() %}
+{%-       set attrparts = av.name.split(".") %}
+{%-       set attrlib = attrparts[0] %}
+{%-       set attrtype = attrparts[1] %}
 <tr><td>
 
 {{ ak }}
@@ -45,9 +47,14 @@ Source code: https://github.com/enfabrica/internal/{{ short_path }}
 {{ av.kwargs.doc }}
 
 </td></tr>
-{%-   endfor %}
+{%-   endfor %}{# ak, av #}
 </tbody></table>
 {# blank line #}
+{%-   else %}{# check for attrs #}
+
+(This rule has no attributes.)
+{# blank line #}
+{%-   endif %}{# check for attrs #}
 
 {%- endfor %}{# k, v #}
 

--- a/tools/bzldoc/md.template
+++ b/tools/bzldoc/md.template
@@ -25,7 +25,10 @@ Source code: https://github.com/enfabrica/internal/{{ short_path }}
 {{ v.kwargs.doc }}
 {%-   endif %}
 
-{%-   if "attrs" in v.kwargs %}
+{%-   if "attrs" not in v.kwargs or not v.kwargs.attrs %}
+
+(This rule has no attributes.)
+{%-   else %}{# check for attrs #}
 {# blank line #}
 <table><thead><tr>
 <th> Attribute </th><th> Type </th><th> Description </th>
@@ -47,12 +50,8 @@ Source code: https://github.com/enfabrica/internal/{{ short_path }}
 {{ av.kwargs.doc }}
 
 </td></tr>
-{%-   endfor %}{# ak, av #}
+{%-     endfor %}{# ak, av #}
 </tbody></table>
-{# blank line #}
-{%-   else %}{# check for attrs #}
-
-(This rule has no attributes.)
 {# blank line #}
 {%-   endif %}{# check for attrs #}
 

--- a/tools/bzldoc/testdata/codegen.bzl
+++ b/tools/bzldoc/testdata/codegen.bzl
@@ -7,6 +7,11 @@ It is a fork of codegen.bzl.
 
 load("//bazel/utils:diff_test.bzl", "diff_test")
 
+missingattrs = rule(
+    doc = """
+      Here is a rule that is missing any attributes, for testing purposes.
+    """,
+)
 
 def _codegen_impl(ctx):
     args = ctx.actions.args()

--- a/tools/bzldoc/testdata/codegen.md
+++ b/tools/bzldoc/testdata/codegen.md
@@ -134,6 +134,12 @@ The path to the codegen tool itself.
 </td></tr>
 </tbody></table>
 
+### `missingattrs` Rule
+
+Here is a rule that is missing any attributes, for testing purposes.
+
+(This rule has no attributes.)
+
 ## Macros
 
 ### `codegen_test` Macro

--- a/tools/bzldoc/testdata/codegen.yaml
+++ b/tools/bzldoc/testdata/codegen.yaml
@@ -1,4 +1,11 @@
 rules:
+  missingattrs:
+    name: rule
+    args: []
+    kwargs:
+      doc: 'Here is a rule that is missing any attributes, for testing purposes.
+
+        '
   codegen:
     name: rule
     args: []


### PR DESCRIPTION
bzldoc: handle missing attrs

One of our bzl files defines a rule with no attrs attribute, for some reason,
which blows up our template. This PR adds a conditional to handle this
exceptional condition.

Tested:

Added a rule to testdata/codegen.bzl to reproduce the problem.
Watched the build fail.
Modified the template to resolve the issue.
Watched the build succeed.

