### PR TITLE
bazel/linux: generic rule to implement pre- and post- checks.

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -4,6 +4,118 @@ load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
+def _add_attr_bundle(ctx, bundle, name):
+    """Used by _vm_bundle, helper to parase its attributes"""
+    abin = getattr(ctx.attr, name + "_bin")
+    aargs = getattr(ctx.attr, name + "_args")
+    acmds = getattr(ctx.attr, name + "_cmds")
+
+    if not abin and not acmds:
+        return
+
+    info = dict(commands = acmds, args = aargs)
+    if abin:
+        di = abin[DefaultInfo]
+        info["binary"] = di.files_to_run.executable
+        info["runfiles"] = di.default_runfiles
+
+    bundle[name] = RuntimeInfo(**info)
+
+def _vm_bundle(ctx):
+    bundle = {}
+    _add_attr_bundle(ctx, bundle, "prepare")
+    _add_attr_bundle(ctx, bundle, "run")
+    _add_attr_bundle(ctx, bundle, "check")
+
+    return RuntimeBundleInfo(**bundle)
+
+vm_bundle = rule(
+    doc = """\
+Packages one or more binaries into a bundle suitable for use from an emulator.
+
+This is only needed if you need to provide a specific argv, or to
+supply a script to prepare the environment to run the VM, or to clean
+up afterward.
+
+As an example, let's say you need to create an "internal-test" bundle that 1)
+runs some setup commands outside the VM, 2) runs a test binary in the VM, and
+3) checks the result of the test at the end of the run.
+
+You can set up the bundle like this:
+
+    sh_binary(
+        name = "prepare-environment-outside-vm",
+        srcs = [ ... a shell script ... ],
+        data = [ ... a bunch of static files ...],
+    )
+
+    sh_binary(
+        name = "test-binary-inside-vm",
+        srcs = [ ... a shell script ... ],
+        data = [ ... a bunch of static files ...],
+    )
+
+    sh_binary(
+        name = "check-results-outside-vm",
+        srcs = [ ... a shell script ... ],
+        data = [ ... a bunch of static files ...],
+    )
+
+    vm_bundle(
+        name = "internal-test"
+        prepare_cmds = [
+            "cp /etc/hosts $OUTPUT_DIR",
+        ],
+        prepare_bin = ":prepare-environment-outside-vm",
+        prepare_args = "--read --aggressive",
+
+        run_bin = ":test-binary-inside-vm",
+        
+        check_cmds = [
+            "jq $OUTPUT_DIR > $OUTPUT_DIR/file.json",
+        ],
+        check_bin = ":check-results-outside-vm",
+        check_args = "--check $OUTPUT_DIR/file.json",
+    )
+""",
+    implementation = _vm_bundle,
+    attrs = {
+        "prepare_cmds": attr.string_list(
+            doc = "Shell commands to run OUTSIDE THE VM to prepare the environment (before prepare_bin - optional)",
+        ),
+        "prepare_bin": attr.label(
+            doc = "Binary to run OUTSIDE THE VM to prepare the environment (optional)",
+            executable = True,
+            cfg = "exec",
+        ),
+        "prepare_args": attr.string(
+            doc = "Optional parameters to pass to the prepare_bin. Can use shell expansion.",
+        ),
+        "run_cmds": attr.string_list(
+            doc = "Shell commands to run OUTSIDE THE VM to run the environment (before run_bin - optional)",
+        ),
+        "run_bin": attr.label(
+            doc = "Binary to run OUTSIDE THE VM to run the environment (optional)",
+            executable = True,
+            cfg = "exec",
+        ),
+        "run_args": attr.string(
+            doc = "Optional parameters to pass to the run_bin. Can use shell expansion.",
+        ),
+        "check_cmds": attr.string_list(
+            doc = "Shell commands to check OUTSIDE THE VM to check the environment (before check_bin - optional)",
+        ),
+        "check_bin": attr.label(
+            doc = "Binary to check OUTSIDE THE VM to check the environment (optional)",
+            executable = True,
+            cfg = "exec",
+        ),
+        "check_args": attr.string(
+            doc = "Optional parameters to pass to the check_bin. Can use shell expansion.",
+        ),
+    },
+)
+
 def _kunit_bundle(ctx):
     ki = ctx.attr.image[KernelImageInfo]
     mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)

--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -92,10 +92,10 @@ You can set up the bundle like this:
             doc = "Optional parameters to pass to the prepare_bin. Can use shell expansion.",
         ),
         "run_cmds": attr.string_list(
-            doc = "Shell commands to run OUTSIDE THE VM to run the environment (before run_bin - optional)",
+            doc = "Shell commands to run INSIDE THE VM to run the environment (before run_bin - optional)",
         ),
         "run_bin": attr.label(
-            doc = "Binary to run OUTSIDE THE VM to run the environment (optional)",
+            doc = "Binary to run INSIDE THE VM to run the environment (optional)",
             executable = True,
             cfg = "exec",
         ),

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -58,6 +58,7 @@ and have basic tools available necessary for its users.
 RuntimeInfo = provider(
     doc = """Represents a binary to run""",
     fields = {
+        "commands": "list of string, shell commands to embed in the script before running the binary",
         "binary": "File object, executable, binary to run",
         "runfiles": "runfiles() object, representing the files needed by the binary at run time",
         "args": "string, optional arguments to pass to the binary. args is NOT ESCAPED " +


### PR DESCRIPTION
Background:
The runner() in runner.bzl supports preparing the machin in
arbitrary ways, running tests in the VM, and checking the
machine in arbitrary ways.

But this feature was not exposed except for custom rules.

In this PR:
- introduced a generic vm_bundle that allows to create
  a bundle with a prepare/check/run step without having
  to write any bazel code.
