### PR TITLE
kbuild: generate artifact meta-data file suitable for bazel

### DIFF
--- a/kbuild/v2/README.adoc
+++ b/kbuild/v2/README.adoc
@@ -7,22 +7,35 @@ astore.
 
 == TL;DR -- Building For Production
 
-To publish the kernel artifacts to production, run `kpub-astore` like
-this:
+Current as of 05/16/2022:
+
+To publish the kernel artifacts, run `kpub-astore` like this:
 
 ```
-  $ kpub-astore -b <kernel_branch> -a kernel
+  $ kpub-astore -b enf/impish-19.19 -l ENF_UBUNTU_IMPISH -a kernel
 ```
 
-For example, to build and release the `enf/impish-19.19` branch do
-this:
+The `-b` option specifies the git branch in the kernel tree. Here we
+are using `enf/impish-19.19`.
+
+The `-l` option specifies the Bazel kernel label, which is used to
+form various Bazel variables.  Here we are using `ENF_UBUNTU_IMPISH`.
+
+The `-a` option specifies the root path in astore.  For a kernel
+flavour, the artifacts are published to
+`<astore_root>/<git-branch>/<flavour>`.  Here we are using the
+production path `kernel`, which will publish artifacts to the
+following paths:
 
 ```
-  $ kpub-astore -b enf/impish-19.19 -a kernel
-```
+- kernel/enf/impish-19.19/generic  (Ubuntu generic)
+- kernel/enf/impish-19.19/minimal  (Ubuntu minimal)
+- kernel/enf/impish-19.19/test     (UML)
 
-The "kernel" path in astore is the root of all the published kernel
-artifacts.  See `kpub-astore -h` for more options to control the build.
+The build outputs a Bazel file, suitable for checking into the
+internal repo in `bazel/kernel.version.bzl`.
+
+See `kpub-astore -h` for more options to control the build.
 
 == Build Time Dependencies
 

--- a/kbuild/v2/kpub-astore
+++ b/kbuild/v2/kpub-astore
@@ -19,8 +19,14 @@ DEFAULT_KERNEL_FLAVOURS="minimal generic"
 # BUILD_ROOT -- scratch space to perform the build
 DEFAULT_BUILD_ROOT="${HOME}/scratch/kernel-builder"
 
+# ENKIT -- enkit binary to use
+DEFAULT_ENKIT="enkit"
+
 # ASTORE_ROOT -- root directory in astore to store outputs
 DEFAULT_ASTORE_ROOT="home/${USER}/scratch/kernel"
+
+# KERNEL_LABEL: label to use for creating BAZEL variable names
+DEFAULT_KERNEL_LABEL="ENF_UBUNTU_IMPISH"
 
 # CLEAN_BUILD -- whether to wipe the build directory first Set
 # CLEAN_BUILD to "no" to skip some lengthy steps during development.
@@ -37,7 +43,9 @@ RT_KERNEL_REPO="${ENF_KERNEL_REPO:-${DEFAULT_KERNEL_REPO}}"
 RT_KERNEL_BRANCH="${ENF_KERNEL_BRANCH:-${DEFAULT_KERNEL_BRANCH}}"
 RT_KERNEL_FLAVOURS="${ENF_KERNEL_FLAVOURS:-${DEFAULT_KERNEL_FLAVOURS}}"
 RT_BUILD_ROOT="${ENF_BUILD_ROOT:-${DEFAULT_BUILD_ROOT}}"
+RT_ENKIT="${ENF_ENKIT:-${DEFAULT_ENKIT}}"
 RT_ASTORE_ROOT="${ENF_ASTORE_ROOT:-${DEFAULT_ASTORE_ROOT}}"
+RT_KERNEL_LABEL="${ENF_KERNEL_LABEL:-${DEFAULT_KERNEL_LABEL}}"
 RT_CLEAN_BUILD="${ENF_CLEAN_BUILD:-${DEFAULT_CLEAN_BUILD}}"
 RT_VERBOSE="${ENF_VERBOSE:-${DEFAULT_VERBOSE}}"
 
