### PR TITLE
bazel: add missing pipefail to bash scripts

### DIFF
--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 echo "===== Running target: {target}"
 echo "===== Path: $(realpath $0)"

--- a/bazel/utils/files.bzl
+++ b/bazel/utils/files.bzl
@@ -177,7 +177,8 @@ def files_to_dir(ctx, dirname, paths, post = ""):
         dest = dest,
     )
 
-    copy_command = """#!/bin/bash -e
+    copy_command = """#!/bin/bash
+set -euo pipefail
 {pack}
 {post}
 """.format(


### PR DESCRIPTION
Some bash scripts were failing silently due to missing pipefail.

Signed-off-by: George Prekas <george@enfabrica.net>