### PR TITLE
enkit outputs: Add proxy flag

### DIFF
--- a/proxy/ptunnel/exec/exec.go
+++ b/proxy/ptunnel/exec/exec.go
@@ -11,15 +11,17 @@ import (
 // tunnels to `target:targetPort`. There is no way to stop a backgrounded
 // tunnel, other than to kill it manually via the OS.
 func NewBackgroundTunnel(target string, targetPort int, hostPort int, gatewayProxy string) error {
-	cmd := osexec.Command(
-		"enkit",
-		"tunnel",
-		"--proxy",
-		gatewayProxy,
+	args := []string{"tunnel"}
+	if gatewayProxy != "" {
+		args = append(args, "--proxy", gatewayProxy)
+	}
+	args = append(args,
 		"--background",
 		"-L", strconv.FormatInt(int64(hostPort), 10),
-		target, strconv.FormatInt(int64(targetPort), 10),
+		target,
+		strconv.FormatInt(int64(targetPort), 10),
 	)
+	cmd := osexec.Command("enkit", args...)
 	output, err := cmd.CombinedOutput()
 	var exitErr *osexec.ExitError
 	if err != nil {

--- a/proxy/ptunnel/exec/exec.go
+++ b/proxy/ptunnel/exec/exec.go
@@ -10,10 +10,12 @@ import (
 // NewBackgroundTunnel starts and detaches a tunnel listening on `hostPort` that
 // tunnels to `target:targetPort`. There is no way to stop a backgrounded
 // tunnel, other than to kill it manually via the OS.
-func NewBackgroundTunnel(target string, targetPort int, hostPort int) error {
+func NewBackgroundTunnel(target string, targetPort int, hostPort int, gatewayProxy string) error {
 	cmd := osexec.Command(
 		"enkit",
 		"tunnel",
+		"--proxy",
+		gatewayProxy,
 		"--background",
 		"-L", strconv.FormatInt(int64(hostPort), 10),
 		target, strconv.FormatInt(int64(targetPort), 10),


### PR DESCRIPTION
Since buildbarn has moved to a different realm, `enkit outputs` needs a
flag to control which proxy to tunnel through when tunneling is
necessary.

This change adds said flag and makes sure it is propagated to the tunnel
creation command.

Tested:
* Ran: https://keep.google.com/u/0/#NOTE/1bz2F5i3Hy56Z_rfunezp_hhwnatWvoe2uPUN1MEj-yxfPko2ANpz-xkASPtjUQ

  and was able to read all outputs

Jira: INFRA-1269