### PR TITLE
astore: Fix bug with astore_download_and_extract implementation

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -170,12 +170,19 @@ def astore_download_and_extract(ctx, digest, stripPrefix):
     ctx.extract(
         archive = f,
         output = ".",
-        stripPrefix = "",
+        stripPrefix = stripPrefix,
     )
     ctx.delete(f)
 
+# This wrapper is in place to allow a rolling upgrade across Enkit and the
+# external repositories which consume the kernel_tree_version rule defined in
+# //enkit/linux/defs.bzl, which uses "sha256" as the attribute name instead of
+# "digest".
+def _astore_download_and_extract_impl(ctx):
+    astore_download_and_extract(ctx, ctx.attr.digest, ctx.attr.strip_prefix)
+
 astore_package = repository_rule(
-    implementation = astore_download_and_extract,
+    implementation = _astore_download_and_extract_impl,
     attrs = {
         "path": attr.string(
             doc = "Path to the object in astore.",
@@ -186,8 +193,11 @@ astore_package = repository_rule(
             mandatory = True,
         ),
         "digest": attr.string(
-            doc = "SHA256 digest of the object",
+            doc = "SHA256 digest of the object.",
             mandatory = True,
+        ),
+        "strip_prefix": attr.string(
+            doc = "Optional path prefix to strip out of the archive.",
         ),
     },
 )


### PR DESCRIPTION
A repository rule's implementation only gets the ctx object as a
parameter, and this commit fixes that with a wrapper function. In a
perfect world, we would pass any attribute needed in via ctx.attr, but
like noted in the inline comment, kernel_tree_version uses "sha256" in
place of "digest", and changing it now would break external consumers of
the rule and a rolling update will not be feasible. Longer-term, this
wrapper should be replaced with a dict of attributes for the various
consumers of the common function.

The commit also introduces a strip_prefix attribute for the general
astore_package rule.

Tested manually with both astore_package consumers (which was missed
with cdf318cf0) and kernel_tree_version consumers (with and without an
authenticated download).

Signed-off-by: Raghu Raja <raghu@enfabrica.net>