### PR TITLE
bazel/linux: pass command line arguments to QEMU wrapper scripts

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -56,11 +56,15 @@ test -z "$SINGLE" || KERNEL_FLAGS+=("init=/bin/sh")
 QEMU_FLAGS+=("-append" "${{KERNEL_FLAGS[*]}} ${{KERNEL_OPTS[*]}}")
 QEMU_FLAGS+=("${{EMULATOR_OPTS[@]}}")
 
-echo 1>&2 '$' "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"
+if [ ${{#WRAPPER_OPTS[@]}} -ne 0 ]; then
+    WRAPPER_OPTS=('--' "${{WRAPPER_OPTS[@]}}")
+fi
+
+echo 1>&2 '$' "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" "${{WRAPPER_OPTS[@]}}"
 if [ -z "$INTERACTIVE" -a -z "$SINGLE" ]; then
-    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" </dev/null | tee "$OUTPUT_FILE"
+    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" "${{WRAPPER_OPTS[@]}}" </dev/null | tee "$OUTPUT_FILE"
 else
-    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}"
+    "$QEMU_BINARY" "${{QEMU_FLAGS[@]}}" "${{WRAPPER_OPTS[@]}}"
 fi
 """
     qemu_search = ctx.attr.qemu_search

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -115,6 +115,8 @@ while getopts "k:e:r:hsx" opt; do
 done
 shift $((OPTIND - 1))
 
+WRAPPER_OPTS=("$@")
+
 showstate
 
 echo 1>&2 "======================================"
@@ -140,11 +142,12 @@ trap onexit EXIT
 #   - OUTPUT_FILE - console output must be stored in this file
 #                   (kernel boot log, and any shell output).
 #   - OUTPUT_DIR - directory where to store any other output file.
+#   - WRAPPER_OPTS - extra command line arguments to emulator wrapper script.
 #
 # - Additionally, they should check for:
 #   - KERNEL_OPTS - array, may have additional kernel arguments.
 #   - EMULATOR_OPTS - array, may have additional arguments for the emulator.
-for var in TARGET KERNEL INIT ROOTFS RUNTIME TMPDIR INTERACTIVE SINGLE OUTPUT_FILE OUTPUT_DIR KERNEL_OPTS EMULATOR_OPTS; do
+for var in TARGET KERNEL INIT ROOTFS RUNTIME TMPDIR INTERACTIVE SINGLE OUTPUT_FILE OUTPUT_DIR KERNEL_OPTS EMULATOR_OPTS WRAPPER_OPTS; do
     export "$var"
 done
 


### PR DESCRIPTION
Prefix all arguments that are handled by the runner itself with
--runner-. The rest of the arguments are stored in an array ARGS and are
available to a potential QEMU wrapper script.

Jira: https://enfabrica.atlassian.net/browse/SF-194
Signed-off-by: George Prekas <george@enfabrica.net>