### PR TITLE
kbuild: combine vmlinuz and modules.tar.gz into a single artifact

### DIFF
--- a/kbuild/v2/README.adoc
+++ b/kbuild/v2/README.adoc
@@ -106,6 +106,12 @@ following arguments:
     -a   Install APT sources.list.d config
 ```
 
+=== Tarball of Kernel Image and Modules
+
+This is a tarball of the kernel vmlinuz image and all the modules from
+`lib/modules/<kernel-version>`.  This tarball is used by bazel to run
+tests using QEMU.
+
 === UML Kernel Image
 
 The script also publishes a UML kernel image to astore.  Bazel uses

--- a/kbuild/v2/scripts/build-uml.sh
+++ b/kbuild/v2/scripts/build-uml.sh
@@ -55,13 +55,3 @@ make ARCH=um O="$OUTPUT_UML_DIR" olddefconfig
 
 # Build the kernel with our LOCAL version
 make -j ARCH=um O="$OUTPUT_UML_DIR" LOCALVERSION="$kernel_version" all
-
-# Install the modules
-make ARCH=um O="$OUTPUT_UML_DIR" LOCALVERSION="$kernel_version" \
-     INSTALL_MOD_PATH="$MOD_INSTALL" modules_install
-
-rm -f "${MOD_INSTALL}/source" "${MOD_INSTALL}/build"
-
-# Create modules.tar.gz
-modules_tar="${OUTPUT_UML_DIR}/modules.tar.gz"
-tar -C "$MOD_INSTALL" --owner root --group root --create --gzip --file "$modules_tar" .

--- a/kbuild/v2/scripts/upload-uml.sh
+++ b/kbuild/v2/scripts/upload-uml.sh
@@ -30,12 +30,8 @@ if [ ! -r "$archive_src" ] ; then
 fi
 archive_astore_dest="${ASTORE_ROOT}/test/build-headers.tar.gz"
 
-modules_tar="${OUTPUT_UML_DIR}/modules.tar.gz"
-modules_astore_dest="${ASTORE_ROOT}/test/modules.tar.gz"
-
 kernel_version="$(cat ${OUTPUT_UML_DIR}/include/config/kernel.release)"
 tag="kernel=$kernel_version"
 
 upload_artifact "$uml_image_src" "$uml_image_astore_dest" "um" "$tag"
 upload_artifact "$archive_src"   "$archive_astore_dest"   "um" "$tag"
-upload_artifact "$modules_tar"   "$modules_astore_dest"   "um" "$tag"


### PR DESCRIPTION
This patch combines the vmlinuz kernel image and the modules.tar.gz
artifacts into a single artifact, called `vmlinuz-modules.tar.gz`.

The format of the tarball is:

``` text
  boot/vmlinuz-<kernel-version>
  lib/modules/<kernel-version>/...
```

This patch also removes the `modules.tar.gz` for the UML variant as it
is not needed.