### PR TITLE
zipdiff_test: don't fail if --update_goldens is set

### DIFF
--- a/bazel/utils/diff_test.bzl
+++ b/bazel/utils/diff_test.bzl
@@ -18,6 +18,7 @@ def _zipdiff_test_impl(ctx):
             b="$(readlink -f "${{exp}}")"
             echo "Updating ${{b}}"
             cp -vf "${{act}}" "${{b}}"
+            RC=0  # clear the error if we updated goldens
           fi
           shift
         done


### PR DESCRIPTION
This propagates the behavior of diff_test to zipdiff_test: if --update_goldens
is specified, zipdiff_test script no longer terminates with a non-zero exit
code.  Important for users like Gavin who want to use multirun to group
diff_tests together.

Tested: ?

