### PR TITLE
gee restore_all_branches: make more interactive

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5028,7 +5028,7 @@ function _render_markdown_manual() {
   for h in "${HELP[@]}"; do
     IFS=": " read -r h_cmd h_desc <<< "${h}"
     echo "| <a href=\"#${h_cmd}\">${BT}${h_cmd}${BT}</a> | ${h_desc} |"
-  done | sort
+  done | sort --dictionary-order
   echo ""
   echo "## Commands"
   echo ""

--- a/scripts/gee
+++ b/scripts/gee
@@ -4561,12 +4561,12 @@ function gee__restore_all_branches() {
         --backtitle "gee ${VERSION}"
         --title "gee restore_all_branches"
         --checklist
-        "Unselect any branches you don't want to restore."
+        "Select which branches you want to restore:"
         0 0 0
       )
       local B
       for B in "${BRANCHES[@]}"; do
-        DIALOG_OPTS+=( "${B}" "" "on" )
+        DIALOG_OPTS+=( "${B}" "" "off" )
       done
 
       local RESULT EXITCODE
@@ -4580,6 +4580,7 @@ function gee__restore_all_branches() {
         _warn "User cancelled operation."
         return
       fi
+      read -r -a BRANCHES <<< "${RESULT}"
     fi
   fi
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -4532,6 +4532,9 @@ Usage: gee restore_all_branches
 Gee looks up all branches on the origin remote, and makes sure an equivalent
 branch is checked out and updated locally.
 
+Alternately, if the user supplies a list of branches on the command line,
+restore_all_branches will only attempt to restore those branches.
+
 Note that gee isn't able to restore parentage metadata in this way.  Be
 sure to invoke `gee set_parent` in branches that benefit from this.
 EOT
@@ -4547,9 +4550,38 @@ function gee__restore_all_branches() {
   _info "Fetching all commits in origin since ${OLDEST_COMMIT}"
   _git fetch origin --shallow-since "${OLDEST_COMMIT}"
 
-  local -a BRANCHES=()
-  mapfile -t BRANCHES < <( \
-    git branch -r --format="%(refname:short)" | grep ^origin/ | grep -v HEAD )
+  local -a BRANCHES=( "$@" )
+  if (( "${#BRANCHES[@]}" == 0 )); then
+    mapfile -t BRANCHES < <( \
+      git branch -r --format="%(refname:short)" | grep ^origin/ | grep -v HEAD )
+    if command -v dialog > /dev/null; then
+      local -a DIALOG_OPTS=(
+        --no-lines
+        --keep-tite
+        --backtitle "gee ${VERSION}"
+        --title "gee restore_all_branches"
+        --checklist
+        "Unselect any branches you don't want to restore."
+        0 0 0
+      )
+      local B
+      for B in "${BRANCHES[@]}"; do
+        DIALOG_OPTS+=( "${B}" "" "on" )
+      done
+
+      local RESULT EXITCODE
+      set +e
+      exec 3>&1
+      RESULT="$(dialog "${DIALOG_OPTS[@]}" 2>&1 1>&3)"
+      EXITCODE=$?
+      exec 3>&-
+      set -e
+      if (( EXITCODE != 0  )); then
+        _warn "User cancelled operation."
+        return
+      fi
+    fi
+  fi
 
   _set_main
   local RB

--- a/scripts/gee
+++ b/scripts/gee
@@ -4532,8 +4532,12 @@ Usage: gee restore_all_branches
 Gee looks up all branches on the origin remote, and makes sure an equivalent
 branch is checked out and updated locally.
 
-Alternately, if the user supplies a list of branches on the command line,
-restore_all_branches will only attempt to restore those branches.
+If you have the `dialog` utility installed, gee will let you interactively
+select which branches you want to restore.
+
+Alternately, if the user supplies a list of branches on the command line (for
+instance, "origin/test1 origin/test2"), restore_all_branches will only attempt
+to restore those branches.
 
 Note that gee isn't able to restore parentage metadata in this way.  Be
 sure to invoke `gee set_parent` in branches that benefit from this.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -110,8 +110,8 @@ review.
 | <a href="#lsbranches">`lsbranches`</a> | List information about each branch. |
 | <a href="#make_branch">`make_branch`</a> | Create a new child branch based on the current branch. |
 | <a href="#pack">`pack`</a> | Exports all unsubmitted changes in this branch as a pack file. |
-| <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
 | <a href="#pr_check">`pr_check`</a> | Checks whether presubmit tests for a PR. |
+| <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
 | <a href="#pr_edit">`pr_edit`</a> | Edit an existing pull request. |
 | <a href="#pr_list">`pr_list`</a> | List outstanding PRs |
 | <a href="#pr_make">`pr_make`</a> | Creates a pull request from this branch. |
@@ -127,8 +127,8 @@ review.
 | <a href="#set_parent">`set_parent`</a> | Set another branch as parent of this branch. |
 | <a href="#share">`share`</a> | Share your branch. |
 | <a href="#unpack">`unpack`</a> | Patch the local branch from a pack file. |
-| <a href="#update_all">`update_all`</a> | Update all branches. |
 | <a href="#update">`update`</a> | integrate changes from parent into this branch. |
+| <a href="#update_all">`update_all`</a> | Update all branches. |
 | <a href="#upgrade">`upgrade`</a> | Upgrade the gee tool. |
 | <a href="#version">`version`</a> | Print tool version information. |
 | <a href="#whatsout">`whatsout`</a> | List locally changed files in this branch. |

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -110,8 +110,8 @@ review.
 | <a href="#lsbranches">`lsbranches`</a> | List information about each branch. |
 | <a href="#make_branch">`make_branch`</a> | Create a new child branch based on the current branch. |
 | <a href="#pack">`pack`</a> | Exports all unsubmitted changes in this branch as a pack file. |
-| <a href="#pr_check">`pr_check`</a> | Checks whether presubmit tests for a PR. |
 | <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
+| <a href="#pr_check">`pr_check`</a> | Checks whether presubmit tests for a PR. |
 | <a href="#pr_edit">`pr_edit`</a> | Edit an existing pull request. |
 | <a href="#pr_list">`pr_list`</a> | List outstanding PRs |
 | <a href="#pr_make">`pr_make`</a> | Creates a pull request from this branch. |
@@ -127,8 +127,8 @@ review.
 | <a href="#set_parent">`set_parent`</a> | Set another branch as parent of this branch. |
 | <a href="#share">`share`</a> | Share your branch. |
 | <a href="#unpack">`unpack`</a> | Patch the local branch from a pack file. |
-| <a href="#update">`update`</a> | integrate changes from parent into this branch. |
 | <a href="#update_all">`update_all`</a> | Update all branches. |
+| <a href="#update">`update`</a> | integrate changes from parent into this branch. |
 | <a href="#upgrade">`upgrade`</a> | Upgrade the gee tool. |
 | <a href="#version">`version`</a> | Print tool version information. |
 | <a href="#whatsout">`whatsout`</a> | List locally changed files in this branch. |
@@ -631,6 +631,13 @@ Usage: `gee restore_all_branches`
 
 Gee looks up all branches on the origin remote, and makes sure an equivalent
 branch is checked out and updated locally.
+
+If you have the `dialog` utility installed, gee will let you interactively
+select which branches you want to restore.
+
+Alternately, if the user supplies a list of branches on the command line (for
+instance, "origin/test1 origin/test2"), restore_all_branches will only attempt
+to restore those branches.
 
 Note that gee isn't able to restore parentage metadata in this way.  Be
 sure to invoke `gee set_parent` in branches that benefit from this.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -110,8 +110,8 @@ review.
 | <a href="#lsbranches">`lsbranches`</a> | List information about each branch. |
 | <a href="#make_branch">`make_branch`</a> | Create a new child branch based on the current branch. |
 | <a href="#pack">`pack`</a> | Exports all unsubmitted changes in this branch as a pack file. |
-| <a href="#pr_check">`pr_check`</a> | Checks whether presubmit tests for a PR. |
 | <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
+| <a href="#pr_check">`pr_check`</a> | Checks whether presubmit tests for a PR. |
 | <a href="#pr_edit">`pr_edit`</a> | Edit an existing pull request. |
 | <a href="#pr_list">`pr_list`</a> | List outstanding PRs |
 | <a href="#pr_make">`pr_make`</a> | Creates a pull request from this branch. |
@@ -127,8 +127,8 @@ review.
 | <a href="#set_parent">`set_parent`</a> | Set another branch as parent of this branch. |
 | <a href="#share">`share`</a> | Share your branch. |
 | <a href="#unpack">`unpack`</a> | Patch the local branch from a pack file. |
-| <a href="#update">`update`</a> | integrate changes from parent into this branch. |
 | <a href="#update_all">`update_all`</a> | Update all branches. |
+| <a href="#update">`update`</a> | integrate changes from parent into this branch. |
 | <a href="#upgrade">`upgrade`</a> | Upgrade the gee tool. |
 | <a href="#version">`version`</a> | Print tool version information. |
 | <a href="#whatsout">`whatsout`</a> | List locally changed files in this branch. |


### PR DESCRIPTION
The typical user of "restore_all_branches" doesn't really want
to restore all the branches.  This change allows the user to
interactively select which branches to restore, if they have
the `dialog` utilty installed.

Alternately, a list of branches can be specified on the
commandline.

Tested: Works locally for me, also getting @abhienfabrica to help validate
a pre-release version.

