### PR TITLE
bazel/linux: fix propagation of exit status

### DIFF
--- a/bazel/linux/templates/init-qemu.template.sh
+++ b/bazel/linux/templates/init-qemu.template.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 echo ========= {message} - {target} ==========
-trap "poweroff -f" EXIT
+on_exit() {
+    echo $? > "/tmp/output_dir/exit_status_file" || true
+    poweroff -f
+}
+trap on_exit EXIT
 
 # Find the "root" where the package was mounted.
 path="$0"

--- a/bazel/linux/templates/init-uml.template.sh
+++ b/bazel/linux/templates/init-uml.template.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
 echo ========= {message} - {target} ==========
-on_exit() {
-    echo $? > "/tmp/output_dir/exit_status_file" || true
-    poweroff -f
-}
-trap on_exit EXIT
+trap "poweroff -f" EXIT
 
 # Find the "root" where the package was mounted.
 path="$0"


### PR DESCRIPTION
We support propagating the exit status only when using QEMU. By mistake,
we updated the wrong init.template.sh.

Fixes: 65d5933499d1 ("bazel/linux: propagate the exit status outside the emulator")
Signed-off-by: George Prekas <george@enfabrica.net>