### PR TITLE
meson: add Bazel support for building with Meson

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -205,3 +205,20 @@ def stage_1():
         strip_prefix = "protobuf-3.20.1",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.1.tar.gz"],
     )
+
+    maybe(
+        name = "rules_foreign_cc",
+        repo_rule = http_archive,
+        sha256 = "bcd0c5f46a49b85b384906daae41d277b3dc0ff27c7c752cc51e43048a58ec83",
+        strip_prefix = "rules_foreign_cc-0.7.1",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.7.1.tar.gz",
+    )
+
+    maybe(
+        name = "meson",
+        repo_rule = http_archive,
+        build_file = "@enkit//bazel/meson:meson.BUILD.bazel",
+        sha256 = "a0f5caa1e70da12d5e63aa6a9504273759b891af36c8d87de381a4ed1380e845",
+        urls = ["https://github.com/mesonbuild/meson/releases/download/0.62.1/meson-0.62.1.tar.gz"],
+        strip_prefix = "meson-0.62.1",
+    )

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -4,6 +4,7 @@ See README.md for more information.
 """
 
 load("//bazel:go_repositories.bzl", "go_repositories")
+load("//bazel/meson:meson.bzl", "meson_register_toolchains")
 load("//bazel/ui:deps.bzl", "install_ui_deps")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
@@ -15,6 +16,7 @@ load("@io_bazel_rules_docker//go:image.bzl", rules_docker_go_dependencies = "rep
 load("@io_bazel_rules_docker//repositories:deps.bzl", rules_docker_container_dependencies = "deps")
 load("@io_bazel_rules_docker//repositories:repositories.bzl", rules_docker_dependencies = "repositories")
 load("@io_bazel_rules_go//extras:embed_data_deps.bzl", "go_embed_data_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
@@ -96,3 +98,6 @@ def stage_2():
     grpc_web_plugin_linux()
     grpc_web_plugin_darwin()
     grpc_web_plugin_windows()
+
+    rules_foreign_cc_dependencies()
+    meson_register_toolchains()

--- a/bazel/meson/meson.BUILD.bazel
+++ b/bazel/meson/meson.BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_foreign_cc//toolchains/native_tools:native_tools_toolchain.bzl", "native_tool_toolchain")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "meson_bin",
+    srcs = ["meson.py"],
+)
+
+native_tool_toolchain(
+    name = "meson_tool",
+    path = "$(execpath :meson_bin)",
+    target = ":meson_bin",
+)
+
+toolchain(
+    name = "meson_toolchain",
+    toolchain = ":meson_tool",
+    toolchain_type = ":meson_toolchain_type",
+)
+
+toolchain_type(
+    name = "meson_toolchain_type",
+)

--- a/bazel/meson/meson.bzl
+++ b/bazel/meson/meson.bzl
@@ -1,0 +1,107 @@
+load("@rules_foreign_cc//foreign_cc/private:detect_root.bzl", "detect_root")
+load("@rules_foreign_cc//toolchains/native_tools:tool_access.bzl", "access_tool")
+load("@rules_foreign_cc//foreign_cc/private:make_script.bzl", "pkgconfig_script")
+load("@rules_foreign_cc//foreign_cc/private:make_env_vars.bzl", "get_make_env_vars")
+load("@rules_foreign_cc//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info", "get_tools_info")
+load(
+    "@rules_foreign_cc//foreign_cc/private:framework.bzl",
+    "CC_EXTERNAL_RULE_ATTRIBUTES",
+    "CC_EXTERNAL_RULE_FRAGMENTS",
+    "cc_external_rule_impl",
+    "create_attrs",
+    "expand_locations_and_make_variables",
+)
+
+def _create_meson_script(configureParameters):
+    ctx = configureParameters.ctx
+    inputs = configureParameters.inputs
+
+    tools = get_tools_info(ctx)
+    flags = get_flags_info(ctx)
+    data = ctx.attr.data + ctx.attr.build_data
+    user_env = expand_locations_and_make_variables(ctx, "env", data)
+
+    ext_build_dirs = inputs.ext_build_dirs
+
+    script = pkgconfig_script(ext_build_dirs)
+
+    script.append("{env_vars} meson.py setup --prefix {prefix} {builddir} {sourcedir}".format(
+        env_vars = get_make_env_vars(ctx.workspace_name, tools, flags, user_env, ctx.attr.deps, inputs),
+        prefix = "$$INSTALLDIR$$",
+        builddir = "$$BUILD_TMPDIR$$",
+        sourcedir = "$$EXT_BUILD_ROOT$$/" + detect_root(ctx.attr.lib_source),
+    ))
+
+    script.append("meson.py install -C {dir}".format(
+        dir = "$$BUILD_TMPDIR$$",
+    ))
+
+    return script
+
+def _access_and_expect_label_copied(toolchain_type_, ctx):
+    tool_data = access_tool(toolchain_type_, ctx, "")
+
+    # This could be made more efficient by changing the
+    # toolchain to provide the executable as a target
+    cmd_file = tool_data
+    for f in tool_data.target.files.to_list():
+        if f.path.endswith("/" + tool_data.path):
+            cmd_file = f
+            break
+    return struct(
+        deps = [tool_data.target],
+        # as the tool will be copied into tools directory
+        path = "$EXT_BUILD_ROOT/{}".format(cmd_file.path),
+    )
+
+def get_meson_data(ctx):
+    return _access_and_expect_label_copied(Label("@meson//:meson_toolchain_type"), ctx)
+
+def _meson_impl(ctx):
+    cmake_data = get_meson_data(ctx)
+
+    tools_deps = cmake_data.deps
+
+    attrs = create_attrs(
+        ctx.attr,
+        configure_name = "Meson",
+        create_configure_script = _create_meson_script,
+        tools_deps = tools_deps,
+    )
+    return cc_external_rule_impl(ctx, attrs)
+
+meson = rule(
+    doc = """Rule for building external library with Meson.
+
+Here is an example on how to use this rule:
+
+```
+load("@enkit//bazel/meson:meson.bzl", "meson")
+
+filegroup(
+    name = "src",
+    srcs = glob(["**"]),
+)
+
+meson(
+    name = "program",
+    lib_source = ":src",
+    out_binaries = [
+        "program",
+    ],
+)
+```
+""",
+    attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES),
+    fragments = CC_EXTERNAL_RULE_FRAGMENTS,
+    output_to_genfiles = True,
+    implementation = _meson_impl,
+    toolchains = [
+        "@meson//:meson_toolchain_type",
+        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    ],
+    incompatible_use_toolchain_transition = True,
+)
+
+def meson_register_toolchains():
+    native.register_toolchains("@meson//:meson_toolchain")

--- a/bazel/meson/test/BUILD.bazel
+++ b/bazel/meson/test/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@enkit//bazel/meson:meson.bzl", "meson")
+
+filegroup(
+    name = "src",
+    srcs = glob(["**"]),
+)
+
+meson(
+    name = "hello",
+    lib_source = ":src",
+    out_binaries = [
+        "hello",
+    ],
+)

--- a/bazel/meson/test/hello.c
+++ b/bazel/meson/test/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+	printf("Hello, world!\n");
+	return 0;
+}

--- a/bazel/meson/test/meson.build
+++ b/bazel/meson/test/meson.build
@@ -1,0 +1,2 @@
+project('hello', 'c')
+executable('hello', 'hello.c', install : true)


### PR DESCRIPTION
Add Meson as a cc_external_rule. Can be used in a similar way to cmake
from rules_foreign_cc.

Signed-off-by: George Prekas <george@enfabrica.net>