### PR TITLE
gee rmbr: also delete bazel cache

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3822,6 +3822,16 @@ function gee__remove_branch() {
   local SHA
   SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
 
+  # delete the bazel cache associated with this worktree
+  if [[ -h ./bazel-out ]]; then
+    local BAZELCACHE
+    BAZELCACHE="$(readlink -f ./bazel-out)"
+    BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"
+    _info "Removing linked bazel cache directory \"${BAZELCACHE}\""
+    chmod -R u+w "${BAZELCACHE}"
+    rm -rf "${BAZELCACHE}"
+  fi
+
   _checkout_or_die "${MAIN}"
   # --force is required for git v2.17.1, or the remove operation will always fail.
   _git worktree remove --force "${BR}"

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Unreleased
+
+* #594: `gee rmbr` now also removes bazel cache directory.
+
 ### Release 0.2.29
 
 * Streamling PR submission, and make the PR description template more terse.


### PR DESCRIPTION
bazel creates a unique cache directory for each worktree directory.  These
cache directories are often quite large and exhaust disk space on shared
machines.  It was suggested that it might save disk space to delete this cache
whenever a worktree/branch is deleted.  This PR implements this suggestion.

Tested: Ran `gee rmbr` on an old branch, verified the right cache directory was deleted.

```
# gcd quicktest
$ ls -ld bazel-out
lrwxrwxrwx 1 jonathan kvmext 105 Apr 11 14:56 bazel-out -> /home/jonathan/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da/execroot/enfabrica/bazel-out
$ du -sh ~/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da/
674M    /home/jonathan/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da/
$ gcd master
$ ~/gee/enkit/gee_rm_bazel_cache/scripts/gee rmbr quicktest

######################
# Deleting quicktest #
######################
WARNING: Branch "quicktest" contains uncommitted changes.
Are you sure you want to force-remove branch quicktest? (y/N) y
Whatever you say, boss.
Removing linked bazel cache directory "/home/jonathan/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da"
CMD: /usr/bin/git worktree remove --force quicktest
CMD: /usr/bin/git branch -D quicktest
Deleted branch quicktest (was 092b6a889).
Not deleting remote branch quicktest: was never created.
Deleted quicktest.  To undo: gee make_branch quicktest 092b6a889
(int:master S=5) [549] ~/gee/internal/master
$ du -sh ~/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da/
du: cannot access '/home/jonathan/.cache/bazel/_bazel_jonathan/a23fa97ce46f53d20a55a7f9115bd9da/': No such file or directory
```

