### PR TITLE
gee diff: show changes since branches diverged

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2143,9 +2143,9 @@ _register_help "diff" \
   "Differences in this branch." <<'EOT'
 Usage: gee diff [<files...>]
 
-Diffs the current branch against its parent branch.
+Shows all local changes this since branch diverged from its parent branch.
 
-If <files...> are omited, defaults to all files.
+If <files...> are omited, shows changes to all files.
 EOT
 
 function gee__diff() {
@@ -2161,9 +2161,9 @@ function gee__diff() {
     PARENT_BRANCH="FETCH_HEAD"
   fi
   if (( "$#" )); then
-    _git_can_fail diff "${PARENT_BRANCH}"..HEAD -- "$@"
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD -- "$@"
   else
-    _git_can_fail diff "${PARENT_BRANCH}"..HEAD
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD
   fi
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."

--- a/scripts/gee
+++ b/scripts/gee
@@ -2161,9 +2161,9 @@ function gee__diff() {
     PARENT_BRANCH="FETCH_HEAD"
   fi
   if (( "$#" )); then
-    _git_can_fail diff "${PARENT_BRANCH}" -- "$@"
+    _git_can_fail diff "${PARENT_BRANCH}"..HEAD -- "$@"
   else
-    _git_can_fail diff "${PARENT_BRANCH}"
+    _git_can_fail diff "${PARENT_BRANCH}"..HEAD
   fi
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -180,9 +180,9 @@ Usage: `gee log`
 
 Usage: `gee diff [<files...>]`
 
-Diffs the current branch against its parent branch.
+Shows all local changes this since branch diverged from its parent branch.
 
-If <files...> are omited, defaults to all files.
+If <files...> are omited, shows changes to all files.
 
 ### pack
 


### PR DESCRIPTION
This PR undoes a bad decision made months ago.  When the user asks for a diff,
they are almost always expecting "changes since this branch diverged from its
parent branch" (the 3-dot diff), not "show all differences between the
branches" (the 2-dot diff).

Tested: Ran "gee diff" manually in a few branches.

