### PR TITLE
enproxy: Add /get_srv_port handler

### DIFF
--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//lib/errdiff:go_default_library",
         "//lib/khttp:go_default_library",
         "//lib/khttp/ktest:go_default_library",
         "//lib/khttp/protocol:go_default_library",
@@ -39,6 +40,7 @@ go_test(
         "//lib/token:go_default_library",
         "//proxy/utils:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_prashantv_gostub//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -31,6 +31,9 @@ type ProxyErrors struct {
 	SshResumeNoSID   utils.Counter
 	SshCreateExists  utils.Counter
 	SshDialFailed    utils.Counter
+
+	SrvLookupFailed      utils.Counter
+	SrvLookupInvalidAuth utils.Counter
 }
 
 type BrowserWindowCounters struct {


### PR DESCRIPTION
We want to allow `enkit tunnel` to infer ports for Consul DNS names, as
Consul also exposes SRV records with port numbers. Since clients don't
have access to query Consul DNS directly (only enproxy is on that
network segment) clients must either indicate to enproxy that it should
look up port numbers via DNS, or clients must query enproxy for this
info before creating a tunnel.

This change implements the latter approach by implementing a
`/get_srv_port` authenticated handler. After authentication, enproxy
looks for an SRV record for the specified host, and returns the port of
the first SRV record returned, or an error. The returned port is
marshaled into a JSON response, so further response params can be added
in the future.

Tested: Added test

Jira: INFRA-1223