### PR TITLE
Increase timeout of running jobs

### DIFF
--- a/flextape/client/flextape_client/main.go
+++ b/flextape/client/flextape_client/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	timeout = flag.Duration("timeout", 7200*time.Second, "Max time waiting in license queue")
+	timeout = flag.Duration("timeout", 7*24*60*60*time.Second, "Max time waiting in license queue")
 )
 
 func main() {


### PR DESCRIPTION
JIRA: [INFRA-1072](https://enfabrica.atlassian.net/browse/INFRA-1072)

Physical design builds often take 24 hours to up to 7 days to complete. The default timeout for currently running invocations and queued license requests is 2 hours.

Testing:
- Currently, there is no staging flextape and staging flexlm servers to work with the staging cluster. How should I proceed to test?