### PR TITLE
gee bazelgc: handle case of no dirs to remove

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4134,7 +4134,11 @@ function gee__bazelgc() {
        readlink -f "${GEE_DIR}"/*/*/*/bazel-out \
          | sed 's/\/execroot\/.*\?\/bazel-out//';
                 ) | sort | uniq -c | awk '$1 == "1" {print $2}' )
-  _info "About to delete the following directories:" "${EXPIRED[@]}"
+  if [[ "${#EXPIRED[@]}" == 0 ]]; then
+    _info "No ~/.cache/bazel directories to delete."
+    return 0
+  fi
+  _info "About to delete the following ~/.cache/bazel directories:" "${EXPIRED[@]}"
   if _confirm_default_no "Proceed? (y/N)  "; then
     local USED1
     USED1="$(df -k --output=used ~/.cache | tail -1)"


### PR DESCRIPTION
Bug: bazelgc command was emitting a confusing error message if it
attempted to remove zero ~/.cache/bazel directories.  This PR resolves
that issue.

Tested: manually ran bazelgc, observed desired behavior.

