### PR TITLE
gee rmbr: handle broken bazel-out links

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.30"
+readonly VERSION="0.2.31"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3872,7 +3872,7 @@ function gee__remove_branch() {
   SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
 
   # delete the bazel cache associated with this worktree
-  if [[ -h ./bazel-out ]]; then
+  if [[ -h ./bazel-out ]] && readlink -qf ./bazel-out; then
     local BAZELCACHE
     BAZELCACHE="$(readlink -f ./bazel-out)"
     BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,10 +2,12 @@
 
 ## Releases
 
-### unreleased
+### 0.2.31
 
+* `gee rmbr`: fails functional if the directory bazel-out links to has already
+  been removed. (#630)
 * `gee pr_make`: Make parsing of PR description more robust by parsing comments
-  like blank lines.
+  like blank lines. (#629)
 * `gee diff`: show only new changes in this branch since branches diverged (#628)
 * `gee lspr`: fix incomplete reviews list (#627)
 *

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.30
+gee version: 0.2.31
 
 gee is a wrapper around the "git" and "gh-cli" tools.  "gee" captures all
 tribal knowledge about how to use git the right way (for us), implementing one


### PR DESCRIPTION
The problem: "gee rmbr" was failing-and-exiting for branches where the
bazel-out link exists, but points to a bazel cache directory that is no longer
there.  This PR makes gee tolerant of this error case.

Tested: Used to remove a branch with a broken link.

```
$ ~/gee/enkit/fix_rmbr/scripts/gee rmbr pr_4628

####################
# Deleting pr_4628 #
####################
WARNING: Branch "pr_4628" is 2 commit(s) ahead of master.
Are you sure you want to force-remove branch pr_4628? (y/N) y
As you wish.
CMD: /usr/bin/git worktree remove --force pr_4628
CMD: /usr/bin/git branch -D pr_4628
Deleted branch pr_4628 (was 565db1b86).
CMD: /usr/bin/git push --quiet origin --delete pr_4628
Deleted pr_4628.  To undo: gee make_branch pr_4628 565db1b86
```
