### PR TITLE
bazel/meson: fix wrong paths

### DIFF
--- a/bazel/meson/meson.bzl
+++ b/bazel/meson/meson.bzl
@@ -26,10 +26,14 @@ def _create_meson_script(configureParameters):
 
     script = pkgconfig_script(ext_build_dirs)
 
+    script.append("export INSTALL_PREFIX=\"{install_prefix}\"".format(
+        install_prefix=ctx.attr.name,
+    ))
+
     script.append("{env_vars} {meson} setup --prefix {prefix} {builddir} {sourcedir}".format(
         meson = attrs.meson_path,
         env_vars = get_make_env_vars(ctx.workspace_name, tools, flags, user_env, ctx.attr.deps, inputs),
-        prefix = "$$INSTALLDIR$$",
+        prefix = "$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$",
         builddir = "$$BUILD_TMPDIR$$",
         sourcedir = "$$EXT_BUILD_ROOT$$/" + detect_root(ctx.attr.lib_source),
     ))
@@ -38,6 +42,8 @@ def _create_meson_script(configureParameters):
         meson = attrs.meson_path,
         dir = "$$BUILD_TMPDIR$$",
     ))
+
+    script.append("##copy_dir_contents_to_dir## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ $$INSTALLDIR$$")
 
     return script
 

--- a/bazel/meson/test/BUILD.bazel
+++ b/bazel/meson/test/BUILD.bazel
@@ -9,6 +9,9 @@ meson(
     name = "hello",
     lib_source = ":src",
     out_binaries = [
-        "hello",
+        # It looks like a limitation of rules_foreign_cc where you cannot have
+        # a generated file with the same name as the rule because it creates a
+        # directory named as the rule in the build directory.
+        "hello_bin",
     ],
 )

--- a/bazel/meson/test/meson.build
+++ b/bazel/meson/test/meson.build
@@ -1,2 +1,2 @@
 project('hello', 'c')
-executable('hello', 'hello.c', install : true)
+executable('hello_bin', 'hello.c', install : true)


### PR DESCRIPTION
Set the install prefix to be a subdirectory of $BUILD_TMPDIR because
rules_foreign_cc/framework.bzl replaces in the generated files any path
that is under $BUILD_TMPDIR with the appropriate placeholder (such as
$EXT_BUILD_DEPS).

Signed-off-by: George Prekas <george@enfabrica.net>