### PR TITLE
bazel/linux: expose /dev/output_dir

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -48,6 +48,10 @@ else
     KERNEL_FLAGS+=("root=/dev/root" "rootfstype=9p" "init=$INIT")
     KERNEL_FLAGS+=("rootflags=trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl")
 fi
+
+QEMU_FLAGS+=("-fsdev" "local,security_model=none,multidevs=remap,id=fsdev-fsOutputDir,path=$OUTPUT_DIR")
+QEMU_FLAGS+=("-device" "virtio-9p-pci,fsdev=fsdev-fsOutputDir,mount_tag=/dev/output_dir")
+
 test -z "$KERNEL" || QEMU_FLAGS+=("-kernel" "$KERNEL")
 test -z "$SINGLE" || KERNEL_FLAGS+=("init=/bin/sh")
 

--- a/bazel/linux/templates/init-qemu.template.sh
+++ b/bazel/linux/templates/init-qemu.template.sh
@@ -10,4 +10,17 @@ dir="${path%%$relpath}"
 test "$dir" == "$path" || cd "$dir"
 
 set -e
+
+# Remount / with the nosuid flag. Otherwise the following mount fails with:
+# mount: only root can use "--options" option (effective UID is 65534)
+python -c 'import ctypes; exit(ctypes.cdll.LoadLibrary("libc.so.6").mount("", "/", "", 2|32, 0))'
+
+mount --types tmpfs tmpfs /tmp
+
+# Mount the output directory. This directory is shared with the host.
+mkdir /tmp/output_dir
+mount --types 9p \
+    --options trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl \
+    /dev/output_dir /tmp/output_dir
+
 {commands}


### PR DESCRIPTION
Map the $OUTPUT_DIR directory from the host to the device
/dev/output_dir in the guest.

Signed-off-by: George Prekas <george@enfabrica.net>