### PR TITLE
INFRA-1088: bestie: enforce 20 MB output file size limit

### DIFF
--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -25,6 +25,7 @@ import (
 var (
 	logger      = log.New(os.Stdout, "bestie: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC|log.Lshortfile|log.Lmsgprefix)
 	isDebugMode bool // Set this to true to enable certain debug behaviors (e.g. special log messages).
+	maxFileSize int  = (20 * 1024 * 1024)
 )
 
 func debugPrintf(format string, str ...interface{}) {
@@ -100,10 +101,11 @@ func (s *BuildEventService) PublishBuildToolEventStream(stream bpb.PublishBuildE
 
 // Command line arguments.
 var (
-	argBaseUrl   = flag.String("base_url", "", "Base URL for accessing output artifacts in the build cluster (required)")
-	argDataset   = flag.String("dataset", "", "BigQuery dataset name (required) -- staging, production")
-	argDebug     = flag.Bool("debug", false, "Enable debug mode within the server")
-	argTableName = flag.String("table_name", "testmetrics", "BigQuery table name")
+	argBaseUrl     = flag.String("base_url", "", "Base URL for accessing output artifacts in the build cluster (required)")
+	argDataset     = flag.String("dataset", "", "BigQuery dataset name (required) -- staging, production")
+	argDebug       = flag.Bool("debug", false, "Enable debug mode within the server")
+	argMaxFileSize = flag.Int("max_file_size", maxFileSize, "Maximum output file size allowed for processing")
+	argTableName   = flag.String("table_name", "testmetrics", "BigQuery table name")
 )
 
 func checkCommandArgs() error {
@@ -124,6 +126,7 @@ func checkCommandArgs() error {
 	// Set/override the default values.
 	deploymentBaseUrl = *argBaseUrl
 	isDebugMode = *argDebug
+	maxFileSize = *argMaxFileSize
 	bigQueryTableDefault.dataset = *argDataset
 	bigQueryTableDefault.tableName = *argTableName
 

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	logger      = log.New(os.Stdout, "bestie: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC|log.Lshortfile|log.Lmsgprefix)
-	isDebugMode bool // Set this to true to enable certain debug behaviors (e.g. special log messages).
-	maxFileSize int  = (5 * 1024 * 1024)
+	fileTooBigErr      = errors.New("File exceeds maximum size allowed")
+	isDebugMode   bool = false // Set this to true to enable certain debug behaviors (e.g. special log messages).
+	logger             = log.New(os.Stdout, "bestie: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC|log.Lshortfile|log.Lmsgprefix)
+	maxFileSize   int  = (5 * 1024 * 1024)
 )
 
 func debugPrintf(format string, str ...interface{}) {

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -25,7 +25,7 @@ import (
 var (
 	logger      = log.New(os.Stdout, "bestie: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC|log.Lshortfile|log.Lmsgprefix)
 	isDebugMode bool // Set this to true to enable certain debug behaviors (e.g. special log messages).
-	maxFileSize int  = (20 * 1024 * 1024)
+	maxFileSize int  = (5 * 1024 * 1024)
 )
 
 func debugPrintf(format string, str ...interface{}) {

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -74,11 +74,11 @@ type SkippedMsg struct {
 }
 
 // Read test result info from a test.xml file and create result metrics.
-func processXmlMetrics(stream *bazelStream, fileReader io.Reader) error {
+func processXmlMetrics(stream *bazelStream, fileReader io.Reader, fileName string) error {
 	// Read entire file into a byte slice.
-	fileData, err := ioutil.ReadAll(fileReader)
+	fileData, err := readFileWithLimit(fileReader)
 	if err != nil {
-		return fmt.Errorf("Error reading file: %w", err)
+		return fmt.Errorf("Error reading file %q: %w", filepath.Base(fileName), err)
 	}
 
 	// Extract all metrics from the XML file contents.

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -76,8 +77,11 @@ type SkippedMsg struct {
 // Read test result info from a test.xml file and create result metrics.
 func processXmlMetrics(stream *bazelStream, fileReader io.Reader, fileName string) error {
 	// Read entire file into a byte slice.
-	fileData, err := readFileWithLimit(fileReader)
+	fileData, err := readFileWithLimit(fileReader, maxFileSize)
 	if err != nil {
+		if errors.Is(err, fileTooBigErr) {
+			cidOutputFileTooBigTotal.increment()
+		}
 		return fmt.Errorf("Error reading file %q: %w", filepath.Base(fileName), err)
 	}
 


### PR DESCRIPTION
The BES Endpoint will not attempt to read and process any output
file whose size exceeds 20 MB. This is to prevent out-of-memory
conditions being experienced several times per day in the production
cluster. This does not impact the running 'bazel test' job, but
will preclude updating the BigQuery database with any metrics
contained in the unprocessed files.

Note that the built in default of 20 MB for the file size limit
can be overridden using the --max_file_size command line
parameter.

Tested: Ran a local instance of the bestie server along with
a bazel test //systest/src/demo:test_sample_metrics that sent
its BES events to localhost:6433. Observed the desired behavior
when files exceeded the limit.

Jira: INFRA-1088