### PR TITLE
kbuild: create UML vmlinuz-modules.tar.gz artifact

### DIFF
--- a/kbuild/v2/README.adoc
+++ b/kbuild/v2/README.adoc
@@ -60,6 +60,7 @@ needs to be installed:
             libcap-dev       \
             python3-docutils \
             asciidoc         \
+            jq               \
             zstd
 
 ```

--- a/kbuild/v2/scripts/build-uml.sh
+++ b/kbuild/v2/scripts/build-uml.sh
@@ -57,3 +57,7 @@ make ARCH=um O="$OUTPUT_UML_DIR" olddefconfig
 
 # Build the kernel with our LOCAL version
 make -j ARCH=um O="$OUTPUT_UML_DIR" LOCALVERSION="$kernel_version" all
+
+# Build and install the kernel modules
+make -j ARCH=um O="$OUTPUT_UML_DIR" LOCALVERSION="$kernel_version" \
+     INSTALL_MOD_PATH="${OUTPUT_UML_DIR}/modules-install" modules_install

--- a/kbuild/v2/scripts/build-uml.sh
+++ b/kbuild/v2/scripts/build-uml.sh
@@ -24,7 +24,9 @@ if [ ! -r "$KERNEL_VERSION" ] ; then
     echo "ERROR: unable to read kernel version file: $KERNEL_VERSION"
     exit 1
 fi
-kernel_version="$(cat $KERNEL_VERSION)"
+
+flavour="test"
+kernel_version="$(cat $KERNEL_VERSION)-${flavour}"
 
 # clean output UML dir
 if [ "$RT_CLEAN_BUILD" = "yes" ] ; then

--- a/kbuild/v2/scripts/gen-bazel-meta.sh
+++ b/kbuild/v2/scripts/gen-bazel-meta.sh
@@ -96,14 +96,15 @@ gen_deb_flavours() {
 gen_uml() {
     local kernel_version="$(uml_get_kernel_version $OUTPUT_UML_DIR)"
 
+    local flavour="test"
+
     ## build-headers.tar.gz
     local astore_file="build-headers.tar.gz"
-    gen_artifact_desc "KERNEL_TREE" $kernel_version test $astore_file
+    gen_artifact_desc "KERNEL_TREE" $kernel_version "$flavour" $astore_file
 
-    ## kernel image
-    local astore_file="vmlinuz"
-    gen_artifact_desc "KERNEL_IMAGE" $kernel_version test $astore_file
-
+    ## vmlinuz-modules.tar.gz
+    local astore_file="vmlinuz-modules.tar.gz"
+    gen_artifact_desc "KERNEL_BIN" $kernel_version "$flavour" $astore_file
 }
 
 gen_deb_flavours

--- a/kbuild/v2/scripts/gen-bazel-meta.sh
+++ b/kbuild/v2/scripts/gen-bazel-meta.sh
@@ -56,7 +56,7 @@ gen_artifact_desc() {
     local astore_path="/${ASTORE_ROOT}/${flavour}/${astore_file}"
     local astore_meta="${ASTORE_META_DIR}/${astore_file}-${kernel_version}.json"
     if [ ! -r "$astore_meta" ] ; then
-        echo "ERROR: Unable to read build-headers.tar.gz astore meta file: $astore_meta"
+        echo "ERROR: Unable to read astore meta file: $astore_meta"
         exit 1
     fi
 
@@ -88,7 +88,7 @@ gen_deb_flavours() {
 
         ## vmlinuz-modules.tar.gz
         local astore_file="vmlinuz-modules.tar.gz"
-        gen_artifact_desc "KERNEL_MODULES" $kernel_version $f $astore_file
+        gen_artifact_desc "KERNEL_BIN" $kernel_version $f $astore_file
 
     done
 }

--- a/kbuild/v2/scripts/lib.sh
+++ b/kbuild/v2/scripts/lib.sh
@@ -52,7 +52,7 @@ deb_get_kernel_version() {
 uml_get_kernel_version() {
     local uml_dir="$1"
 
-    kernel_version="$(cat ${uml_dir}/include/config/kernel.release)-uml"
+    kernel_version="$(cat ${uml_dir}/include/config/kernel.release)"
     echo -n "$kernel_version"
 }
 

--- a/kbuild/v2/scripts/upload-uml.sh
+++ b/kbuild/v2/scripts/upload-uml.sh
@@ -81,8 +81,8 @@ upload_uml_kernel_image_modules() {
 
     # copy vmlinuz into tarball directory and make it executable
     mkdir -p "${tmpdir}/boot"
-    /bin/cp "$uml_image" "${tmpdir}/boot/vmlinuz-${kernel_version}"
-    chmod a+x "${tmpdir}/boot/vmlinuz-${kernel_version}"
+    /bin/cp "$uml_image" "$vmlinuz"
+    chmod a+x "$vmlinuz"
 
     # copy modules into tarball directory
     /bin/cp -r "${uml_modules_dir}/lib" "$tmpdir"


### PR DESCRIPTION
This PR creates a vmlinuz-modules.tar.gz artifact for the UML
testing kernel that matches the same format used by the "generic" and
"minimal" kernel flavours.

Fixes: SF-186
