### PR TITLE
bazel/utils: enhance exec_test to expect failing binaries.

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -51,6 +51,11 @@ sh_binary(
     srcs = ["echo-argv_test.sh"],
 )
 
+sh_binary(
+    name = "failing-script",
+    srcs = ["failing-script_test.sh"],
+)
+
 # This is not really a test: it should always succeed.
 # The target is here so it generates a shell script that
 # the real test, echo-argv-run_test, can then invoke to
@@ -63,6 +68,12 @@ exec_test(
         "arg3 with $NASTY `characters`",
     ],
     dep = ":echo-argv",
+)
+
+exec_test(
+    name = "failing_test",
+    dep = ":failing-script",
+    must_fail = True,
 )
 
 # Checks that the exec_test rule works as expected.

--- a/bazel/utils/failing-script_test.sh
+++ b/bazel/utils/failing-script_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "oh, no! I've failed horribly. What a shame."
+exit 100


### PR DESCRIPTION
In this PR:
- add a `must_fail` boolean - when set to true, the test
  succeeds if the execed binary fails. When left to the false
  default, the binary must succeed.
  Purposedly avoided naming this 'expect_failure', to avoid
  conflict with still undocumented bazel feature.
- added a corresponding test.

Tested:
exec_test happens to have unit tests, old tests are passing,
newly added one is also passing. Change is minimal.
