### PR TITLE
postsubmits: Add method of disabling build in config

### DIFF
--- a/infra/postsubmit/proto/postsubmit.proto
+++ b/infra/postsubmit/proto/postsubmit.proto
@@ -19,6 +19,9 @@ message Build {
     // stable value based on the name of this build, which allows builds to not
     // all hammer infrastructure by starting e.g. every hour on the hour.
     string cron = 3;
+
+    // If set, the build is created but never run.
+    bool disabled = 11;
   }
 
   // Bazel target patterns to include in the build.


### PR DESCRIPTION
This change adds a "disable" trigger that creates the build but prevents
it from ever running. This can be used to disable builds on a temporary
basis.

Jira: INFRA-1232