### PR TITLE
postsubmit: Add ability to configure buildbarn instance

### DIFF
--- a/infra/postsubmit/proto/postsubmit.proto
+++ b/infra/postsubmit/proto/postsubmit.proto
@@ -66,4 +66,9 @@ message Build {
   // by the above fields; popular bazel options may be replaced by an applicable
   // field in the future.
   repeated string bazel_args = 10;
+
+  // RBE instance to use to run build. Defaults to the currently-supported
+  // buildbarn instance, but can be changed in order to target a non-prod
+  // instance.
+  string rbe_instance = 12;
 }


### PR DESCRIPTION
This change adds a configuration setting to postsubmits that will allow
users to configure which buildbarn instance builds should go to.

This will be used in the short-term to migrate builds to buildbarn on
gcp01 while leaving the majority of builds running on buildbarn in MTV.

Jira: INFRA-1284