@@ -78,11 +86,24 @@ OPTIONS:
 
 		The default is "$DEFAULT_BUILD_ROOT".
 
+    -e enkit binary to use
+
+		The path to the enkit binary to use.
+
+		The default is "$DEFAULT_ENKIT".
+
     -a astore root directory
 
 		The root directory within astore to publish artifacts.
 
 		The default is "$DEFAULT_ASTORE_ROOT".
+
+    -l kernel label
+
+		A label used to create BAZEL variables, e.g.
+		KERNEL_TREE_<label>_<flavour> and KERNEL_IMAGE_<label>_<flavour>.
+
+		The default is "$DEFAULT_KERNEL_LABEL".
 
     -p
 
@@ -105,7 +126,9 @@ The above options can also be set via environment variables:
 ENF_KERNEL_REPO:      (current_value: ${ENF_KERNEL_REPO:-unset})
 ENF_KERNEL_BRANCH:    (current_value: ${ENF_KERNEL_BRANCH:-unset})
 ENF_KERNEL_FLAVOURS:  (current_value: ${ENF_KERNEL_FLAVOURS:-unset})
+ENF_KERNEL_LABEL:     (current_value: ${ENF_KERNEL_LABEL:-unset})
 ENF_BUILD_ROOT:	      (current_value: ${ENF_BUILD_ROOT:-unset})
+ENF_ENKIT:            (current_value: ${ENF_ENKIT:-unset})
 ENF_ASTORE_ROOT:      (current_value: ${ENF_ASTORE_ROOT:-unset})
 
 In all cases, the command line arguments take precedence.
@@ -114,7 +137,7 @@ EOF
 }
 
 # Command line argument override any environment variables
-while getopts hvpr:b:f:o:a: opt ; do
+while getopts hvpr:b:f:o:e:a:l: opt ; do
     case $opt in
         r)
             RT_KERNEL_REPO=$OPTARG
@@ -128,8 +151,14 @@ while getopts hvpr:b:f:o:a: opt ; do
         o)
             RT_BUILD_ROOT=$OPTARG
             ;;
+        e)
+            RT_ENKIT=$OPTARG
+            ;;
         a)
             RT_ASTORE_ROOT=$OPTARG
+            ;;
+        l)
+            RT_KERNEL_LABEL=$OPTARG
             ;;
         p)
             RT_CLEAN_BUILD="no"
@@ -150,7 +179,8 @@ done
 shift `expr $OPTIND - 1`
 
 echo "Using configuration:"
-for var in RT_KERNEL_REPO RT_KERNEL_BRANCH RT_KERNEL_FLAVOURS RT_BUILD_ROOT RT_ASTORE_ROOT RT_CLEAN_BUILD RT_VERBOSE; do
+for var in RT_KERNEL_REPO RT_KERNEL_BRANCH RT_KERNEL_FLAVOURS RT_KERNEL_LABEL \
+       RT_BUILD_ROOT RT_ENKIT RT_ASTORE_ROOT RT_CLEAN_BUILD RT_VERBOSE; do
     printf "%-20s:   %s\n" "$var" "$(eval echo -n \$$var)"
 done
 
@@ -158,6 +188,12 @@ if [ "$RT_VERBOSE" = "yes" ] ; then
     set -x
     RUN="/bin/sh -x"
 fi
+
+if ! which "$RT_ENKIT" > /dev/null 2>&1 ; then
+    echo "ERROR: unable to find enkit binary: $RT_ENKIT"
+    exit 1
+fi
+export RT_ENKIT
 
 ASTORE_BASE="${RT_ASTORE_ROOT}/${RT_KERNEL_BRANCH}"
 
@@ -175,11 +211,12 @@ OUTPUT_DEB_DIR="$RT_BUILD_ROOT/deb"
 OUTPUT_REPO_DIR="$RT_BUILD_ROOT/repo"
 OUTPUT_BAZEL_ARCHIVE_DIR="$RT_BUILD_ROOT/bazel-archive"
 OUTPUT_APT_ARCHIVE_DIR="$RT_BUILD_ROOT/deb-archive"
