### PR TITLE
bazel/linux: move and rename dir bundle.

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -1,0 +1,99 @@
+load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "RuntimeBundleInfo")
+load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible")
+load("//bazel/utils:messaging.bzl", "location", "package")
+load("//bazel/utils:files.bzl", "files_to_dir")
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _kunit_bundle(ctx):
+    ki = ctx.attr.image[KernelImageInfo]
+    mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
+    alldeps = expand_deps(ctx, mods, ctx.attr.depth)
+
+    commands = []
+    inputs = []
+    for kmod in alldeps:
+        commands += ["", "# module " + package(kmod.label)]
+        if kmod.setup:
+            commands += kmod.setup
+
+        for mod in kmod.files:
+            if mod.extension != "ko":
+                continue
+            commands.append("load " + mod.short_path)
+            inputs.append(mod)
+
+    init = ctx.actions.declare_file(ctx.attr.name + "-init.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._template_init,
+        output = init,
+        substitutions = {
+            "{relpath}": init.short_path,
+            "{commands}": "\n".join(commands),
+        },
+        is_executable = True,
+    )
+
+    check = ctx.actions.declare_file(ctx.attr.name + "-check.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._template_check,
+        output = check,
+        substitutions = {
+            "{parser}": ctx.executable._parser.short_path,
+        },
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(files = ctx.attr._parser.files.to_list())
+    runfiles = runfiles.merge(ctx.attr._parser.default_runfiles)
+
+    d = files_to_dir(
+        ctx,
+        ctx.attr.name + "-root",
+        inputs + [init],
+        post = "cd {dest}; cp -L %s ./init.sh" % (shell.quote(init.short_path)),
+    )
+    return [
+        DefaultInfo(files = depset([init, d, check]), runfiles = runfiles),
+        RuntimeBundleInfo(init = init.short_path, root = d.short_path, deps = [d], check = struct(
+            binary = check,
+            runfiles = runfiles,
+        )),
+    ]
+
+kunit_bundle = rule(
+    doc = """\
+Generates a directory containing the kernel modules, all their dependencies,
+and an init script to run them as a kunit test.""",
+    implementation = _kunit_bundle,
+    attrs = {
+        "module": attr.label(
+            mandatory = True,
+            providers = [KernelBundleInfo],
+            doc = "The label of the KUnit linux kernel module to be used for testing. It must define a kunit_test_suite so that when loaded, KUnit will start executing its tests.",
+        ),
+        "image": attr.label(
+            mandatory = True,
+            providers = [KernelImageInfo],
+            doc = "The label of a kernel image this test will run against. Important to select the correct architecture and package module.",
+        ),
+        "depth": attr.int(
+            default = 5,
+            doc = "Maximum recursive depth when expanding a list of kernel module dependencies.",
+        ),
+        "_template_init": attr.label(
+            allow_single_file = True,
+            default = Label("//bazel/linux:templates/init.template.sh"),
+            doc = "The template to generate the bash script used to run the tests.",
+        ),
+        "_template_check": attr.label(
+            allow_single_file = True,
+            default = Label("//bazel/linux:templates/check_kunit.template.sh"),
+            doc = "The template to generate the bash script used to run the tests.",
+        ),
+        "_parser": attr.label(
+            default = Label("//bazel/linux/kunit:kunit_zip"),
+            doc = "KUnit TAP output parser.",
+            executable = True,
+            cfg = "host",
+        ),
+    },
+)

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,5 +1,7 @@
 load("//bazel/linux:uml.bzl", "kernel_uml_run")
-load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimePackageInfo")
+load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimeBundleInfo")
+load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible", "is_module")
+load("//bazel/linux:bundles.bzl", "kunit_bundle")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
@@ -17,7 +19,6 @@ def _kernel_tree_version(ctx):
 
     else:
         fail("WORKSPACE repository {}: Provide either a URL, OR an astore path and UID".format(ctx.attr.name))
-
 
     install_script = "install-" + version + ".sh"
     install_script_path = ctx.path(install_script)
@@ -131,63 +132,6 @@ To create a .tar.gz suitable for this rule, you can use the kbuild tool, availab
         ),
     },
 )
