### PR TITLE
wip: bundle a binary with its dynamic libraries for deployment in a VM

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -991,3 +991,31 @@ def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = 
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
     name_runner = mcreate_rule(name, runner, "", runner_cfg, kwargs, cfg)
+
+def _bundle(ctx):
+    out = []
+
+    for dep in ctx.attr.deps:
+        for f in dep.default_runfiles.files.to_list():
+            out.append(f)
+
+    d = files_to_dir(
+        ctx,
+        ctx.attr.name + "-root",
+        out,
+    )
+
+    return [
+        DefaultInfo(files = depset([d]))
+    ]
+
+bundle = rule(
+    implementation = _bundle,
+    attrs = {
+        "deps": attr.label_list(
+            mandatory = True,
+            providers = [],
+            doc = "",
+        ),
+    },
+)


### PR DESCRIPTION
Test:

Add the following in `ib/util/BUILD.bazel`:
```
load("@enkit//bazel/linux:defs.bzl", "bundle")
bundle(
    name = "bundle-sf_111",
    deps = [
        "//ib/apps:sf_111",
    ]
)
```

And run:
```
$ bazel build ib/util:bundle-sf_111 --override_repository=enkit=$(realpath ~/enkit)
$ (cd bazel-bin/ib/util/bundle-sf_111-root && find -type f)
...
./_solib_k8/_U@rdma-core_S_S_Crdma-core___Uexternal_Srdma-core_Srdma-core_Slib/libmlx5.so.1
./_solib_k8/_U@rdma-core_S_S_Crdma-core___Uexternal_Srdma-core_Srdma-core_Slib/libibverbs.so.1
./_solib_k8/_U@rdma-core_S_S_Crdma-core___Uexternal_Srdma-core_Srdma-core_Slib/libmlx4.so.1
./ib/apps/sf_111
```