### PR TITLE
bazel/linux: fallback from KVM to TCG when using QEMU

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -3,10 +3,8 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 
 DEFAULT_QEMU_FLAGS = [
     "-enable-kvm",
-    "-cpu",
-    "host",
     "-machine",
-    "pc,accel=kvm,usb=off,dump-guest-core=off",
+    "pc,accel=kvm:tcg,usb=off,dump-guest-core=off",
     "-m",
     "2048",
     "-smp",


### PR DESCRIPTION
QEMU will try to use KVM and if that fails will fallback to TCG.

Signed-off-by: George Prekas <george@enfabrica.net>