-
-def is_module(dep):
-    """Returns True if this dependency is considered a kernel module."""
-    return KernelModulesInfo in dep or KernelBundleInfo in dep
-
-def is_compatible(arch, pkg, dep):
-    """Checks if the supplied KernelModulesInfo matches the parameters."""
-    if dep.package == pkg and dep.arch == arch:
-        return [dep]
-    return []
-
-def get_compatible(ctx, arch, pkg, dep):
-    """Extracts the set of compatible dependencies from a single dependency.
-
-    The same kernel module can be built against multiple kernel trees and
-    architectures. When that happens, it is packed in a KernelBundleInfo.
-
-    When a build has a dependency on a KernelBundleInfo or even a plain
-    kernel module through KernelModulesInfo, the build requires finding the
-    specific .ko .symvers files for linking - the ones matching the same kernel
-    and arch being built with the current target.
-
-    Given a dependency dep, either a KernelBundleInfo or a KernelModuleInfo,
-    this macro returns the set of KernelModuleInfo to build against, or
-    an error.
-
-    Args:
-      ctx: a bazel rule ctx, for error printing.
-      arch: string, desired architecture.
-      pkg: string, desired kernel package.
-      dep: a KernelModuleInfo or KernelBundleInfo to check.
-
-    Returns:
-      List of KernelModuleInfo to link against.
-    """
-    mods = []
-    builtfor = []
-    if KernelModulesInfo in dep:
-        di = dep[KernelModulesInfo]
-        mods.extend(is_compatible(arch, pkg, di))
-        builtfor.append((di.package, di.arch))
-
-    if KernelBundleInfo in dep:
-        for module in dep[KernelBundleInfo].modules:
-            mods.extend(is_compatible(arch, pkg, module))
-            builtfor.append((module.package, module.arch))
-
-    # Confirm that the kernel test module is compatible with the precompiled linux kernel executable image.
-    if not mods:
-        fail("\n\nERROR: " + location(ctx) + "requires {module} to be built for\n  kernel:{kernel} arch:{arch}\nBut it is only configured for:\n  {built}".format(
-            arch = arch,
-            kernel = pkg,
-            module = package(dep.label),
-            built = "\n  ".join(["kernel:{pkg} arch:{arch}".format(pkg = pkg, arch = arch) for pkg, arch in builtfor]),
-        ))
-
-    return mods
 
 def _kernel_modules(ctx):
     modules = ctx.attr.modules
@@ -835,168 +779,12 @@ To create an image suitable for this rule, you can compile a linux source tree u
     },
 )
 
