### PR TITLE
enkit affected tests: made broken build graph an error

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -116,10 +116,14 @@ func GetAffectedTargets(start string, end string, config *ppb.PresubmitConfig, l
 		if startQueryErr != nil && endQueryErr == nil {
 			// We are calculating targets over a change that fixes the build graph
 			// (broken before, working after).  Since we cannot calculate the affected
-      // targets, we fail the presubmit and inform the user that they must both
-      // test their change manually, and submit by overriding the presubmit test.
-			log.Warnf("Got error at start point:\n%v\n", startQueryErr)
-      log.Warnf("If this PR is fixing a known broken build graph, it must be manually tested and then override the presubmit check to submit.")
+			// targets, we fail the presubmit and inform the user that they must both
+			// test their change manually, and submit by overriding the presubmit test.
+			log.Warnf("Got error at start point:\n%v\n"+
+				"\n"+
+				"It is impossible to determine the set of affected tests.\n"+
+				"If this PR is fixing a known broken build graph, it must be\n"+
+				"manually tested and force-submitted (overriding this presubmit\n"+
+				"check) to submit.\n", startQueryErr)
 		}
 		return nil, nil, errs
 	}

--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -115,14 +115,11 @@ func GetAffectedTargets(start string, end string, config *ppb.PresubmitConfig, l
 	if errs != nil {
 		if startQueryErr != nil && endQueryErr == nil {
 			// We are calculating targets over a change that fixes the build graph
-			// (broken before, working after). In a presubmit context, we want this
-			// step to succeed, but there is no sensible list of targets that the
-			// change affects since the build graph was broken in one stage.
-			//
-			// Pass here but emit a warning.
+			// (broken before, working after).  Since we cannot calculate the affected
+      // targets, we fail the presubmit and inform the user that they must both
+      // test their change manually, and submit by overriding the presubmit test.
 			log.Warnf("Got error at start point:\n%v\n", startQueryErr)
-			log.Warnf("Broken build graph detected at start point; this change fixes the build graph, but no targets will be tested. This change must be tested manually.")
-			return nil, nil, nil // No changed targets and no error
+      log.Warnf("If this PR is fixing a known broken build graph, it must be manually tested and then override the presubmit check to submit.")
 		}
 		return nil, nil, errs
 	}


### PR DESCRIPTION
This PR causes presubmits where either the start or end build graph is broken
to fail.  Rationale: it's better to ask a user who is submitting a PR that
fixes the build graph to force-submit (override the presubmit), than to run the
risk of a PR that isn't fixing the build graph to accidentally have an
incorrect "pass" result.

The rationale for the original code was that this situation only arises
if the user is fixing a build graph that is broken at top-of-tree.  Unfortunately,
bazel isn't 100% reliable at generating build graphs, and so there are
other reasons why a start build graph might fail.

This PR makes it mandatory that a PR that fixes the build graph manually
test, and the override the presubmit in order to merge changes.

Jira: INFRA-1179

Tested: existing unit tests pass.  I am unable to force bazel to fail on
demand, but this change is pretty straightforward.

