### PR TITLE
bazel/meson: fix missing toolchain argument

### DIFF
--- a/bazel/meson/meson.bzl
+++ b/bazel/meson/meson.bzl
@@ -97,6 +97,7 @@ meson(
     output_to_genfiles = True,
     implementation = _meson_impl,
     toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
         "@meson//:meson_toolchain_type",
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
     ],


### PR DESCRIPTION
Fixes the following error:

"Error in fail: In order to use find_cpp_toolchain, you must include the
'@bazel_tools//tools/cpp:toolchain_type' in the toolchains argument to
your rule."

Signed-off-by: George Prekas <george@enfabrica.net>