### PR TITLE
bazel/linux: add cleanup attribute to vm_bundle

### DIFF
--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -71,6 +71,7 @@ RuntimeBundleInfo = provider(
     fields = {
         "prepare": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM BEFORE the RUN to prepare the environment",
         "run": "RuntimeInfo, executable (and its runfiles) to run INSIDE the VM",
+        "cleanup": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN (in reverse order) to clean up the environment",
         "check": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN to check if the run was successful",
     },
 )

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -158,6 +158,10 @@ echo 1>&2 "Running emulator..."
 {code}
 
 estatus="$?"
+
+echo 1>&2 "===== emulator exited - now running cleanups (if any) ===="
+{cleanups}
+
 test "$estatus" == 0 || {
     echo 1>&2 "===== emulator exited with non zero status - check logs above ===="
     exit "$estatus"

--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -75,11 +75,12 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 exit $failures
 """
 
-    prepares, runs, checks = get_prepare_run_check(ctx, ctx.attr.tests)
+    prepares, runs, cleanups, checks = get_prepare_run_check(ctx, ctx.attr.tests)
 
     outside_runfiles = ctx.runfiles()
     cprepares, outside_runfiles, _ = commands_and_runtime(ctx, "prepare", prepares, outside_runfiles, verbose = False)
     cchecks, outside_runfiles, _ = commands_and_runtime(ctx, "check", checks, outside_runfiles, verbose = False)
+    ccleanups, outside_runfiles, _ = commands_and_runtime(ctx, "cleanup", cleanups, outside_runfiles, verbose = False)
     cruns, inside_runfiles, run_labels = commands_and_runtime(ctx, "run", runs, ctx.runfiles(), verbose = False)
 
     tests = []
@@ -94,6 +95,7 @@ exit $failures
     return [RuntimeBundleInfo(
         prepare = RuntimeInfo(commands = cprepares, runfiles = outside_runfiles),
         run = RuntimeInfo(binary = script, runfiles = inside_runfiles),
+        cleanup = RuntimeInfo(commands = ccleanups, runfiles = outside_runfiles),
         check = RuntimeInfo(commands = cchecks, runfiles = outside_runfiles),
     )]
 


### PR DESCRIPTION
Clean up operations execute outside of the emulator after the execution
of the emulator in reverse order.

Jira: https://enfabrica.atlassian.net/browse/SF-246
Signed-off-by: George Prekas <george@enfabrica.net>