### PR TITLE
bazel/linux: run the init script even in QEMU interactive mode

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -49,7 +49,6 @@ else
     KERNEL_FLAGS+=("rootflags=trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl")
 fi
 test -z "$KERNEL" || QEMU_FLAGS+=("-kernel" "$KERNEL")
-test -z "$INTERACTIVE" || KERNEL_FLAGS+=("init=/bin/sh")
 
 QEMU_FLAGS+=("-append" "${{KERNEL_FLAGS[*]}} ${{KERNEL_OPTS[*]}}")
 QEMU_FLAGS+=("${{EMULATOR_OPTS[@]}}")

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -31,9 +31,10 @@ or:
 
 Accepted options:
 
-  -s           Configures /bin/sh as init, drops you in a shell.
+  -s           Starts the VM in interactive mode. It is expected that the
+               init script executes a shell.
                Hint: you can then use the paths shown with -x to manually
-               start the init script used.
+               start any target.
 
   -k [value]   Adds one or more command line options to the kernel.
 


### PR DESCRIPTION
The user might want to perform some initialization before starting a
shell in the VM.

Signed-off-by: George Prekas <george@enfabrica.net>