### PR TITLE
bazel/linux: fix for modprobe

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -9,7 +9,11 @@ def _kunit_bundle(ctx):
     mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
     alldeps = expand_deps(ctx, mods, ctx.attr.depth)
 
-    commands = []
+    commands = [
+        # modprobe does not work correctly without /sys
+        "mount -t sysfs sysfs /sys",
+    ]
+
     inputs = []
     for kmod in alldeps:
         commands += ["", "# module " + package(kmod.label)]


### PR DESCRIPTION
modprobe does not work correctly without a proper /sys: if a module is
already loaded on the host, then modprobe will erroneously see it loaded
in the guest as well because it accesses the /sys of the host.

Signed-off-by: George Prekas <george@enfabrica.net>