### PR TITLE
bazel/linux: introduce interactive mode

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -49,13 +49,13 @@ else
     KERNEL_FLAGS+=("rootflags=trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl")
 fi
 test -z "$KERNEL" || QEMU_FLAGS+=("-kernel" "$KERNEL")
-test -z "$INTERACTIVE" || KERNEL_FLAGS+=("init=/bin/sh")
+test -z "$SINGLE" || KERNEL_FLAGS+=("init=/bin/sh")
 
 QEMU_FLAGS+=("-append" "${{KERNEL_FLAGS[*]}} ${{KERNEL_OPTS[*]}}")
 QEMU_FLAGS+=("${{EMULATOR_OPTS[@]}}")
 
 echo 1>&2 '$' "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"
-if [ -z "$INTERACTIVE" ]; then
+if [ -z "$INTERACTIVE" -a -z "$SINGLE" ]; then
     "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" </dev/null | tee "$OUTPUT_FILE"
 else
     "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -87,6 +87,7 @@ function showstate {
 declare -a KERNEL_OPTS
 declare -a EMULATOR_OPTS
 INTERACTIVE=""
+SINGLE=""
 
 # Make sure the log file is saved by BES protocol, store it in the
 # UNDECLARED_OUTPUTS_DIR.
@@ -105,7 +106,7 @@ while getopts "k:e:r:hsx" opt; do
     h) help; exit 0;;
     k) KERNEL_OPTS+=("$OPTARG");;
     e) EMULATOR_OPTS+=("$OPTARG");;
-    s) INTERACTIVE=True;;
+    s) SINGLE=True;;
     r) ROOTFS=("$OPTARG");;
     x) showstate; exit 0;;
     ?|*) help 1>&2; exit 1;;
@@ -134,6 +135,7 @@ trap onexit EXIT
 #   - RUNTIME - path to the top level directory that needs to be exposed.
 #   - TMPDIR - path to a temporary directory.
 #   - INTERACTIVE - if non-empty value, run the VM in interactive mode (shell).
+#   - SINGLE - if non-empty value, run the VM in single-user mode (init=/bin/sh).
 #   - OUTPUT_FILE - console output must be stored in this file
 #                   (kernel boot log, and any shell output).
 #   - OUTPUT_DIR - directory where to store any other output file.
@@ -141,7 +143,7 @@ trap onexit EXIT
 # - Additionally, they should check for:
 #   - KERNEL_OPTS - array, may have additional kernel arguments.
 #   - EMULATOR_OPTS - array, may have additional arguments for the emulator.
-for var in TARGET KERNEL INIT ROOTFS RUNTIME TMPDIR INTERACTIVE OUTPUT_FILE OUTPUT_DIR KERNEL_OPTS EMULATOR_OPTS; do
+for var in TARGET KERNEL INIT ROOTFS RUNTIME TMPDIR INTERACTIVE SINGLE OUTPUT_FILE OUTPUT_DIR KERNEL_OPTS EMULATOR_OPTS; do
     export "$var"
 done
 
@@ -159,7 +161,7 @@ test "$estatus" == 0 || {
     echo 1>&2 "===== emulator exited with non zero status - check logs above ===="
     exit "$estatus"
 }
-test -z "$INTERACTIVE" || exit "$estatus"
+test -z "$INTERACTIVE" -a -z "$SINGLE" || exit "$estatus"
 
 echo 1>&2 "===== emulator exited - now running checkers (if any) ===="
 {checks}

--- a/bazel/linux/uml.bzl
+++ b/bazel/linux/uml.bzl
@@ -18,16 +18,19 @@ else
 fi
 
 # If debugging is enabled, throw the user in a shell.
-if [ -z "$INTERACTIVE" ]; then
+if [ -z "$INTERACTIVE" -a -z "$SINGLE" ]; then
   OPTIONS=("con0=null,fd:1" "con1=null,fd:1" "${{OPTIONS[@]}}")
 else
-  OPTIONS=("con0=fd:0,fd:1" "${{OPTIONS[@]}}" "init=/bin/sh")
+  OPTIONS=("con0=fd:0,fd:1" "${{OPTIONS[@]}}")
 fi
+
+test -z "$SINGLE" || OPTIONS+=("init=/bin/sh")
+
 OPTIONS+=("${{EMULATOR_OPTS[@]}}")
 OPTIONS+=("${{KERNEL_OPTS[@]}}")
 
 echo 1>&2 '$' "$KERNEL" "${{OPTIONS[@]}}"
-if [ -z "$INTERACTIVE" ]; then
+if [ -z "$INTERACTIVE" -a -z "$SINGLE" ]; then
   "$KERNEL" "${{OPTIONS[@]}}" | tee "$OUTPUT_FILE"
 else
   "$KERNEL" "${{OPTIONS[@]}}"


### PR DESCRIPTION
Rename the previous interactive mode to single-user mode, which
effectively does init=/bin/sh and is useful for debugging.

The new interactive mode is enabled only programmatically with:

vm_bundle(
    name = "interactive",
    prepare_cmds = [
        "INTERACTIVE=1",
    ],
)

The init script is executed and is expected to invoke the shell.

Signed-off-by: George Prekas <george@enfabrica.net>