### PR TITLE
bazel: automatically format all .bzl files.

### DIFF
--- a/bazel/linux/qemu.bzl
+++ b/bazel/linux/qemu.bzl
@@ -1,4 +1,4 @@
-load("//bazel/linux:runner.bzl", "create_runner_attrs", "create_runner")
+load("//bazel/linux:runner.bzl", "create_runner", "create_runner_attrs")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 DEFAULT_QEMU_FLAGS = [

--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -37,7 +37,7 @@ If not specified, the current root of the filesystem will be used as rootfs.
         ),
     }
 
-def commands_and_runtime(ctx, msg, runs, runfiles, verbose=True):
+def commands_and_runtime(ctx, msg, runs, runfiles, verbose = True):
     """Computes commands and runfiles from a list of RuntimeInfo"""
     commands = []
     runfiles = ctx.runfiles().merge(runfiles)
@@ -85,10 +85,10 @@ def commands_and_runtime(ctx, msg, runs, runfiles, verbose=True):
 
     if len(labels) != len(commands):
         fail(location(ctx) +
-            "enkit error: count mismatch between labels ({len_lab}) and commands ({len_cmd})".format(
-                len_lab = len(labels),
-                len_cmd = len(commands),
-            ))
+             "enkit error: count mismatch between labels ({len_lab}) and commands ({len_cmd})".format(
+                 len_lab = len(labels),
+                 len_cmd = len(commands),
+             ))
 
     return commands, runfiles, labels
 

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -92,9 +92,9 @@ exit $failures
     script = ctx.actions.declare_file("{}_test_runner.sh".format(ctx.attr.name))
     ctx.actions.write(script, script_begin + "\n".join(tests) + script_end)
     return [RuntimeBundleInfo(
-        prepare=RuntimeInfo(commands = cprepares, runfiles = outside_runfiles),
-        run=RuntimeInfo(binary = script, runfiles = inside_runfiles),
-        check=RuntimeInfo(commands = cchecks, runfiles = outside_runfiles),
+        prepare = RuntimeInfo(commands = cprepares, runfiles = outside_runfiles),
+        run = RuntimeInfo(binary = script, runfiles = inside_runfiles),
+        check = RuntimeInfo(commands = cchecks, runfiles = outside_runfiles),
     )]
 
 test_runner = rule(
@@ -108,8 +108,14 @@ test_runner = rule(
     },
 )
 
-def qemu_test(name, kernel_image, setup, run, qemu_binary = None,
-              config = {}, **kwargs):
+def qemu_test(
+        name,
+        kernel_image,
+        setup,
+        run,
+        qemu_binary = None,
+        config = {},
+        **kwargs):
     """Instantiates all the rules necessary to create a qemu based test.
 
     Specifically:
@@ -127,22 +133,38 @@ def qemu_test(name, kernel_image, setup, run, qemu_binary = None,
             kernel_qemu_run rule, generally created with mconfig().
     """
 
-    runner_script = mcreate_rule(name, test_runner, "test-runner", [],
-        kwargs, mconfig(tests = run),
+    runner_script = mcreate_rule(
+        name,
+        test_runner,
+        "test-runner",
+        [],
+        kwargs,
+        mconfig(tests = run),
     )
     runner = mcreate_rule(
-        name, kernel_qemu_run, "run", config, kwargs,
-        kwargs, mconfig(
+        name,
+        kernel_qemu_run,
+        "run",
+        config,
+        kwargs,
+        kwargs,
+        mconfig(
             kernel_image = kernel_image,
             run = setup + [runner_script],
-            qemu_binary = qemu_binary
+            qemu_binary = qemu_binary,
         ),
     )
     exec_test(name = name, dep = runner, **kwargs)
 
-def kunit_test(name, kernel_image, module, rootfs_image = None,
-               kunit_bundle_cfg = {}, runner_cfg = {},
-               runner = kernel_qemu_run, **kwargs):
+def kunit_test(
+        name,
+        kernel_image,
+        module,
+        rootfs_image = None,
+        kunit_bundle_cfg = {},
+        runner_cfg = {},
+        runner = kernel_qemu_run,
+        **kwargs):
     """Instantiates all the rules necessary to create a kunit test.
 
     Creates 3 rules:
@@ -163,7 +185,7 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
       runner: a rule function, will be invoked to create the runner using
           the generated kunit bundle.
       kwargs: options common to all instantiated rules.
-    """ 
+    """
     runtime = mcreate_rule(
         name,
         kunit_bundle,
@@ -180,7 +202,7 @@ def kunit_test(name, kernel_image, module, rootfs_image = None,
 
     if runner == kernel_qemu_run:
         # printk timestamps breaks kunit result parsing in the QEMU runner
-        cfg = mconfig(cfg, kernel_flags = [ "printk.time=0" ])
+        cfg = mconfig(cfg, kernel_flags = ["printk.time=0"])
 
     name_runner = mcreate_rule(name, runner, "emulator", cfg, kwargs, runner_cfg)
     exec_test(name = name, dep = name_runner, **kwargs)

--- a/bazel/linux/uml.bzl
+++ b/bazel/linux/uml.bzl
@@ -1,4 +1,4 @@
-load("//bazel/linux:runner.bzl", "create_runner_attrs", "create_runner")
+load("//bazel/linux:runner.bzl", "create_runner", "create_runner_attrs")
 
 def _kernel_uml_run(ctx):
     code = """
@@ -48,7 +48,7 @@ See the RuntimeBundleInfo provider for details.
 """,
     implementation = _kernel_uml_run,
     attrs = create_runner_attrs(
-      template_init_default = Label("//bazel/linux:templates/init-uml.template.sh"),
+        template_init_default = Label("//bazel/linux:templates/init-uml.template.sh"),
     ),
     executable = True,
 )

--- a/bazel/utils/files.bzl
+++ b/bazel/utils/files.bzl
@@ -142,25 +142,25 @@ def files_to_dir(ctx, dirname, paths, post = ""):
 
     roots = {}
     for f in paths:
-      root = f.path
-      if f.is_source and f.owner and f.owner.workspace_root:
-          # The root of foreign source files is their workspace root.
-          root = f.owner.workspace_root
-      else:
-          # Remove the ../ from short_path, if it exists.
-          short_path = f.short_path
-          if short_path.startswith('../'):
-            short_path = short_path[3:]
-          root = root[:-(len(short_path)+1)]
+        root = f.path
+        if f.is_source and f.owner and f.owner.workspace_root:
+            # The root of foreign source files is their workspace root.
+            root = f.owner.workspace_root
+        else:
+            # Remove the ../ from short_path, if it exists.
+            short_path = f.short_path
+            if short_path.startswith("../"):
+                short_path = short_path[3:]
+            root = root[:-(len(short_path) + 1)]
 
-      if root not in roots:
-          roots[root] = []
+        if root not in roots:
+            roots[root] = []
 
-      if not root:
-        roots[root].append(f.path)
-        continue
+        if not root:
+            roots[root].append(f.path)
+            continue
 
-      roots[root].append(f.path[len(root)+1:])
+        roots[root].append(f.path[len(root) + 1:])
 
     pack = []
     for k, v in roots.items():


### PR DESCRIPTION
This PR is a nop, it was generated with 'bazelisk run //:buildifier',
the `fix_format` for .bzl files in the enkit repository.

It just formatted all .bzl files to use the same indentation, style
rules, etc.

This PR is in preparation for the next one, to minimize unrelated
diffs.