-def _expand_deps(ctx, mods, depth):
-    """Recursively expands the dependencies of a module.
-
-    Args:
-      ctx: a Bazel ctx object, used to print useful error messages.
-      mods: list of KernelModulesInfo, modules to compute the dependencies of.
-      depth: int, how deep to go in recursively expanding the list of modules.
-
-    Returns:
-      List of KernelModulesInfo de-duplicated, in an order where insmod
-      as a chance to successfully resolve the dependencies.
-    """
-    error = """ERROR:
-
-While recurisvely expanding the chain of 'kdeps' for the module,
-at {depth} iterations there were still dependencies to expand.
-Loop? Or adjust the 'depth = ' attribute setting the max.
-
-The modules computed to load so far are:
-  {expanded}
-
-The modules still to expand are:
-  {current}
-"""
-    alldeps = list(mods)
-    current = list(mods)
-
-    for it in range(depth):
-        pending = []
-        for mi in current:
-            for kdep in mi.kdeps:
-                pending.append(kdep)
-
-        alldeps.extend(pending)
-        current = pending
-
-        # Error out if we still have not expanded the full set of
-        # dependencies at the last iteration.
-        if current and it >= depth - 1:
-            fail(location(ctx) + error.format(
-                depth = depth,
-                expanded = [package(d.label) for d in alldeps],
-                current = [package(d.label) for d in current],
-            ))
-
-    # alldeps here lists all the recurisve dependencies of the supplied
-    # mods starting from the module themselves.
-    #
-    # But... kernel module loading requires having the dependencies loaded
-    # first. insmod may also fail if a module is loaded twice.
-    #
-    # So: reverse the list, remove duplicates.
-    dups = {}
-    result = []
-    for mod in reversed(alldeps):
-        key = package(mod.label)
-        if key in dups:
-            continue
-        result.append(mod)
-
-    return result
-
-def _kernel_test_dir(ctx):
-    ki = ctx.attr.image[KernelImageInfo]
-    mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
-    alldeps = _expand_deps(ctx, mods, ctx.attr.depth)
-
-    commands = []
-    inputs = []
-    for kmod in alldeps:
-        commands += ["", "# module " + package(kmod.label)]
-        if kmod.setup:
-            commands += kmod.setup
-
-        for mod in kmod.files:
-            if mod.extension != "ko":
-                continue
-            commands.append("load " + mod.short_path)
-            inputs.append(mod)
-
-    init = ctx.actions.declare_file(ctx.attr.name + "-init.sh")
-    ctx.actions.expand_template(
-        template = ctx.file._template_init,
-        output = init,
-        substitutions = {
-            "{relpath}": init.short_path,
-            "{commands}": "\n".join(commands),
-        },
-        is_executable = True,
-    )
-
-    check = ctx.actions.declare_file(ctx.attr.name + "-check.sh")
-    ctx.actions.expand_template(
-        template = ctx.file._template_check,
-        output = check,
-        substitutions = {
-            "{parser}": ctx.executable._parser.short_path,
-        },
-        is_executable = True,
-    )
-    runfiles = ctx.runfiles(files = ctx.attr._parser.files.to_list())
-    runfiles = runfiles.merge(ctx.attr._parser.default_runfiles)
-
-    d = files_to_dir(
-        ctx,
-        ctx.attr.name + "-root",
-        inputs + [init],
-        post = "cd {dest}; cp -L %s ./init.sh" % (shell.quote(init.short_path)),
-    )
-    return [
-        DefaultInfo(files = depset([init, d, check]), runfiles = runfiles),
-        RuntimePackageInfo(init = init.short_path, root = d.short_path, deps = [d], check = struct(
-            binary = check,
-            runfiles = runfiles,
-        )),
-    ]
-
-kernel_test_dir = rule(
-    doc = """\
-Generates a directory containing the kernel module, all its dependencies,
-and an init script to run them as a kunit test.""",
-    implementation = _kernel_test_dir,
-    attrs = {
-        "module": attr.label(
-            mandatory = True,
-            providers = [KernelBundleInfo],
-            doc = "The label of the KUnit linux kernel module to be used for testing. It must define a kunit_test_suite so that when loaded, KUnit will start executing its tests.",
-        ),
-        "image": attr.label(
-            mandatory = True,
-            providers = [KernelImageInfo],
-            doc = "The label of a kernel image this test will run against. Important to select the correct architecture and package module.",
-        ),
-        "depth": attr.int(
-            default = 5,
-            doc = "Maximum recursive depth when expanding a list of kernel module dependencies.",
-        ),
-        "_template_init": attr.label(
-            allow_single_file = True,
-            default = Label("//bazel/linux:templates/init.template.sh"),
-            doc = "The template to generate the bash script used to run the tests.",
-        ),
-        "_template_check": attr.label(
-            allow_single_file = True,
-            default = Label("//bazel/linux:templates/check_kunit.template.sh"),
-            doc = "The template to generate the bash script used to run the tests.",
-        ),
-        "_parser": attr.label(
-            default = Label("//bazel/linux/kunit:kunit_zip"),
-            doc = "KUnit TAP output parser.",
-            executable = True,
-            cfg = "host",
-        ),
-    },
-)
-
-def kernel_test(name, kernel_image, module, rootfs_image = None, test_dir_cfg = {}, runner_cfg = {}, runner = kernel_uml_run, **kwargs):
+def kernel_test(name, kernel_image, module, rootfs_image = None, kunit_bundle_cfg = {}, runner_cfg = {}, runner = kernel_uml_run, **kwargs):
     runtime = mcreate_rule(
         name,
-        kernel_test_dir,
+        kunit_bundle,
         "runtime",
-        test_dir_cfg,
+        kunit_bundle_cfg,
         kwargs,
         mconfig(module = module, image = kernel_image),
     )

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -55,7 +55,7 @@ and have basic tools available necessary for its users.
     },
 )
 
