### PR TITLE
bazel/linux: change the configuration of qemu_binary from host to target

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -102,7 +102,7 @@ See the RuntimeBundleInfo provider for details.
             "qemu_binary": attr.label(
                 doc = "A target defining the qemu binary to run. If unspecified, it will use a search path",
                 executable = True,
-                cfg = "host",
+                cfg = "target",
             ),
             "qemu_search": attr.string_list(
                 doc = "Qemu binaries to try to run, in turn, until one is found. Ignored if qemu_binary is specified.",


### PR DESCRIPTION
The host configuration is compiled with optimizations enabled and the
target configuration is compiled with the fastbuild compilation mode. To
maintain consistency with the other built binaries, which are built with
the target configuration, change it for the qemu_binary attribute in the
kernel_qemu_run rule.

Signed-off-by: George Prekas <george@enfabrica.net>