### PR TITLE
rules_docker: Update to v0.24.0

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -177,9 +177,9 @@ def stage_1():
     maybe(
         name = "io_bazel_rules_docker",
         repo_rule = http_archive,
-        sha256 = "85ffff62a4c22a74dbd98d05da6cf40f497344b3dbf1e1ab0a37ab2a1a6ca014",
-        strip_prefix = "rules_docker-0.23.0",
-        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.23.0/rules_docker-v0.23.0.tar.gz"],
+        sha256 = "27d53c1d646fc9537a70427ad7b034734d08a9c38924cc6357cc973fed300820",
+        strip_prefix = "rules_docker-0.24.0",
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.24.0/rules_docker-v0.24.0.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
This update to `rules_docker` fixes an issue in internal where a race in
the build causes a build error while building certain images.

Tested: Built internal with enkit overridden with this change:
http://buddy.bazel.corp.enfabrica.net/invocation/9eb0ec3c-19f0-490b-91e5-43cb33d8213e

Jira: INFRA-1038