-RuntimePackageInfo = provider(
+RuntimeBundleInfo = provider(
     doc = """Represents something to run in an isolated environment.""",
     fields = {
         "init": "string, path relative to root, script to run in the environment once it is ready, typically as an init=",

--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -81,7 +81,7 @@ kernel_qemu_run = rule(
 
 The code to run is specified by using the "runner" attribute, which
 pretty much provides a self contained directory with an init script.
-See the RuntimePackageInfo provider for details.
+See the RuntimeBundleInfo provider for details.
 """,
     implementation = _kernel_qemu_run,
     executable = True,

--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -1,4 +1,4 @@
-load("//bazel/linux:providers.bzl", "KernelImageInfo", "RootfsImageInfo", "RuntimePackageInfo")
+load("//bazel/linux:providers.bzl", "KernelImageInfo", "RootfsImageInfo", "RuntimeBundleInfo")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
@@ -20,8 +20,8 @@ If not specified, the current root of the filesystem will be used as rootfs.
     ),
     "runtime": attr.label(
         mandatory = True,
-        providers = [RuntimePackageInfo],
-        doc = "A target returning a RuntimePackageInfo, with commands to run in the emulator.",
+        providers = [RuntimeBundleInfo],
+        doc = "A target returning a RuntimeBundleInfo, with commands to run in the emulator.",
     ),
     "_template": attr.label(
         allow_single_file = True,
@@ -52,7 +52,7 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
         rootfs = ctx.attr.rootfs_image[RootfsImageInfo].image.short_path
         inputs = depset(transitive = [inputs, ctx.attr.rootfs_image.files])
 
-    runtime = ctx.attr.runtime[RuntimePackageInfo]
+    runtime = ctx.attr.runtime[RuntimeBundleInfo]
     subs = dict({
         "target": package(ctx.label),
         "kernel": ki.image.short_path,

--- a/bazel/linux/uml.bzl
+++ b/bazel/linux/uml.bzl
@@ -41,7 +41,7 @@ kernel_uml_run = rule(
 
 The code to run is specified by using the "runner" attribute, which
 pretty much provides a self contained directory with an init script.
-See the RuntimePackageInfo provider for details.
+See the RuntimeBundleInfo provider for details.
 """,
     implementation = _kernel_uml_run,
     attrs = CREATE_RUNNER_ATTRS,

--- a/bazel/linux/utils.bzl
+++ b/bazel/linux/utils.bzl
@@ -1,0 +1,121 @@
+load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimeBundleInfo")
+load("//bazel/utils:messaging.bzl", "location", "package")
+
+def is_module(dep):
+    """Returns True if this dependency is considered a kernel module."""
+    return KernelModulesInfo in dep or KernelBundleInfo in dep
+
+def is_compatible(arch, pkg, dep):
+    """Checks if the supplied KernelModulesInfo matches the parameters."""
+    if dep.package == pkg and dep.arch == arch:
+        return [dep]
+    return []
+
+def get_compatible(ctx, arch, pkg, dep):
+    """Extracts the set of compatible dependencies from a single dependency.
+
+    The same kernel module can be built against multiple kernel trees and
+    architectures. When that happens, it is packed in a KernelBundleInfo.
+
+    When a build has a dependency on a KernelBundleInfo or even a plain
+    kernel module through KernelModulesInfo, the build requires finding the
+    specific .ko .symvers files for linking - the ones matching the same kernel
+    and arch being built with the current target.
+
+    Given a dependency dep, either a KernelBundleInfo or a KernelModuleInfo,
+    this macro returns the set of KernelModuleInfo to build against, or
+    an error.
+
+    Args:
+      ctx: a bazel rule ctx, for error printing.
+      arch: string, desired architecture.
+      pkg: string, desired kernel package.
+      dep: a KernelModuleInfo or KernelBundleInfo to check.
+
+    Returns:
+      List of KernelModuleInfo to link against.
+    """
+    mods = []
+    builtfor = []
+    if KernelModulesInfo in dep:
+        di = dep[KernelModulesInfo]
+        mods.extend(is_compatible(arch, pkg, di))
+        builtfor.append((di.package, di.arch))
+
+    if KernelBundleInfo in dep:
+        for module in dep[KernelBundleInfo].modules:
+            mods.extend(is_compatible(arch, pkg, module))
+            builtfor.append((module.package, module.arch))
+
+    # Confirm that the kernel test module is compatible with the precompiled linux kernel executable image.
+    if not mods:
+        fail("\n\nERROR: " + location(ctx) + "requires {module} to be built for\n  kernel:{kernel} arch:{arch}\nBut it is only configured for:\n  {built}".format(
+            arch = arch,
+            kernel = pkg,
+            module = package(dep.label),
+            built = "\n  ".join(["kernel:{pkg} arch:{arch}".format(pkg = pkg, arch = arch) for pkg, arch in builtfor]),
+        ))
+
+    return mods
+
+def expand_deps(ctx, mods, depth):
+    """Recursively expands the dependencies of a module.
+
+    Args:
+      ctx: a Bazel ctx object, used to print useful error messages.
+      mods: list of KernelModulesInfo, modules to compute the dependencies of.
+      depth: int, how deep to go in recursively expanding the list of modules.
+
+    Returns:
+      List of KernelModulesInfo de-duplicated, in an order where insmod
+      as a chance to successfully resolve the dependencies.
+    """
+    error = """ERROR:
+
+While recurisvely expanding the chain of 'kdeps' for the module,
+at {depth} iterations there were still dependencies to expand.
+Loop? Or adjust the 'depth = ' attribute setting the max.
+
+The modules computed to load so far are:
+  {expanded}
+
+The modules still to expand are:
+  {current}
+"""
+    alldeps = list(mods)
+    current = list(mods)
+
+    for it in range(depth):
+        pending = []
+        for mi in current:
+            for kdep in mi.kdeps:
+                pending.append(kdep)
+
+        alldeps.extend(pending)
+        current = pending
+
+        # Error out if we still have not expanded the full set of
+        # dependencies at the last iteration.
+        if current and it >= depth - 1:
+            fail(location(ctx) + error.format(
+                depth = depth,
+                expanded = [package(d.label) for d in alldeps],
+                current = [package(d.label) for d in current],
+            ))
+
+    # alldeps here lists all the recurisve dependencies of the supplied
+    # mods starting from the module themselves.
+    #
+    # But... kernel module loading requires having the dependencies loaded
+    # first. insmod may also fail if a module is loaded twice.
+    #
+    # So: reverse the list, remove duplicates.
+    dups = {}
+    result = []
+    for mod in reversed(alldeps):
+        key = package(mod.label)
+        if key in dups:
+            continue
+        result.append(mod)
+
+    return result


### PR DESCRIPTION
Background:
RuntimeInfo is not really representative of what the provider does.
The _dir rule... is kunit specific.
defs.bzl is too big.

In this change:
- move the kunit dir rule into bundles.bzl, rename it appropriately.
- rename the provider from RuntimePackageInfo to RuntimeBundleInfo.
- to avoid circular dependencies between files, create a utils.bzl
  and move a few functions there. This is a bit unfortunate, but
  as we break down defs.bzl further, it'll improve.
