### PR TITLE
bazel/linux: export the env. variable OUTPUT_DIR in the guest

### DIFF
--- a/bazel/linux/templates/init-qemu.template.sh
+++ b/bazel/linux/templates/init-qemu.template.sh
@@ -2,7 +2,7 @@
 
 echo ========= {message} - {target} ==========
 on_exit() {
-    echo $? > "/tmp/output_dir/exit_status_file" || true
+    echo $? > "$OUTPUT_DIR/exit_status_file" || true
     poweroff -f
 }
 trap on_exit EXIT
@@ -22,9 +22,10 @@ python -c 'import ctypes; exit(ctypes.cdll.LoadLibrary("libc.so.6").mount("", "/
 mount --types tmpfs tmpfs /tmp
 
 # Mount the output directory. This directory is shared with the host.
-mkdir /tmp/output_dir
+export OUTPUT_DIR=/tmp/output_dir
+mkdir "$OUTPUT_DIR"
 mount --types 9p \
     --options trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl \
-    /dev/output_dir /tmp/output_dir
+    /dev/output_dir "$OUTPUT_DIR"
 
 {commands}

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -70,7 +70,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
 '"${junit}"'
 </testsuites>
-' > "/tmp/output_dir/junit.xml"
+' > "$OUTPUT_DIR/junit.xml"
 
 exit $failures
 """


### PR DESCRIPTION
Replace in the guest the hardcoded path /tmp/output_dir with the
environment variable OUTPUT_DIR.

Signed-off-by: George Prekas <george@enfabrica.net>