### PR TITLE
enkit tunnel: Add --use-srv-port flag

### DIFF
--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//lib/errdiff:go_default_library",
         "//lib/khttp:go_default_library",
         "//lib/khttp/ktest:go_default_library",
         "//lib/khttp/protocol:go_default_library",
@@ -39,6 +40,7 @@ go_test(
         "//lib/token:go_default_library",
         "//proxy/utils:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_prashantv_gostub//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -31,6 +31,9 @@ type ProxyErrors struct {
 	SshResumeNoSID   utils.Counter
 	SshCreateExists  utils.Counter
 	SshDialFailed    utils.Counter
+
+	SrvLookupFailed      utils.Counter
+	SrvLookupInvalidAuth utils.Counter
 }
 
 type BrowserWindowCounters struct {

--- a/proxy/nasshp/nassh.go
+++ b/proxy/nasshp/nassh.go
@@ -89,9 +89,9 @@ func (s *sessions) Orphan(sid string) {
 	s.Orphaned.Increment()
 }
 
-// getSRVPortResponse is marshalled to JSON and returned by the /get_srv_port
+// GetSRVPortResponse is marshalled to JSON and returned by the /get_srv_port
 // handler.
-type getSRVPortResponse struct {
+type GetSRVPortResponse struct {
 	// Port for the queried hostname
 	Port uint16 `json:"port"`
 }
@@ -538,7 +538,7 @@ func (np *NasshProxy) GetSRVPort(w http.ResponseWriter, r *http.Request) {
 		np.requestError(&np.errors.SrvLookupFailed, w, "no SRV records for %q", host, err)
 		return
 	}
-	res := getSRVPortResponse{
+	res := GetSRVPortResponse{
 		Port: srvs[0].Port,
 	}
 	if err := json.NewEncoder(w).Encode(res); err != nil {


### PR DESCRIPTION
This change adds a boolean flag `--use-srv-port`. When set, this flag
ignores the target port arg and instead queries enproxy for an
appropriate target port based on an SRV record lookup.

Tested: Against current enproxy, fails with 404 as expected

Jira: INFRA-1223