### PR TITLE
bazel/linux: test cleanups, and qemu_test target

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,10 +1,7 @@
-load("//bazel/linux:uml.bzl", "kernel_uml_run")
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimeBundleInfo")
 load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible", "is_module")
-load("//bazel/linux:bundles.bzl", "kunit_bundle")
+load("//bazel/linux:test.bzl", "kunit_test")
 load("//bazel/utils:messaging.bzl", "location", "package")
-load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
-load("//bazel/utils:exec_test.bzl", "exec_test")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _kernel_modules(ctx):
@@ -519,18 +516,5 @@ Example:
     },
 )
 
-def kernel_test(name, kernel_image, module, rootfs_image = None, kunit_bundle_cfg = {}, runner_cfg = {}, runner = kernel_uml_run, **kwargs):
-    runtime = mcreate_rule(
-        name,
-        kunit_bundle,
-        "runtime",
-        kunit_bundle_cfg,
-        kwargs,
-        mconfig(module = module, image = kernel_image),
-    )
-
-    cfg = mconfig(run = [runtime], kernel_image = kernel_image)
-    if rootfs_image:
-        cfg = mconfig(cfg, rootfs_image = rootfs_image)
-    name_runner = mcreate_rule(name, runner, "emulator", runner_cfg, kwargs, cfg)
-    exec_test(name = name, dep = name_runner)
+# Remove once all uses of kernel_test are removed.
+kernel_test = kunit_test

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,4 +1,3 @@
-load("//bazel/linux:repository.bzl", _kernel_image_version = "kernel_image_version", _kernel_tree_version = "kernel_tree_version", _rootfs_version = "rootfs_version")
 load("//bazel/linux:uml.bzl", "kernel_uml_run")
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimeBundleInfo")
 load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible", "is_module")
@@ -7,16 +6,6 @@ load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
 load("//bazel/utils:exec_test.bzl", "exec_test")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-
-# Symbols loaded from an external library are private by default.
-# Reassign those symbols to private variables so that old code using:
-#
-#   load("bazel/linux/defs.bzl", "kernel_tree_version")
-#
-# still works.
-kernel_tree_version = _kernel_tree_version
-kernel_image_version = _kernel_image_version
-rootfs_version = _rootfs_version
 
 def _kernel_modules(ctx):
     modules = ctx.attr.modules

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -1,0 +1,43 @@
+load("//bazel/linux:uml.bzl", "kernel_uml_run")
+load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
+load("//bazel/utils:exec_test.bzl", "exec_test")
+load("//bazel/linux:bundles.bzl", "kunit_bundle")
+
+def kunit_test(name, kernel_image, module, rootfs_image = None,
+               kunit_bundle_cfg = {}, runner_cfg = {},
+               runner = kernel_uml_run, **kwargs):
+    """Instantiates all the rules necessary to create a kunit test.
+
+    Creates 3 rules:
+       {name}-runtime: which when built will create a kunit bundle for use.
+       {name}-emulator: which when run will invoke the specified emulator
+           together with the generated kunit runtime.
+       {name}: which when executed as a test will invoke the emulator, and
+           fail/succeed based on the results of the checks.
+    Args:
+      kernel_image: label, something like @type-of-kernel//:image,
+          a kernel image to use.
+      module: label, a module representing a kunit test to run.
+      rootfs_image: optional, label, a rootfs image to use for the test.
+      kunit_bundle_cfg: optional, dict, attributes to pass to the instantiated
+          kunit_bundle rule, follows the mconfig use pattern.
+      runner_cfg: optional, dict, attributes to pass to the instantiated
+          runner rule, follows the mconfig use pattern.
+      runner: a rule function, will be invoked to create the runner using
+          the generated kunit bundle.
+      kwargs: options common to all instantiated rules.
+    """ 
+    runtime = mcreate_rule(
+        name,
+        kunit_bundle,
+        "runtime",
+        kunit_bundle_cfg,
+        kwargs,
+        mconfig(module = module, image = kernel_image),
+    )
+
+    cfg = mconfig(run = [runtime], kernel_image = kernel_image)
+    if rootfs_image:
+        cfg = mconfig(cfg, rootfs_image = rootfs_image)
+    name_runner = mcreate_rule(name, runner, "emulator", runner_cfg, kwargs, cfg)
+    exec_test(name = name, dep = name_runner)

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -1,7 +1,30 @@
 load("//bazel/linux:uml.bzl", "kernel_uml_run")
+load("//bazel/linux:qemu.bzl", "kernel_qemu_run")
 load("//bazel/utils:macro.bzl", "mconfig", "mcreate_rule")
 load("//bazel/utils:exec_test.bzl", "exec_test")
 load("//bazel/linux:bundles.bzl", "kunit_bundle")
+
+def qemu_test(name, kernel_image, run, qemu_binary = None,
+              config = {}, **kwargs):
+    """Instantiates all the rules necessary to create a qemu based test.
+
+    Specifically:
+        {name}-run: which when run will execute a kernel_qemu_run target
+           with the configs specified in config.
+        {name}: which when executed as a test will invoke {name}-run and
+           succeed if the target exits with 0.
+
+    Args:
+        kernel_image, run, qemu_binary: passed as is to the generated
+            kernel_qemu_run rule. Exposed externally for convenience.
+        config: dict, all additional attributes to pass to the
+            kernel_qemu_run rule, generally created with mconfig().
+    """
+    runner = mcreate_rule(
+        name, kernel_qemu_run, "run", config, kwargs,
+        mconfig(kernel_image = kernel_image, qemu_binary = qemu_binary),
+    )
+    exec_test(name = name, dep = runner, **kwargs)
 
 def kunit_test(name, kernel_image, module, rootfs_image = None,
                kunit_bundle_cfg = {}, runner_cfg = {},
@@ -40,4 +63,4 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
     name_runner = mcreate_rule(name, runner, "emulator", runner_cfg, kwargs, cfg)
-    exec_test(name = name, dep = name_runner)
+    exec_test(name = name, dep = name_runner, **kwargs)


### PR DESCRIPTION
- bazel/linux: remove compatibility rules.
- bazel/linux: rename kernel_test to kunit_test, move in test.bzl file.
- bazel/linux: add a qemu_test target.

See log for individual commits. This should help with SF-162 ans SF-150.