### PR TITLE
kunit: updates for kunit inside of QEMU

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -121,11 +121,7 @@ def _kunit_bundle(ctx):
     mods = get_compatible(ctx, ki.arch, ki.package, ctx.attr.module)
     alldeps = expand_deps(ctx, mods, ctx.attr.depth)
 
-    commands = [
-        # modprobe does not work correctly without /sys
-        "mount -t sysfs sysfs /sys || echo 1>&2 'Could not mount sys - modprobe may not work properly'",
-    ]
-
+    commands = []
     inputs = []
     for kmod in alldeps:
         commands += ["", "# module " + package(kmod.label)]

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -173,13 +173,14 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
         mconfig(module = module, image = kernel_image),
     )
 
-    cfg = mconfig(
-        run = [runtime],
-        kernel_image = kernel_image,
-        kernel_flags = [
-            "printk.time=0", # printk timestamps breaks kunit result parsing
-        ])
+    cfg = mconfig(run = [runtime], kernel_image = kernel_image)
+
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
+
+    if runner == kernel_qemu_run:
+        # printk timestamps breaks kunit result parsing in the QEMU runner
+        cfg = mconfig(cfg, kernel_flags = [ "printk.time=0" ])
+
     name_runner = mcreate_rule(name, runner, "emulator", cfg, kwargs, runner_cfg)
     exec_test(name = name, dep = name_runner, **kwargs)

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -142,7 +142,7 @@ def qemu_test(name, kernel_image, setup, run, qemu_binary = None,
 
 def kunit_test(name, kernel_image, module, rootfs_image = None,
                kunit_bundle_cfg = {}, runner_cfg = {},
-               runner = kernel_uml_run, **kwargs):
+               runner = kernel_qemu_run, **kwargs):
     """Instantiates all the rules necessary to create a kunit test.
 
     Creates 3 rules:
@@ -173,7 +173,12 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
         mconfig(module = module, image = kernel_image),
     )
 
-    cfg = mconfig(run = [runtime], kernel_image = kernel_image)
+    cfg = mconfig(
+        run = [runtime],
+        kernel_image = kernel_image,
+        kernel_flags = [
+            "printk.time=0", # printk timestamps breaks kunit result parsing
+        ])
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
     name_runner = mcreate_rule(name, runner, "emulator", cfg, kwargs, runner_cfg)

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -176,5 +176,5 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
     cfg = mconfig(run = [runtime], kernel_image = kernel_image)
     if rootfs_image:
         cfg = mconfig(cfg, rootfs_image = rootfs_image)
-    name_runner = mcreate_rule(name, runner, "emulator", runner_cfg, kwargs, cfg)
+    name_runner = mcreate_rule(name, runner, "emulator", cfg, kwargs, runner_cfg)
     exec_test(name = name, dep = name_runner, **kwargs)


### PR DESCRIPTION
```
    kunit: do mot mount sysfs on /sys automatically

    This patch removes the automatic mount of sysfs on /sys for a couple
    of reasons:

    1. the kunit framework now uses 'insmod' instead of 'modprobe', so the
    original reason for mounting sysfs no longer exists.

    2. kunit_test() can be run with a custom runner that can handle any
    needed "pre-test" steps, like mounting sysfs or procfs, etc.

    For the case of using a QEMU runner, we will use a common system setup
    set of run commands that already handles mounting various kernel file
    systems.

    Relates-to: MCU-85
```

```
    kunit: append the kunit command steps to the runner steps

    This patch swaps the order of the 'runner_cfg' and 'cfg' parameters in
    the mcreate_rule() call for kunit tests.  The net effect is the
    commands from 'cfg' are appended to the 'runner_cfg' commands, instead
    of the other way around.

    We want the 'runner_cfg' commands to run first, as their job is to
    setup the test environment for the kunit test.  We do not want to run
    the kunit test and then setup the environment.

    Relates-to: MCU-85
```