+OUTPUT_ASTORE_META_DIR="$RT_BUILD_ROOT/astore-meta"
 
 OUTPUT_UML_DIR="$RT_BUILD_ROOT/uml"
 OUTPUT_UML_BAZEL_ARCHIVE_DIR="$RT_BUILD_ROOT/uml/bazel"
 
-mkdir -p "$KERNEL_DIR"
+mkdir -p "$KERNEL_DIR" "$OUTPUT_ASTORE_META_DIR"
 
 # Initialize the build area and clone the kernel repo
 $RUN ${SCRIPT_PATH}/init-build.sh "$KERNEL_DIR" "$RT_KERNEL_REPO" "$RT_KERNEL_BRANCH" "$KERNEL_VERSION"
@@ -197,7 +234,13 @@ $RUN ${SCRIPT_PATH}/archive-bazel-deb.sh "$OUTPUT_DEB_DIR" "$RT_KERNEL_FLAVOURS"
 $RUN ${SCRIPT_PATH}/archive-deb.sh "$OUTPUT_DEB_DIR" "$OUTPUT_REPO_DIR" "$RT_KERNEL_FLAVOURS" "$OUTPUT_APT_ARCHIVE_DIR"
 
 # Uploads the bazel ready tarball for each flavour
-$RUN ${SCRIPT_PATH}/upload-deb.sh "$OUTPUT_DEB_DIR" "$OUTPUT_BAZEL_ARCHIVE_DIR" "$OUTPUT_APT_ARCHIVE_DIR" "$RT_KERNEL_FLAVOURS" "$ASTORE_BASE"
+$RUN ${SCRIPT_PATH}/upload-deb.sh \
+     "$OUTPUT_DEB_DIR"            \
+     "$OUTPUT_BAZEL_ARCHIVE_DIR"  \
+     "$OUTPUT_APT_ARCHIVE_DIR"    \
+     "$RT_KERNEL_FLAVOURS"        \
+     "$ASTORE_BASE"               \
+     "$OUTPUT_ASTORE_META_DIR"
 
 # Builds the UML kernel
 $RUN ${SCRIPT_PATH}/build-uml.sh "$KERNEL_DIR" "$KERNEL_VERSION" "$OUTPUT_UML_DIR"
@@ -206,4 +249,22 @@ $RUN ${SCRIPT_PATH}/build-uml.sh "$KERNEL_DIR" "$KERNEL_VERSION" "$OUTPUT_UML_DI
 $RUN ${SCRIPT_PATH}/archive-bazel-uml.sh "$KERNEL_DIR" "$OUTPUT_UML_DIR" "$OUTPUT_UML_BAZEL_ARCHIVE_DIR"
 
 # For UML, uploads the bazel ready tarball and kernel image
-$RUN ${SCRIPT_PATH}/upload-uml.sh "$OUTPUT_UML_DIR" "$OUTPUT_UML_BAZEL_ARCHIVE_DIR" "$ASTORE_BASE"
+$RUN ${SCRIPT_PATH}/upload-uml.sh    \
+     "$OUTPUT_UML_DIR"               \
+     "$OUTPUT_UML_BAZEL_ARCHIVE_DIR" \
+     "$ASTORE_BASE"                  \
+     "$OUTPUT_ASTORE_META_DIR"
+
+# Generate Bazel include file from upload meta-data files
+$RUN ${SCRIPT_PATH}/gen-bazel-meta.sh    \
+     "$OUTPUT_DEB_DIR"                   \
+     "$RT_KERNEL_FLAVOURS"               \
+     "$OUTPUT_UML_DIR"                   \
+     "$ASTORE_BASE"                      \
+     "$OUTPUT_ASTORE_META_DIR"           \
+     "$RT_KERNEL_LABEL"
+
+echo
+echo "SUCCESS: All Done."
+echo "Copy the following file to the internal repo,  in internal-repo/bazel/kernel.version.bzl"
+echo "${OUTPUT_ASTORE_META_DIR}/kernel.version.bzl"

