### PR TITLE
enkit-astore: add meta-data output command line flags

### DIFF
--- a/astore/client/commands/BUILD.bazel
+++ b/astore/client/commands/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//lib/client:go_default_library",
         "//lib/config:go_default_library",
         "//lib/config/defcon:go_default_library",
+        "//lib/config/marshal:go_default_library",
         "//lib/kflags:go_default_library",
         "//lib/kflags/kcobra:go_default_library",
         "@com_github_dustin_go_humanize//:go_default_library",

--- a/astore/client/commands/BUILD.bazel
+++ b/astore/client/commands/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -30,4 +30,13 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "formatter_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/astore/client/commands/formatter_test.go
+++ b/astore/client/commands/formatter_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enfabrica/enkit/astore/rpc/astore"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalFormat(t *testing.T) {
+	artifact := astore.Artifact {
+		Created: 1234,
+		Creator: "Friedrich Nietzsche",
+		Architecture: "amd64",
+		MD5: []byte{102, 97, 108, 99, 111, 110},
+		Uid: "uid-string",
+		Sid: "sid-string",
+		Tag: []string{"tag1", "tag2"},
+		Note: "note1",
+	}
+
+	element := astore.Element {
+		Created: 1234,
+		Creator: "Friedrich Nietzsche",
+		Name: "foo-element",
+	}
+
+	dir, err := ioutil.TempDir("", "test-marshal")
+	assert.NoError(t, err)
+
+	for _, ext := range []string{ "json", "yaml" } {
+		root := NewRoot(nil)
+		root.outputFile = filepath.Join(dir, "test." + ext)
+
+		formatter := root.Formatter()
+		formatter.Artifact(&artifact)
+		formatter.Element(&element)
+		formatter.Flush()
+
+		// check that the destination was created
+		_, err = os.Open(root.outputFile)
+		assert.NoError(t, err)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/enfabrica/enkit
 go 1.16
 
 require (
-	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect
+	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05
 	cloud.google.com/go/bigquery v1.28.0 // indirect
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/datastore v1.1.0
@@ -14,6 +14,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e
+	github.com/bazelbuild/rules_go v0.32.0
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/containerd/containerd v1.4.3 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible
@@ -40,6 +41,7 @@ require (
 	github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547 // indirect
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.3.0
@@ -50,15 +52,16 @@ require (
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/klauspost/cpuid v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pelletier/go-toml v1.8.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
-	github.com/prashantv/gostub v1.0.0 // indirect
+	github.com/prashantv/gostub v1.0.0
 	github.com/prometheus/client_golang v1.12.1
-	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef // indirect
+	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 // indirect
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.8.1/go.mod h1:CM+19rL1+4dFWnO
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e h1:VMFMISXa1RypQNG0j4KVCbsUcrxFudkY/IvWzEJCyO8=
 github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
+github.com/bazelbuild/rules_go v0.32.0 h1:2DmbGvRnmGUTIn9upKuly/8Wg3/HNKesliVPWKnrtZU=
+github.com/bazelbuild/rules_go v0.32.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
@@ -700,6 +702,7 @@ github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.0 h1:wJbzvpYMVGG9iTI9VxpnNZfd4DzMPoCWze3GgSqz8yg=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=


### PR DESCRIPTION
This patch adds two command line options to the `enkit astore`
commands for formatting the output of artifact meta-data.

```
  -m, --meta-file string       Meta-data output file (default "-")
  -f, --meta-format string     Meta-data output format. One of [text, json] (default "text")
```

These options can be used with any astore command that outputs
artifact meta data, including:

- astore ls
- astore note
- astore download
- astore tag
- astore public
- astore upload

Running the `enkit astore ls` command with JSON output to stdout,
piped through `jq .`, looks like this:

```json
$ bazel run //enkit:enkit -- astore ls kernel/enf/impish-19.19/minimal/build-headers.tar.gz -l -f json | jq .

[                                                                                                                                                   [85/35147]
  {
    "created": 1651805121388725000,
    "creator": "david@enfabrica.net",
    "arch": "amd64",
    "md5": "853102bbcb3a6cf0305d87a11173f9bf",
    "sid": "2h/ny/tq6foqdrtudojw35dmkx4cz846vq",
    "uid": "yqeikizdt6ofyc4uxt46cxbiiwz6gokt",
    "size": 13229515,
    "note": "",
    "tags": [
      "latest"
    ]
  },
  {
    "created": 1651190180548809000,
    "creator": "david@enfabrica.net",
    "arch": "amd64",
    "md5": "430aaeb5e1facead28969bd23a4f4b12",
    "sid": "2n/e2/4orwcghvvnnv6ew3rhfbj8nb8pqg",
    "uid": "osedtx3766kkg6mnx8bh2iwp3i52bayh",
    "size": 13227673,
    "note": "",
    "tags": []
  },
  {
    "created": 1651189530301254000,
    "creator": "david@enfabrica.net",
    "arch": "amd64",
    "md5": "430aaeb5e1facead28969bd23a4f4b12",
    "sid": "st/7w/3wjipb27swx7t8svfux5j6k7rgk5",
    "uid": "gvomb82d278txu6ud8pof47vwjzk44c4",
    "size": 13227673,
    "note": "",
    "tags": []
  }
]
```

Fixes:  INFRA-1039