### PR TITLE
kbuild: enable tagging of kernel artifacts in astore

### DIFF
--- a/kbuild/v2/scripts/lib.sh
+++ b/kbuild/v2/scripts/lib.sh
@@ -46,8 +46,7 @@ upload_artifact() {
     fi
 
     # upload archive to astore
-    # TODO: add '-t "$tag"' after INFRA-1047 is fixed.
-    enkit astore upload "${archive}@${astore_path}" -a $arch
+    enkit astore upload "${archive}@${astore_path}" -a $arch -t "$tag"
 
     echo "Upload sha256sum:"
     sha256sum "$archive"


### PR DESCRIPTION
Since INFRA-1047 is fixed we can enable tagging the kernel artifacts
in astore.  Each kernel artifact now has a "kernel=<kernel_version>"
tag.