--- a/kbuild/v2/scripts/archive-bazel-uml.sh
+++ b/kbuild/v2/scripts/archive-bazel-uml.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+LIB_SH="$(dirname $(realpath $0))/lib.sh"
+. $LIB_SH
+
 KERNEL_DIR="$(realpath $1)"
 OUTPUT_UML_DIR="$(realpath $2)"
 OUTPUT_UML_BAZEL_ARCHIVE_DIR="$(realpath $3)"
@@ -29,7 +32,7 @@ if [ ! -r "$INSTALL_TEMPLATE" ] ; then
     exit 1
 fi
 
-KERNEL_VERSION=$(cat "${OUTPUT_UML_DIR}/include/config/kernel.release")
+KERNEL_VERSION="$(uml_get_kernel_version $OUTPUT_UML_DIR)"
 
 # clean output UML bazel archive dir
 rm -rf "$OUTPUT_UML_BAZEL_ARCHIVE_DIR"

--- a/kbuild/v2/scripts/gen-bazel-meta.sh
+++ b/kbuild/v2/scripts/gen-bazel-meta.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+# This script generates kernel version variables for bazel
+#
+# Inputs
+# - a flat directory containing the kernel .debs
+# - a space separated list of kernel flavours
+# - the UML kernel build directory
+# - The astore root where artifacts are stored
+# - a directory to store astore meta data files
+# - kernel label for creating bazel variable names
+
+set -e
+
+LIB_SH="$(dirname $(realpath $0))/lib.sh"
+. $LIB_SH
+
+OUTPUT_DEB_ROOT="$(realpath $1)"
+KERNEL_FLAVOURS="$2"
+OUTPUT_UML_DIR="$(realpath $3)"
+ASTORE_ROOT="$4"
+ASTORE_META_DIR="$5"
+KERNEL_LABEL="$6"
+
+bazel_kernel_file="${ASTORE_META_DIR}/kernel.version.bzl"
+rm -f "$bazel_kernel_file"
+touch "$bazel_kernel_file"
+
+get_sha256() {
+    local astore_meta="$1"
+    local sha256=$(cat "$astore_meta" | jq '.sha256' | sed -e 's/"//g')
+    if [ -z "$sha256" ] ; then
+        echo "ERROR: Unable to find sha256 in astore meta: $astore_meta"
+        exit 1
+    fi
+    echo -n "$sha256"
+}
+
+get_uid() {
+    local astore_meta="$1"
+    local uid=$(cat "$astore_meta" | jq '.uid' | sed -e 's/"//g')
+    if [ -z "$sha256" ] ; then
+        echo "ERROR: Unable to find uid in astore meta: $astore_meta"
+        exit 1
+    fi
+    echo -n "$uid"
+}
+
+gen_artifact_desc() {
+    local artifact="$1"
+    local kernel_version="$2"
+    local flavour="$3"
+    local astore_file="$4"
+    # Note the leading "/", which is different from how the files are
+    # uploaded.
+    local astore_path="/${ASTORE_ROOT}/${flavour}/${astore_file}"
+    local astore_meta="${ASTORE_META_DIR}/${astore_file}-${kernel_version}.json"
+    if [ ! -r "$astore_meta" ] ; then
+        echo "ERROR: Unable to read build-headers.tar.gz astore meta file: $astore_meta"
+        exit 1
+    fi
+
+    # Upcase the flavour name
+    local FLAVOUR="$(echo -n $flavour | tr [:lower:] [:upper:])"
+
+    local sha256=$(get_sha256 "$astore_meta")
+    local uid=$(get_uid "$astore_meta")
+
+    cat <<EOF >> "$bazel_kernel_file"
+${artifact}_${KERNEL_LABEL}_${FLAVOUR} = {
+    "package":     "enf-${kernel_version}",
+    "sha256":      "$sha256",
+    "astore_path": "$astore_path",
+    "astore_uid":  "$uid",
+}
+
+EOF
+
+}
+
+gen_deb_flavours() {
+    for f in $KERNEL_FLAVOURS ; do
+        local kernel_version="$(deb_get_kernel_version $OUTPUT_DEB_ROOT $f)"
+
+        ## build-headers.tar.gz
+        local astore_file="build-headers.tar.gz"
+        gen_artifact_desc "KERNEL_TREE" $kernel_version $f $astore_file
+
+        ## vmlinuz-modules.tar.gz
+        local astore_file="vmlinuz-modules.tar.gz"
+        gen_artifact_desc "KERNEL_MODULES" $kernel_version $f $astore_file
+
+    done
+}
+
+gen_uml() {
+    local kernel_version="$(uml_get_kernel_version $OUTPUT_UML_DIR)"
+
+    ## build-headers.tar.gz
+    local astore_file="build-headers.tar.gz"
+    gen_artifact_desc "KERNEL_TREE" $kernel_version test $astore_file
+
+    ## kernel image
+    local astore_file="vmlinuz"
+    gen_artifact_desc "KERNEL_IMAGE" $kernel_version test $astore_file
+
+}
+
+gen_deb_flavours
+gen_uml

