### PR TITLE
bazel/linux: add modules_bundle rule

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -4,27 +4,79 @@ load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
-def _kunit_bundle(ctx):
+def _modules_bundle(ctx):
     ki = ctx.attr.image[KernelImageInfo]
     mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
     alldeps = expand_deps(ctx, mods, ctx.attr.depth)
 
     commands = [
+        "#!/bin/sh",
+        "set -e",
         # modprobe does not work correctly without /sys
         "mount -t sysfs sysfs /sys",
     ]
 
     inputs = []
     for kmod in alldeps:
-        commands += ["", "# module " + package(kmod.label)]
         if kmod.setup:
             commands += kmod.setup
 
         for mod in kmod.files:
             if mod.extension != "ko":
                 continue
-            commands.append("load " + mod.short_path)
             inputs.append(mod)
+
+    init = ctx.actions.declare_file(ctx.attr.name + "-modprobe-deps.sh")
+    ctx.actions.write(
+        output = init,
+        content = "\n".join(commands),
+        is_executable = True,
+    )
+
+    inside_runfiles = ctx.runfiles(inputs)
+
+    return [
+        DefaultInfo(files = depset([init]), runfiles = inside_runfiles),
+        RuntimeBundleInfo(
+            run = RuntimeInfo(binary = init, runfiles = inside_runfiles),
+        ),
+    ]
+
+modules_bundle = rule(
+    doc = """\
+Generates a directory containing the kernel modules, all their dependencies.""",
+    implementation = _modules_bundle,
+    attrs = {
+        "module": attr.label(
+            mandatory = True,
+            providers = [KernelBundleInfo],
+            doc = "The label of the linux kernel module to be imported.",
+        ),
+        "image": attr.label(
+            mandatory = True,
+            providers = [KernelImageInfo],
+            doc = "The label of a kernel image. Important to select the correct architecture and package module.",
+        ),
+        "depth": attr.int(
+            default = 5,
+            doc = "Maximum recursive depth when expanding a list of kernel module dependencies.",
+        ),
+    },
+)
+
+def _kunit_bundle(ctx):
+    ki = ctx.attr.image[KernelImageInfo]
+    mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
+
+    commands = []
+
+    for kmod in mods:
+        commands += ["", "# module " + package(kmod.label)]
+
+        for mod in kmod.files:
+            if mod.extension != "ko":
+                continue
+            commands.append("load " + mod.short_path)
 
     init = ctx.actions.declare_file(ctx.attr.name + "-kunit.sh")
     ctx.actions.expand_template(
@@ -50,12 +102,11 @@ def _kunit_bundle(ctx):
     )
     outside_runfiles = ctx.runfiles(files = ctx.attr._parser.files.to_list())
     outside_runfiles = outside_runfiles.merge(ctx.attr._parser.default_runfiles)
-    inside_runfiles = ctx.runfiles(inputs)
 
     return [
-        DefaultInfo(files = depset([init, check]), runfiles = inside_runfiles.merge(outside_runfiles)),
+        DefaultInfo(files = depset([init, check]), runfiles = outside_runfiles),
         RuntimeBundleInfo(
-            run = RuntimeInfo(binary = init, runfiles = inside_runfiles),
+            run = RuntimeInfo(binary = init, runfiles = []),
             check = RuntimeInfo(binary = check, runfiles = outside_runfiles),
         ),
     ]
@@ -75,10 +126,6 @@ and an init script to run them as a kunit test.""",
             mandatory = True,
             providers = [KernelImageInfo],
             doc = "The label of a kernel image this test will run against. Important to select the correct architecture and package module.",
-        ),
-        "depth": attr.int(
-            default = 5,
-            doc = "Maximum recursive depth when expanding a list of kernel module dependencies.",
         ),
         "template_kunit": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
This rule brings the requested module and its dependencies in the VM. It
also executes the shell commands of the setup attribute for each
imported module.

Signed-off-by: George Prekas <george@enfabrica.net>