### PR TITLE
enkit outputs: Update bb_clientd config

### DIFF
--- a/lib/kbuildbarn/exec/templates/config.jsonnet
+++ b/lib/kbuildbarn/exec/templates/config.jsonnet
@@ -125,15 +125,17 @@ local blobstoreConfig = {
   // The FUSE file system through which data stored in the Content
   // Addressable Storage can be loaded lazily. This file system relies
   // on credentials captured through gRPC.
-  fuse: {
+  mount: {
     mountPath: '{{.MountDir}}',
-    directoryEntryValidity: '300s',
-    inodeAttributeValidity: '300s',
-    // Enabling this option may be necessary if you want to permit
-    // super-user access to the FUSE file system. It is strongly
-    // recommended that the permissions on the parent directory of the
-    // FUSE file system are locked down before enabling this option.
-    // allowOther: true,
+    fuse: {
+      directoryEntryValidity: '300s',
+      inodeAttributeValidity: '300s',
+      // Enabling this option may be necessary if you want to permit
+      // super-user access to the FUSE file system. It is strongly
+      // recommended that the permissions on the parent directory of the
+      // FUSE file system are locked down before enabling this option.
+      // allowOther: true,
+    },
   },
 
   // The location where locally created files in the "scratch" and


### PR DESCRIPTION
This change updates the bb_clientd configuration so it is compatible
with a newer version of bb_clientd.

Tested:
* Put new version of `bb_clientd` on `$PATH`
* `bazel run //enkit -- outputs mount -i 7edcf668-d0a1-4f3f-8f63-19ae7d5b8e4a` successfully mounts outputs

Jira: INFRA-886