### PR TITLE
bazel/linux: gracefully handle mount failures

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -123,7 +123,7 @@ def _kunit_bundle(ctx):
 
     commands = [
         # modprobe does not work correctly without /sys
-        "mount -t sysfs sysfs /sys",
+        "mount -t sysfs sysfs /sys || echo 1>&2 'Could not mount sys - modprobe may not work properly'",
     ]
 
     inputs = []


### PR DESCRIPTION
When running in a sandbox, mount might fail with the message "mount:
only root can use "--types" option". Handle this failure and print a
warning to the user.

Signed-off-by: George Prekas <george@enfabrica.net>