### PR TITLE
bazel/linux: document the most important options of all.

### DIFF
--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -31,6 +31,10 @@ or:
 
 Accepted options:
 
+  -s           Configures /bin/sh as init, drops you in a shell.
+               Hint: you can then use the paths shown with -x to manually
+               start the init script used.
+
   -k [value]   Adds one or more command line options to the kernel.
 
      For example: "-k ro -k root=/dev/sda -k console=ttyS0"


### PR DESCRIPTION
This is a tiny change documenting `-s` in the help screen of
the runner script.
