### PR TITLE
bazel/linux: mark images as executable, and minor logging fix.

### DIFF
--- a/bazel/linux/repository.bzl
+++ b/bazel/linux/repository.bzl
@@ -125,6 +125,8 @@ def _install_kernel_image(ctx, candidate, required):
     if not versioned_path.exists:
         path = candidate
 
+    # vmlinuz file may need to be executed (for uml, mark it as such).
+    ctx.execute(["chmod", "0755", path])
     return ("image", ctx.attr.template_image, {
         "image_path": path,
     })
@@ -146,7 +148,7 @@ def _kernel_package(ctx):
             stripPrefix = ctx.attr.strip_prefix,
         )
     else:
-        fail("WORKSPACE repository {}: Provide either a URL, OR an astore path and UID (extract must be True)".format(name = ctx.attr.name))
+        fail("WORKSPACE repository {name}: Either provide an 'url' attribute for HTTP download, OR an astore path and uid (only if extract = True)".format(name = ctx.attr.name))
 
     fragments = []
     if "tree" in ctx.attr.allowed:


### PR DESCRIPTION
Background:
UML images must have the x bit in order to be usable. Add a chmod
0755 <image path> to be more tolerant to different package formats.

Additionally, fix broken fail message.
Helps with SF-186 and SF-155.
