### PR TITLE
enkit/bazel/utils: fix error in exec_test.

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel/utils:diff_test.bzl", "diff_test")
 load("//bazel/utils:types.bzl", "escape_and_join")
 load("//bazel/utils:merge_kwargs_test.bzl", "merge_kwargs_test_suite")
 load("//bazel/utils:files.bzl", "write_to_file")
+load("//bazel/utils:exec_test.bzl", "exec_test")
 
 bzl_library(
     name = "diff_test_bzl",
@@ -43,4 +44,30 @@ diff_test(
 
 merge_kwargs_test_suite(
     name = "merge_kwargs_test_suite",
+)
+
+sh_binary(
+    name = "echo-argv",
+    srcs = ["echo-argv_test.sh"],
+)
+
+# This is not really a test: it should always succeed.
+# The target is here so it generates a shell script that
+# the real test, echo-argv-run_test, can then invoke to
+# verify that exec_test works as expected.
+exec_test(
+    name = "echo-argv_test",
+    argv = [
+        "arg1",
+        "arg2 with space",
+        "arg3 with $NASTY `characters`",
+    ],
+    dep = ":echo-argv",
+)
+
+# Checks that the exec_test rule works as expected.
+sh_test(
+    name = "exec_test_test",
+    srcs = ["echo-argv_test_check.sh"],
+    data = [":echo-argv_test"],
 )

--- a/bazel/utils/echo-argv_test.sh
+++ b/bazel/utils/echo-argv_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Just outputs each argv parameter, so another script can
+# verify that all parameters were passed correctly.
+for arg in "$@"; do
+  echo "$arg"
+done

--- a/bazel/utils/echo-argv_test_check.sh
+++ b/bazel/utils/echo-argv_test_check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cmp <(./bazel/utils/echo-argv_test_test.sh) - <<'EOF'
+arg1
+arg2 with space
+arg3 with `characters`
+EOF
+test "$?" == 1 || {
+    echo "first comparison was expected to fail - test not working?" 1>&2
+    exit 1
+}
+
+set -eu -o pipefail
+
+cmp <(./bazel/utils/echo-argv_test_test.sh) - <<'EOF'
+arg1
+arg2 with space
+arg3 with $NASTY `characters`
+EOF

--- a/bazel/utils/exec_test.bzl
+++ b/bazel/utils/exec_test.bzl
@@ -5,7 +5,7 @@ def _exec_test(ctx):
     # the executable returned by another rule.
     template = """#!/bin/bash
 ARGS={argv}; ARGS+=("$@")
-exec {script} "$ARGS[@]"
+exec {script} "${{ARGS[@]}}"
 """
     script = ctx.actions.declare_file("{}_test.sh".format(ctx.attr.name))
     ctx.actions.write(script, template.format(argv = shell.array_literal(ctx.attr.argv), script = ctx.executable.dep.short_path))


### PR DESCRIPTION
Background:
I noticed qemu_test rules failing when manually specifying some command
line parameters. Turns out the problem was in exec_test, that did not
expand a bash array correctly.

In this PR:
- fix the shell argument expansion.
- add a tiny test to verify that exec_test works as expected.
  fool me once, yadda yadda.

Also, trying to add examples for bazel rules tests, and examples of
sh_binary() just invoking and using other targets (hint: it's easy!).
