### PR TITLE
codegen: add support for "pkgdef" extension as well.

### DIFF
--- a/tools/codegen/codegen.bzl
+++ b/tools/codegen/codegen.bzl
@@ -33,7 +33,7 @@ codegen = rule(
     output_to_genfiles = True,  # so that header files can be found.
     attrs = {
         "data": attr.label_list(
-            allow_files = [".json", ".yaml"],
+            allow_files = [".json", ".yaml", ".pkgdef"],
             doc = "An ordered list of data files to load.",
         ),
         "outs": attr.output_list(

--- a/tools/codegen/tests/BUILD.bazel
+++ b/tools/codegen/tests/BUILD.bazel
@@ -10,3 +10,14 @@ codegen_test(
         "zoo=zebra",
     ],
 )
+
+codegen_test(
+    name = "d2-test",
+    srcs = ["test.template"],
+    data = ["d2.pkgdef"],
+    expected = "d2-test.expected",
+    overrides = [
+        "over=rides",
+        "zoo=zebra",
+    ],
+)

--- a/tools/codegen/tests/d2-test.expected
+++ b/tools/codegen/tests/d2-test.expected
@@ -1,0 +1,7 @@
+over=rides
+zoo=zebra
+foo=bar
+  bum: x
+  bum: y
+  bum: z
+

--- a/tools/codegen/tests/d2.pkgdef
+++ b/tools/codegen/tests/d2.pkgdef
@@ -1,0 +1,9 @@
+foo: bar
+bum:
+  - x
+  - y
+  - z
+bop:
+  a: aleph
+  b: boxcar
+  c: kappa


### PR DESCRIPTION
codegen: add support for "pkgdef" extension as well.

This is necessary to support upcoming https://github.com/enfabrica/internal/pull/4843

Tested: Existing tests pass.  Tested in PR 4843.

