### PR TITLE
gee repair: prune worktree

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4369,6 +4369,8 @@ function gee__repair() {
     _fatal "Not in a gee repo directory, aborting further repairs."
   fi
 
+  _git worktree prune
+
   _info "Checking each directory in ${REPO_DIR}..."
   local DIR BRANCH OBRANCH
   for DIR in "${REPO_DIR}"/*; do


### PR DESCRIPTION
Added "git worktree prune" to "gee repair" flow.  This removes worktree
entries the have been abandoned by their associated branches, perhaps
by the branch being deleted without removing the worktree first.

Tested: gee repair successfully invokes worktree prune.

