### PR TITLE
Move Terraform.bzl to Enkit

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.16.0"
+  hashes = [
+    "h1:NvmY7SXSROwpOBaunbDeVBDyaV3w7jGLs6d9TpDZYLw=",
+    "zh:07ed2a7c5f5acded520167e6bb00698d167a94071f665e754a4f64cbf7a3c5e3",
+    "zh:261ba60510dd3369a1c87887da1cc3c299be6d08880e9d088481528876d90553",
+    "zh:4b166bf306ec493ee576e4601cf452b7d63fdcb3b26a0d6322880d8494397534",
+    "zh:50cd4af01ca53309cebc0f76b5b96e52cb7d09324aef03be2bbfacae52e9c086",
+    "zh:51b54e489a936afa4d65d8e31b58a2377bdb9420572774a94e717386651cd1f3",
+    "zh:7dd7f3427d99d6994f92b5f845060ff889ce093192313768d8c4e21139422680",
+    "zh:86cd2db78552b35d2fce6791f2733f03ea9cb26e4a214afb3adac0fc5440001a",
+    "zh:9895d896f4ae759b1321254be5ad4a57996341d643334f353ca1a64f6c08bf9b",
+    "zh:bdbb88f7f47a2b20bef44e8540d35fcf8c652ee3ebb7716366358ba8488f9b2c",
+    "zh:ddccebcb1203776874ca5a2d8841aafd458f9c6592d7325f43b4b6d7b6c917d0",
+    "zh:f8104c9e113f36caa94baaf28684f54c6261071a65fb55086d32ccc23318f138",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "4.16.0"
+  hashes = [
+    "h1:E46exeQhH8/eraOw9TwI7e+FY/cctTvjSYBf3kRMT48=",
+    "zh:117d90f85dbf99430e7a57d19903065837152f2b9b8b426060f62b561e6d46d2",
+    "zh:1385515f1d95c383ae47ecd1bb66c2d0d9e5484782cbd3be6b14303c79f9a634",
+    "zh:143d51e6e0aef53b1d40a3d828b4d7e151fba01efe98eece8e5b4e6e80dd8eb2",
+    "zh:29206ff8fd22fe91d36ffda381229f33404389ee2dca3f6959a1e5ca3865f998",
+    "zh:38fa1d6d9365e7a38290f4b2454d9d8819da3e746d173715e87c542198f8256b",
+    "zh:58695c5ffc643ddee96a2eb75bbd4fc6a0a60b791dbf0e87ff515e1b0711b466",
+    "zh:625af9db990bf5af532f485bb6ec80a729ff2084d72fa38569f46736726a571b",
+    "zh:805b484ecb19f698341e2de12d7c34612a49e6a09f9decb4e3c4241a0372ac11",
+    "zh:9193e12f4c19541fe788c2990f3e9e572ab69e7d7656b043abcf23d460cc05df",
+    "zh:b6f044ab18f8d2962da7b042100ba8251c20217d4b8cf7a9d03b4a0037477a4c",
+    "zh:e9b736075e76b4159bcf0f9b9607e5a120f6e2d3fb74528abbfa08f96ebb0736",
+  ]
+}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("//bazel:terraform.bzl", "terraform_apply", "terraform_library")
 
 # To update and generate the BUILD.bazel files, run:
 #     bazelisk run //:gazelle
@@ -54,4 +55,22 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 #     bazelisk run //:buildifier
 buildifier(
     name = "buildifier",
+)
+
+terraform_library(
+    name = "cloudbuild",
+    srcs = [
+        "cloudbuild.tf",
+    ],
+    data = [
+        "cloudbuild.sh"
+    ],
+)
+
+terraform_apply(
+    name = "deploy-cloudbuild",
+    configs = [
+        ":cloudbuild",
+    ],
+    terraform_lock = ".terraform.lock.hcl",
 )

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -205,3 +205,11 @@ def stage_1():
         strip_prefix = "protobuf-3.20.1",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.1.tar.gz"],
     )
+
+    maybe(
+        name = "terraform_cli_amd64",
+        repo_rule = http_archive,
+        build_file_content = 'exports_files(["terraform"], visibility = ["//visibility:public"])',
+        sha256 = "fbd37c1ec3d163f493075aa0fa85147e7e3f88dd98760ee7af7499783454f4c5",
+        urls = ["https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip"],
+    )

