### PR TITLE
`enkit bazel`: Propagate environment to all bazel commands

### DIFF
--- a/lib/bazel/workspace.go
+++ b/lib/bazel/workspace.go
@@ -70,6 +70,7 @@ func (w *Workspace) bazelCommand(subCmd subcommand) (Command, error) {
 	args = append(args, subCmd.Args()...)
 	cmd := exec.Command("bazel", args...)
 	cmd.Dir = w.root
+	cmd.Env = os.Environ()
 	bazelCmd, err := NewCommand(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct bazel command: %w", err)


### PR DESCRIPTION
This change ensures that underlying Bazel commands all run with the
expected environment, which may be setting `BAZEL_PROFILE` to be picked
up by our wrapper in `tools/bazel`.

Jira: INFRA-1120