### PR TITLE
bazel/linux: handle multiple module build types

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -54,10 +54,12 @@ def _kernel_modules(ctx):
         for m in modules:
             message += "kernel: compiling %s for arch:%s kernel:%s" % (m, arch, ki.package)
 
-            outfile = "{kernel}/{arch}/{name}".format(
+            # ctx.attr.name is $kernel-$original_bazel_rule_name
+            outfile = "{kernel}/{name}/{arch}/{module}".format(
                 kernel = ki.name,
+                name = ctx.attr.name.removeprefix(ki.name + "-"),
                 arch = arch,
-                name = m,
+                module = m,
             )
 
             output = ctx.actions.declare_file(outfile)


### PR DESCRIPTION
Store the name of the kernel_module rule as part of the generated
module's path to allow compiling the same module with different
parameters.

Example:
Before: bazel-bin/.../$KERNEL/$ARCH/$MODULE.ko
After:  bazel-bin/.../$KERNEL/$NAME/$ARCH/$MODULE.ko

Signed-off-by: George Prekas <george@enfabrica.net>