--- a/bazel/terraform.bzl
+++ b/bazel/terraform.bzl
@@ -1,0 +1,101 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+TerraformConfigInfo = provider(
+    doc = "Propagates Terraform configs through rules",
+    fields = {
+        "configs": "Depset of configs to apply",
+        "data": "Depset of data dependencies for configs",
+    },
+)
+
+def _terraform_library_impl(ctx):
+    return [
+        DefaultInfo(
+            files = depset(direct = ctx.files.srcs + ctx.files.data),
+        ),
+        TerraformConfigInfo(
+            configs = depset(direct = ctx.files.srcs),
+            data = depset(direct = ctx.files.data),
+        ),
+    ]
+
+terraform_library = rule(
+    implementation = _terraform_library_impl,
+    doc = "Wraps Terraform config files so they can be propagated to rules expecting Terraform",
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+            doc = "Terraform files to wrap",
+            allow_files = [".tf"],
+        ),
+        "data": attr.label_list(
+            doc = "Extra files referenced by terraform configs (templates, file()...)",
+            allow_files = True,
+        )
+    },
+)
+
+def _terraform_apply_impl(ctx):
+    outputs = []
+
+    stage_dir = "{}_stage".format(ctx.attr.name)
+
+    # Symlink lock file into stage dir
+    lock_file = ctx.actions.declare_file("{}/.terraform.lock.hcl".format(stage_dir))
+    ctx.actions.symlink(output = lock_file, target_file = ctx.file.terraform_lock)
+    outputs.append(lock_file)
+
+    # Symlink all the configs into stage dir
+    for target in ctx.attr.configs:
+        tfc = target[TerraformConfigInfo]
+        for f in tfc.configs.to_list():
+            symlinked_f = ctx.actions.declare_file(f.basename, sibling = lock_file)
+            ctx.actions.symlink(output = symlinked_f, target_file = f)
+            outputs.append(symlinked_f)
+
+        if not hasattr(tfc, "data"):
+            continue
+
+        for f in tfc.data.to_list():
+            symlinked_f = ctx.actions.declare_file(f.short_path, sibling = lock_file)
+            ctx.actions.symlink(output = symlinked_f, target_file = f)
+            outputs.append(symlinked_f)
+
+    # Generate script that can run terraform commands in stage dir
+    script_file = ctx.actions.declare_file("{}_run.sh".format(ctx.attr.name))
+    script = """#!/bin/bash
+pwd
+
+terraform -chdir={stage_dir} init
+terraform -chdir={stage_dir} "$@"
+""".format(
+        stage_dir = paths.dirname(lock_file.short_path),
+    )
+    ctx.actions.write(script_file, script, is_executable = True)
+    outputs.append(script_file)
+
+    return [
+        DefaultInfo(
+            files = depset(direct = outputs),
+            runfiles = ctx.runfiles(files = outputs),
+            executable = script_file,
+        ),
+    ]
+
+terraform_apply = rule(
+    implementation = _terraform_apply_impl,
+    doc = "Generates a directory with all configs symlinked in, and a script to run Terraform operations on said directory",
+    attrs = {
+        "configs": attr.label_list(
+            mandatory = True,
+            doc = "Targets providing Terraform configuraion",
+            providers = [TerraformConfigInfo],
+        ),
+        "terraform_lock": attr.label(
+            mandatory = True,
+            doc = "Terraform lockfile that describes the versions of plugins to use",
+            allow_single_file = [".lock.hcl"],
+        ),
+    },
+    executable = True,
+)

