### PR TITLE
astore: Check for build attribute before using it

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -174,7 +174,7 @@ def astore_download_and_extract(ctx, digest, stripPrefix):
     )
     ctx.delete(f)
 
-    if ctx.attr.build:
+    if hasattr(ctx.attr, "build") and ctx.attr.build:
         ctx.template("BUILD.bazel", ctx.attr.build)
 
 # This wrapper is in place to allow a rolling upgrade across Enkit and the


### PR DESCRIPTION
6c19853 introduced a build attribute to the astore_download_and_extract
repository rule. The implementation function is also used by other rules
that do not have this attribute in the context. The commit checks for
availabilty before using it.

Signed-off-by: Raghu Raja <raghu@enfabrica.net>

--- 

Tested with both repo rules that use this function.