### PR TITLE
enproxy: Use negative port to signal auto port detection

### DIFF
--- a/proxy/nasshp/BUILD.bazel
+++ b/proxy/nasshp/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "browser.go",
         "counters.go",
         "nassh.go",
+        "resolver.go",
         "window.go",
     ],
     importpath = "github.com/enfabrica/enkit/proxy/nasshp",
@@ -40,5 +41,6 @@ go_test(
         "//proxy/utils:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/proxy/nasshp/counters.go
+++ b/proxy/nasshp/counters.go
@@ -17,8 +17,7 @@ type ProxyErrors struct {
 	CookieInvalidAuth       utils.Counter
 
 	ProxyInvalidAuth     utils.Counter
-	ProxyInvalidPort     utils.Counter
-	ProxyInvalidHost     utils.Counter
+	ProxyInvalidHostPort utils.Counter
 	ProxyCouldNotEncrypt utils.Counter
 	ProxyAllow           AllowErrors
 
@@ -161,16 +160,10 @@ var (
 		nil, prometheus.Labels{"url": "/proxy", "error": "invalid auth", "type": "unauthorized"},
 	)
 
-	descProxyInvalidPort = prometheus.NewDesc(
+	descProxyInvalidHostPort = prometheus.NewDesc(
 		"nasshp_url_errors",
 		helpError,
-		nil, prometheus.Labels{"url": "/proxy", "error": "invalid port", "type": "bad client"},
-	)
-
-	descProxyInvalidHost = prometheus.NewDesc(
-		"nasshp_url_errors",
-		helpError,
-		nil, prometheus.Labels{"url": "/proxy", "error": "invalid host", "type": "bad client"},
+		nil, prometheus.Labels{"url": "/proxy", "error": "invalid host/port", "type": "bad client"},
 	)
 
 	descProxyCouldNotEncrypt = prometheus.NewDesc(
@@ -472,8 +465,7 @@ func (nc *nasshCollector) Collect(ch chan<- prometheus.Metric) {
 		{descCookieInvalidParameters, errors.CookieInvalidParameters.Get()},
 		{descCookieInvalidAuth, errors.CookieInvalidAuth.Get()},
 		{descProxyInvalidAuth, errors.ProxyInvalidAuth.Get()},
-		{descProxyInvalidPort, errors.ProxyInvalidPort.Get()},
-		{descProxyInvalidHost, errors.ProxyInvalidHost.Get()},
+		{descProxyInvalidHostPort, errors.ProxyInvalidHostPort.Get()},
 		{descProxyCouldNotEncrypt, errors.ProxyCouldNotEncrypt.Get()},
 
 		{descProxyInvalidCookie, errors.ProxyAllow.InvalidCookie.Get()},

--- a/proxy/nasshp/resolver.go
+++ b/proxy/nasshp/resolver.go
@@ -1,0 +1,68 @@
+package nasshp
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// Resolver can resolve a host+port pair into a potentially different host+port
+// pair.
+type Resolver interface {
+	Resolve(host, port string) (string, string, error)
+}
+
+// MultiResolver is a list of Resolvers that are applied in order until the list
+// is exhausted or an error is encountered.
+type MultiResolver []Resolver
+
+func (r MultiResolver) Resolve(host, port string) (string, string, error) {
+	var err error
+	for _, resolver := range r {
+		host, port, err = resolver.Resolve(host, port)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return host, port, nil
+}
+
+// FailEmptyHost is a Resolver that errors if host is empty, but otherwise
+// returns the host and port unmodified.
+type FailEmptyHost struct{}
+
+func (r *FailEmptyHost) Resolve(host, port string) (string, string, error) {
+	if host == "" {
+		return "", "", fmt.Errorf("invalid empty host %q", host)
+	}
+	return host, port, nil
+}
+
+// FailEmptyPort is a Resolver that errors if port is empty, but otherwise
+// returns the host and port unmodified.
+type FailEmptyPort struct{}
+
+func (r *FailEmptyPort) Resolve(host, port string) (string, string, error) {
+	if port == "" {
+		return "", "", fmt.Errorf("invalid port %q", port)
+	}
+	return host, port, nil
+}
+
+// SRVResolver is a Resolver that attempts to resolve the port via an SRV record
+// if the port is empty.
+type SRVResolver struct{}
+
+func (r *SRVResolver) Resolve(host, port string) (string, string, error) {
+	if port != "" {
+		return host, port, nil
+	}
+	_, srvs, err := net.LookupSRV("", "", host)
+	if err != nil {
+		return "", "", fmt.Errorf("SRV lookup for %q failed: %v", host, err)
+	}
+	if len(srvs) < 1 {
+		return "", "", fmt.Errorf("no SRV records for host %q", host)
+	}
+	return host, strconv.Itoa(int(srvs[0].Port)), nil
+}

--- a/proxy/ptunnel/commands/tunnel.go
+++ b/proxy/ptunnel/commands/tunnel.go
@@ -89,8 +89,10 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) (err error) {
 		return kflags.NewUsageErrorf("Invalid proxy %s specified with --proxy - %w", proxy, err)
 	}
 
+	// Zero port (default) means the server should try to discover the
+	// appropriate port based on the host field.
 	host := ""
-	port := uint16(22)
+	port := uint16(0)
 
 	switch {
 	case len(args) < 1:
@@ -99,6 +101,8 @@ func (r *Tunnel) Run(cmd *cobra.Command, args []string) (err error) {
 		return kflags.NewUsageErrorf("Too many arguments supplied - run '... tunnel <host> [port]', at most 2 arguments")
 	case len(args) == 2:
 		lport, err := strconv.ParseUint(args[1], 10, 16)
+		// The default port is zero, but if the user supplies a port number it
+		// should be a valid port.
 		if err != nil || lport <= 0 || lport > 65535 {
 			return kflags.NewUsageErrorf("Come on! A port number is an integer between 1 and 65535 - %s leads to %w", args[1], err)
 		}

--- a/proxy/ptunnel/tunnel.go
+++ b/proxy/ptunnel/tunnel.go
@@ -93,7 +93,9 @@ func GetSID(proxy *url.URL, host string, port uint16, mods ...GetModifier) (stri
 
 	params := proxy.Query()
 	params.Add("host", host)
-	params.Add("port", fmt.Sprintf("%d", port))
+	if port > 0 {
+		params.Add("port", fmt.Sprintf("%d", port))
+	}
 	curl.RawQuery = params.Encode()
 	curl.Path = path.Join(curl.Path, "/proxy")
 


### PR DESCRIPTION
It's useful to create a mechanism by which the proxy can deduce the
correct target port for `enkit tunnel` based on the host - the first
usecase is by doing SRV record lookup for Consul DNS names.

This change modifies `enkit tunnel` to omit the port arg to
enproxy when no port is provided on the commandline. Enproxy interprets
an absence of a port as requesting port resolution.

In particular:
* `enkit tunnel` defaults to a "0" port when port is not provided on the commandline
* `enkit tunnel` omits the port arg when port is 0 when contacting enproxy
* enproxy treats no port as requiring a port resolution via SRV record, failing if the record lookup fails
* Resolution happens via an injected Resolver; a MultiResolver allows for chaining of multiple Resolvers
* Due to moving out host/port validation into resolvers, granularity on errors is reduced - invalid host and invalid port are combined into the same error, InvalidHostPort.

Tested: Added test

Jira: INFRA-1223