--- a/kbuild/v2/scripts/upload-uml.sh
+++ b/kbuild/v2/scripts/upload-uml.sh
@@ -6,6 +6,7 @@
 # - the kernel build directory
 # - the UML bazel archive output directory
 # - The astore root where to store kernel artifacts
+# - a directory to store astore meta data files
 
 set -e
 
@@ -15,23 +16,35 @@ LIB_SH="$(dirname $(realpath $0))/lib.sh"
 OUTPUT_UML_DIR="$(realpath $1)"
 OUTPUT_UML_BAZEL_ARCHIVE_DIR="$(realpath $2)"
 ASTORE_ROOT="$3"
+ASTORE_META_DIR="$4"
 
 uml_image_src="${OUTPUT_UML_DIR}/linux"
 if [ ! -r "$uml_image_src" ] ; then
     echo "ERROR: unable to read UML kernel image: $uml_image"
     exit 1
 fi
-uml_image_astore_dest="${ASTORE_ROOT}/test/vmlinuz"
 
 archive_src="${OUTPUT_UML_BAZEL_ARCHIVE_DIR}/build-headers.tar.gz"
 if [ ! -r "$archive_src" ] ; then
     echo "ERROR: unable to read UML kernel archive: $archive_src"
     exit 1
 fi
-archive_astore_dest="${ASTORE_ROOT}/test/build-headers.tar.gz"
 
-kernel_version="$(cat ${OUTPUT_UML_DIR}/include/config/kernel.release)"
+if [ ! -d "$ASTORE_META_DIR" ] ; then
+    echo "ERROR: unable to find astore meta-data directory: $ASTORE_META_DIR"
+    exit 1
+fi
+
+kernel_version="$(uml_get_kernel_version $OUTPUT_UML_DIR)"
 tag="kernel=$kernel_version"
 
-upload_artifact "$uml_image_src" "$uml_image_astore_dest" "um" "$tag"
-upload_artifact "$archive_src"   "$archive_astore_dest"   "um" "$tag"
+uml_image_astore_file="vmlinuz"
+uml_image_astore_path="${ASTORE_ROOT}/test/${uml_image_astore_file}"
+uml_image_astore_meta="${ASTORE_META_DIR}/${uml_image_astore_file}-${kernel_version}.json"
+
+archive_astore_file="build-headers.tar.gz"
+archive_astore_path="${ASTORE_ROOT}/test/$archive_astore_file"
+archive_astore_meta="${ASTORE_META_DIR}/${archive_astore_file}-${kernel_version}.json"
+
+upload_artifact "$uml_image_src" "$uml_image_astore_path" "um" "$tag" "$uml_image_astore_meta"
+upload_artifact "$archive_src"   "$archive_astore_path"   "um" "$tag" "$archive_astore_meta"


### PR DESCRIPTION
This patch updates the kbuild script to generate a file suitable for
commiting to the internal repo in
<internal-repo>/bazel/kernel.version.bzl.

This file contains all the info necessary for bazel to download and
verify the kernel artifacts from astore.

Partially-Fixes: SF-58