### PR TITLE
WORKSPACE: Rename gtest to com_google_googletest

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -116,7 +116,7 @@ def stage_1():
     )
 
     maybe(
-        name = "gtest",
+        name = "com_google_googletest",
         repo_rule = http_archive,
         sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
         strip_prefix = "googletest-release-1.10.0",

--- a/proxy/nss/BUILD.bazel
+++ b/proxy/nss/BUILD.bazel
@@ -63,6 +63,6 @@ cc_test(
     deps = [
         ":nss_autouser-fortesting",
         "//proxy/nss/confparse",
-        "@gtest//:gtest_main",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/proxy/nss/confparse/BUILD.bazel
+++ b/proxy/nss/confparse/BUILD.bazel
@@ -37,6 +37,6 @@ cc_test(
     ],
     deps = [
         ":confparse",
-        "@gtest//:gtest_main",
+        "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
The gtest name is deprecated in favor of "com_google_googletest"; this change migrates enkit to the new name, so that downstream repositories don't need to import the latter themselves.

Jira: INFRA-1038