### PR TITLE
kbuild:uml: update build-header installer to match build rules

### DIFF
--- a/kbuild/v2/template/install-uml-bazel.sh
+++ b/kbuild/v2/template/install-uml-bazel.sh
@@ -13,7 +13,10 @@ install_bazel_build() {
 
     build="${KERNEL_VERSION}/build"
     if [ -d "$build" ] ; then
-        echo "$KERNEL_VERSION"
+        # The bazel consumer of this script will only export the
+        # following directories: ["lib", "usr", "install"]
+        mv "$KERNEL_VERSION" install
+        echo "install"
         exit 0
     fi
 


### PR DESCRIPTION
The UML kernel build-header install script was not installing things
correctly.  The underlying bazel kernel_tree_version() rule that
unpacks and installs the build headers creates a filegroup() using:

  srcs = glob(["lib", "usr", "install"], allow_empty = True, exclude_directories = 0)

The previous installer was not using one these directories at install
time, hence the files were not available to UML kernel module builds.

This patch updates the installer to use the "install" directory.

Fixes: dbf665348d4f ("kbuild/v2: Update scripts to build/publish UML kernel artifacts (#577)")