### PR TITLE
kbuild: Add deb-artifacts.tar.gz astore meta data to bazel/kernel.version.bzl

### DIFF
--- a/kbuild/v2/scripts/gen-bazel-meta.sh
+++ b/kbuild/v2/scripts/gen-bazel-meta.sh
@@ -90,6 +90,10 @@ gen_deb_flavours() {
         local astore_file="vmlinuz-modules.tar.gz"
         gen_artifact_desc "KERNEL_BIN" $kernel_version $f $astore_file
 
+        ## deb-artifacts.tar.gz
+        local astore_file="deb-artifacts.tar.gz"
+        gen_artifact_desc "KERNEL_DEB" $kernel_version $f $astore_file
+
     done
 }
 


### PR DESCRIPTION
This patch updates the scripts to add a stanza to the
bazel/kernel.version.bzl for each kernel flavour, describing the
tarball of kernel .deb packages.

The new stanzas have the label:  KERNEL_DEB_ENF_UBUNTU_IMPISH_<FLAVOUR>