### PR TITLE
astore e2e_test: Fix build, exclude from postsubmits

### DIFF
--- a/astore/BUILD.bazel
+++ b/astore/BUILD.bazel
@@ -1,26 +1,21 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
-# gazelle:exclude e2e_test.go
 go_test(
     name = "go_default_test",
-    srcs = ["server_test.go"],
-    data = glob(["testdata/**"]),
-    deps = [
-        "//astore/atesting:go_default_library",
-        "//astore/rpc:astore-go",
-        "//astore/server/astore:go_default_library",
-        "//lib/srand:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//test/bufconn:go_default_library",
+    srcs = [
+        "e2e_test.go",
+        "server_test.go",
     ],
-)
-
-go_test(
-    name = "e2e_test",
-    srcs = ["e2e_test.go"],
     data = glob(["testdata/**"]),
-    local = True,
-    tags = ["manual"],
+    tags = [
+        # This test spins up emulated Datastore and therefore probably shouldn't
+        # run on Buildbarn.
+        "manual",
+        "no-remote",
+        # TODO(INFRA-1233): This test can't run in the dev container until we
+        # install its dependencies (Datastore emulator)
+        "no-cloudbuild",
+    ],
     deps = [
         "//astore/atesting:go_default_library",
         "//astore/client/astore:go_default_library",

--- a/astore/e2e_test.go
+++ b/astore/e2e_test.go
@@ -3,14 +3,16 @@ package astore_test
 import (
 	"context"
 	"fmt"
+	"log"
+	"testing"
+
 	"github.com/enfabrica/enkit/astore/client/astore"
-	rpcAstore "github.com/enfabrica/enkit/astore/rpc/astore"
+	apb "github.com/enfabrica/enkit/astore/rpc/astore"
 	"github.com/enfabrica/enkit/lib/client/ccontext"
 	"github.com/enfabrica/enkit/lib/logger"
 	"github.com/enfabrica/enkit/lib/progress"
+
 	"github.com/stretchr/testify/assert"
-	"log"
-	"testing"
 )
 
 // TODO(aaahrens): fix client so that its signed urls can depend on an interface for actual e2e testing.
@@ -40,12 +42,12 @@ func TestServer(t *testing.T) {
 	assert.Nil(t, err, "client upload failed with %s", err)
 
 	fmt.Printf("upload is +%v \n", u)
-	storeResponse, err := astoreDescriptor.Server.Store(context.Background(), &rpcAstore.StoreRequest{})
+	storeResponse, err := astoreDescriptor.Server.Store(context.Background(), &apb.StoreRequest{})
 	assert.Nil(t, err)
 	assert.NotEqual(t, "", storeResponse.GetSid())
 	assert.NotEqual(t, "", storeResponse.GetUrl())
 
-	resp, err := astoreDescriptor.Server.Commit(context.Background(), &rpcAstore.CommitRequest{
+	resp, err := astoreDescriptor.Server.Commit(context.Background(), &apb.CommitRequest{
 		Sid:          storeResponse.GetSid(),
 		Architecture: "dwarvenx99",
 		Path:         "127.0.0.1:9000/hello/work/example.yaml",

--- a/astore/server_test.go
+++ b/astore/server_test.go
@@ -3,16 +3,18 @@ package astore_test
 import (
 	"context"
 	"fmt"
-	"github.com/enfabrica/enkit/astore/atesting"
-	rpcAstore "github.com/enfabrica/enkit/astore/rpc/astore"
-	"github.com/enfabrica/enkit/astore/server/astore"
-	"github.com/enfabrica/enkit/lib/srand"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/test/bufconn"
 	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
+
+	"github.com/enfabrica/enkit/astore/atesting"
+	apb "github.com/enfabrica/enkit/astore/rpc/astore"
+	"github.com/enfabrica/enkit/astore/server/astore"
+	"github.com/enfabrica/enkit/lib/srand"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 type AStoreDescriptor struct {
@@ -53,7 +55,7 @@ func RunAStoreServer() (*AStoreDescriptor, atesting.KillAbleProcess, error) {
 	if err != nil {
 		return nil, killFunctions, err
 	}
-	rpcAstore.RegisterAstoreServer(grpcServer, server)
+	apb.RegisterAstoreServer(grpcServer, server)
 	if err := grpcServer.Serve(buffListener); err != nil {
 		return nil, killFunctions, err
 	}


### PR DESCRIPTION
This change fixes the broken target `//astore:e2e_test`, which could
never build in its current BUILD configuration.

This test still doesn't run in the current dev container, but tagging it
as such will at least allow our postsubmits to pass.

Imports are organized in the code, and proto imports are modified to
follow the `?pb` naming convention.

Tested: `bazel build //astore:go_default_test` now succeeds

Jira: INFRA-1233