### PR TITLE
astore_package: Raise sha256sum timeout

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -151,7 +151,7 @@ def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = Non
 
     # Check digest of archive
     checksum_args = ["sha256sum", f]
-    res = ctx.execute(checksum_args, timeout = 10)
+    res = ctx.execute(checksum_args, timeout = 60)
     if res.return_code:
         fail("Failed to calculate checksum\nArgs: {}\nStdout:\n{}\nStderr:\n{}\n".format(
             checksum_args,


### PR DESCRIPTION
This change raises the timeout for calculating the sha256 of items
downloaded from enkit. This timeout is currently causing false failures
in presubmits - while an individual sha256 should be relatively fast
compared to the old timeout, it is likely that the Cloud Build machine
is downloading/unpacking other items concurrently and is therefore
slower than expected.

Jira: INFRA-1179