### PR TITLE
enkit: Add version subcommand

### DIFF
--- a/enkit/cmd/BUILD.bazel
+++ b/enkit/cmd/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//astore/client/commands:go_default_library",
         "//enkit/outputs:go_default_library",
+        "//enkit/version:go_default_library",
         "//lib/bazel/commands:go_default_library",
         "//lib/client:go_default_library",
         "//lib/client/commands:go_default_library",

--- a/enkit/cmd/command.go
+++ b/enkit/cmd/command.go
@@ -5,6 +5,7 @@ import (
 
 	acommands "github.com/enfabrica/enkit/astore/client/commands"
 	ocommands "github.com/enfabrica/enkit/enkit/outputs"
+	vcommands "github.com/enfabrica/enkit/enkit/version"
 	bazelcmds "github.com/enfabrica/enkit/lib/bazel/commands"
 	"github.com/enfabrica/enkit/lib/client"
 	bcommands "github.com/enfabrica/enkit/lib/client/commands"
@@ -58,6 +59,9 @@ func New() (*EnkitCommand, error) {
 
 	bazel := bazelcmds.New(base)
 	root.AddCommand(bazel.Command)
+
+	versionCmd := vcommands.New(base)
+	root.AddCommand(versionCmd.Command)
 
 	outputs, err := ocommands.New(base)
 	if err != nil {

--- a/enkit/version/BUILD.bazel
+++ b/enkit/version/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["version.go"],
+    importpath = "github.com/enfabrica/enkit/enkit/version",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/client:go_default_library",
+        "//lib/stamp:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/enkit/version/version.go
+++ b/enkit/version/version.go
@@ -1,0 +1,42 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/enfabrica/enkit/lib/client"
+	"github.com/enfabrica/enkit/lib/stamp"
+
+	"github.com/spf13/cobra"
+)
+
+type Root struct {
+	*cobra.Command
+	*client.BaseFlags
+}
+
+func New(base *client.BaseFlags) *Root {
+	rc := &Root{
+		Command: &cobra.Command{
+			Use:           "version",
+			Short:         "Show version info",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			Long:          "version - command for getting the version of this tool",
+		},
+		BaseFlags: base,
+	}
+	rc.Command.RunE = rc.Run
+	return rc
+}
+
+func (r *Root) Run(cmd *cobra.Command, args []string) error {
+	fmt.Printf("Built from commit: %s\n", stamp.GitSha)
+	if stamp.GitBranch != "master" {
+		fmt.Printf("Branch is based on master commit %s\n", stamp.GitMasterSha)
+	}
+	fmt.Printf("Built from branch: %s\n", stamp.GitBranch)
+	fmt.Printf("Builder: %s\n", stamp.BuildUser)
+	fmt.Printf("Clean build: %v\n", stamp.IsClean())
+	fmt.Printf("Official build: %v\n", stamp.IsOfficial())
+	return nil
+}

--- a/lib/stamp/BUILD.bazel
+++ b/lib/stamp/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["stamp.go"],
+    importpath = "github.com/enfabrica/enkit/lib/stamp",
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "BuildUser": "{STABLE_USER}",
+        "GitBranch": "{STABLE_GIT_BRANCH}",
+        "GitSha": "{STABLE_GIT_SHA}",
+        "GitMasterSha": "{STABLE_GIT_MASTER_SHA}",
+        "changedFiles": "{STABLE_GIT_CHANGES}",
+    },
+)

--- a/lib/stamp/stamp.go
+++ b/lib/stamp/stamp.go
@@ -1,0 +1,22 @@
+package stamp
+
+import (
+	"strings"
+)
+
+var (
+	BuildUser    = "<unknown>"
+	GitBranch    = "<unknown>"
+	GitSha       = "<unknown>"
+	GitMasterSha = "<unknown>"
+
+	changedFiles = "<unknown>"
+)
+
+func IsClean() bool {
+	return strings.TrimSpace(changedFiles) == ""
+}
+
+func IsOfficial() bool {
+	return strings.TrimSpace(changedFiles) == "" && GitBranch == "master"
+}


### PR DESCRIPTION
This change adds a `version` subcommand to enkit that prints linkstamped
info so that we can more easily debug issues that arise from an
out-of-date enkit version.

Tested: `bazel run //enkit --stamp -- version`