### PR TITLE
bazel/linux: don't escape argv.

### DIFF
--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -60,7 +60,8 @@ RuntimeInfo = provider(
     fields = {
         "binary": "File object, executable, binary to run",
         "runfiles": "runfiles() object, representing the files needed by the binary at run time",
-        "argv": "array of strings, optional arguments to pass to the binary",
+        "args": "string, optional arguments to pass to the binary. args is NOT ESCAPED " +
+                "by the bazel rule, to allow it to reference variable names.",
     },
 )
 

--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -45,19 +45,19 @@ def _commands_and_runtime(ctx, msg, runs, runfiles):
                                   "and have a binary defined".format(target = package(r.label))))
 
         binary = rbi.binary
-        argv = ""
-        if hasattr(rbi, "argv") and rbi.argv:
-            argv = escape_and_join(rbi.argv)
+        args = ""
+        if hasattr(rbi, "args"):
+            args = rbi.args
 
-        commands.append("echo '==== {msg}: {target} as \"{path} {argv}\"...'".format(
+        commands.append("echo '==== {msg}: {target} as \"{path} {args}\"...'".format(
             msg = msg,
             target = package(r.label),
             path = rbi.binary.short_path,
-            argv = argv,
+            args = args,
         ))
-        commands.append("{binary} {argv}".format(
+        commands.append("{binary} {args}".format(
             binary = shell.quote(binary.short_path),
-            argv = argv,
+            args = args,
         ))
 
         runfiles = runfiles.merge(ctx.runfiles([binary]))


### PR DESCRIPTION
Problem:
Would like argv supplied to be able to reference arbitrary environment
variables set by the script, or use things like $(realpath ...).
Today, however, this is not possible: argv is shell escaped, to
prevent any sort of quoting hell.

In this PR:
- stop escaping argv, allowing arbitrary shell sequences to be used
  (on purpose, this is a goal).
- turn argv, from an array, into a single string. No point in maintaining
  separation without escaping, and mimics the semantics of other APIs,
  where arrays are generally considered safe (as passed as argv to
  an execve equivalent kind of function) while a single string is
  considered unsafe (as subject to space field separation, and
  often passed as the argument to bash -c).
- change the contract/documentation of the provider.
