### PR TITLE
astore: Disable integration test in cloudbuild

### DIFF
--- a/astore/client/test/BUILD.bazel
+++ b/astore/client/test/BUILD.bazel
@@ -26,7 +26,10 @@ go_test(
     name = "test",
     srcs = ["regression_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-cloudbuild",
+    ],
     deps = [
         "//astore/client/astore:go_default_library",
         "//astore/server/astore:go_default_library",


### PR DESCRIPTION
This test fails due to a credentials error; this change disables the
test in presubmits and postsubmits. It is probably not expected to be
run in Cloud Build due to the `manual` tag.

Jira: INFRA-1233