### PR TITLE
bazel/linux: propagate the exit status outside the emulator

### DIFF
--- a/bazel/linux/templates/init-uml.template.sh
+++ b/bazel/linux/templates/init-uml.template.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 echo ========= {message} - {target} ==========
-trap "poweroff -f" EXIT
+on_exit() {
+    echo $? > "/tmp/output_dir/exit_status_file" || true
+    poweroff -f
+}
+trap on_exit EXIT
 
 # Find the "root" where the package was mounted.
 path="$0"

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -161,6 +161,11 @@ test "$estatus" == 0 || {
     echo 1>&2 "===== emulator exited with non zero status - check logs above ===="
     exit "$estatus"
 }
+test -f "$OUTPUT_DIR/exit_status_file" && estatus=$(< "$OUTPUT_DIR/exit_status_file")
+test "$estatus" == 0 || {
+    echo 1>&2 "===== a program in the emulator exited with non zero status - check logs above ===="
+    exit "$estatus"
+}
 test -z "$INTERACTIVE" -a -z "$SINGLE" || exit "$estatus"
 
 echo 1>&2 "===== emulator exited - now running checkers (if any) ===="


### PR DESCRIPTION
Success or failure inside the emulator is depicted in the exit status of
bazel run. The init script that executes in the emulator stores its exit
status in a temporary file. The script that executes the emulator
adjusts its own exit status based on this file.

Jira: https://enfabrica.atlassian.net/browse/SF-165
Signed-off-by: George Prekas <george@enfabrica.net>