--- a/cloudbuild.sh
+++ b/cloudbuild.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+#
+# This script updates bazel/enkit.versions.bzl based on the $$COMMIT
+# env variable.
+#
+# It was written for cloudbuild, and assumes that:
+#
+#   1) PWD is a clone of enfabrica/enkit.
+#   2) The GH_TOKEN env variable contains a token for github.
+#   3) A COMMIT environment variable contains the latest enkit commit.
+#
+# TODO: break this down in reasonable units, allow to reuse for other automation.
+
+ENKIT_COMMIT="$$COMMIT_SHA"
+ENKIT_SHORT="$$(echo "$$COMMIT_SHA" | cut -c1-7)"
+
+test -n "$$ENKIT_COMMIT" || {
+    echo "No 'COMMIT' environment variable. Giving up. Environment:" 1>&2
+    exit 5
+}
+
+# Compute the enkit SHA - from the push time to when the .tar.gz will
+# be available on github it may take a few seconds, so retry for a reasonable
+# number of times.
+
+ENKIT_URL="https://github.com/enfabrica/enkit/archive/$$ENKIT_COMMIT.tar.gz"
+
+for attempt in $$(seq 1 10); do
+    echo "Attempt $$attempt to download $$ENKIT_URL..." 
+    ENKIT_SHA256=$$(wget -q -O- "$$ENKIT_URL" |sha256sum |cut -d' ' -f1) && break
+    sleep 10
+done
+
+test -n "$$ENKIT_SHA256" || {
+    echo "Could not compute enkit SHA after 10 attempts of downloading $$ENKIT_URL - giving up" 1>&2
+    exit 1
+}
+
+ENKIT_MESSAGE="$$(git log --format=%B -n 1 "$$ENKIT_COMMIT"|sed -e
+'s@^@    @g' || echo "COMMIT NOT FOUND")"
+
+ENKIT_AUTHOR="$$(gh api repos/enfabrica/enkit/commits/"$$ENKIT_COMMIT"
+--jq .author.login)"
+
+test -n "$$ENKIT_AUTHOR" || {
+    echo "Could not detect author of the commit" 1>&2
+    exit 1
+}
+
+set -e
+set -x
+
+cd "$$(mktemp -d)"
+
+# Configures git to work with the GH_TOKEN key.
+gh auth setup-git </dev/null
+
+# gh is interactive by desing - no great scripting integration.
+#
+# during testing, it would fall back to asking questions on the console
+# even when not strictly necessary (eg, to ask for confirmation, or pick a default).
+#
+# </dev/null closes stdin, which gh detects, causing it to stop asking
+# silly questions (if not all parameters are available, it fails instead).
+
+gh repo clone enfabrica-bot/internal -- --depth=1 --single-branch </dev/null
+cd "internal"
+
+# Create a branch, and the commit.
+
+git checkout -b "enkit-update-$$ENKIT_COMMIT" upstream/master
+
+cat > ./bazel/enkit.version.bzl <<ENKIT_BAZEL
+ENKIT_SHA = "$$ENKIT_SHA256"
+ENKIT_VERSION = "$$ENKIT_COMMIT"
+ENKIT_BAZEL
+
+git add ./bazel/enkit.version.bzl
+git config --global user.email "bot-email@enfabrica.net"
+git config --global user.name "Enfabrica BOT"
+git commit -a -F- <<COMMIT_MESSAGE
+
+WORKSPACE: update enkit for commit $$ENKIT_SHORT
+
+A commit was just mereged in the enkit repository.
+This PR updates internal to pick up the latest version of enkit.
+
+The [commit
+merged](https://github.com/enfabrica/enkit/commit/$$ENKIT_COMMIT) in
+enkit is described as:
+
+$$ENKIT_MESSAGE
+
+And you can blame @$$ENKIT_AUTHOR in case something breaks.
+
+The PR is marked for auto-merge: as soon as there is an approval
+and tests are passing, github will merge it automatically.
+
+You should also know that:
+
+- To save humans from menial work, I, enfabrica-bot, am automatically
+    updating the enkit version in the internal repo.
+
+- If I'm misbehaving, you can disable the corresponding trigger
+    from cloudbuild.
+
+- If this works well, my human overlords promised to disable the
+    need for a manual approval.
+COMMIT_MESSAGE
+
+# The push -u origin below fails if the branch already exists.
+#
+# This is required by 'gh pr create' below - it falls back to interactive
+# mode if it cannot automatically figure out the default origin.
+#
+# See https://github.com/cli/cli/issues/1718.
+
+git push -u origin
+
+gh pr create --head "enfabrica-bot:enkit-update-$$ENKIT_COMMIT" -a
+"$$ENKIT_AUTHOR" -r "$$ENKIT_AUTHOR" --fill </dev/null
+
+# This allows the PR to be automatically merged ONCE TESTS PASS and there
+# is at least one approver. We may relax this constraint once proved to be working.
+
+gh pr merge --auto --rebase </dev/null

--- a/cloudbuild.tf
+++ b/cloudbuild.tf
@@ -1,0 +1,49 @@
+resource "google_cloudbuild_trigger" "internal_repo_update" {
+  name = "Updates-the-enkit-version-in-the-internal-repository"
+
+  description = "Updates the enkit version in the internal repository"
+
+  github {
+    owner = "enfabrica"
+    name  = "enkit"
+    push {
+      branch = "^master$"
+    }
+  }
+
+  build {
+    step {
+      name       = "gcr.io/devops-284019/developer:stable"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        file("${path.module}/cloudbuild.sh")
+      ]
+      secret_env = ["GH_TOKEN"]
+    }
+    available_secrets {
+      secret_manager {
+        version_name = "projects/496137108493/secrets/github-enfabrica-bot-token/versions/latest"
+        env          = "GH_TOKEN"
+      }
+    }
+
+    options {
+      machine_type = "E2_HIGHCPU_8"
+      env = [
+        "ENKIT_OVERRIDE_IDENTITY=@enfabrica.net",
+        "BAZEL_PROFILE=cloudbuild"
+      ]
+    }
+
+    timeout = "600s"
+
+    tags = [
+      "terraform-managed"
+    ]
+  }
+
+  tags = [
+    "terragorm-managed"
+  ]
+}


### PR DESCRIPTION
Effort for https://enfabrica.atlassian.net/browse/INFRA-920

Moving the bazel/terraform.bzl from internal repo - only the `terraform_library` and `terraform_apply` rules.

Adding cloudbuild terraform build for `Updates-the-enkit-version-in-the-internal-repository`