### PR TITLE
bazel/utils/remote: allow local copy, allow non-exec targets.

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -119,7 +119,7 @@ cc_binary(
 
 #### Actual tests
 remote_run(
-    name = "test-no-machines",
+    name = "test-no-dests",
     rsync_cmd = "./bazel/utils/save-argv test1.rsync",
     rsync_opts = [
         "--test_rsync_opt",
@@ -132,10 +132,10 @@ remote_run(
     tools = [":save-argv"],
 )
 
-# No machines are specified for a remote run - the command should fail!
+# No dests are specified for a remote run - the command should fail!
 exec_test(
     name = "test-no-machine-fails_test",
-    dep = ":test-no-machines",
+    dep = ":test-no-dests",
     must_fail = True,
 )
 
@@ -162,7 +162,7 @@ remote_wrapper(
 
 remote_run_test(
     name = "simple",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -171,7 +171,7 @@ remote_run_test(
 
 remote_run_test(
     name = "with-opts",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -192,7 +192,7 @@ remote_run_test(
 
 remote_run_test(
     name = "only-copy",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -202,7 +202,7 @@ remote_run_test(
 
 remote_run_test(
     name = "with-destdir",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -212,7 +212,7 @@ remote_run_test(
 
 remote_run_test(
     name = "with-wrapper",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -225,7 +225,7 @@ remote_run_test(
 
 remote_run_test(
     name = "with-decorated-wrapper",
-    machines = [
+    dests = [
         "non-existant-machine-1.corp",
         "non-existant-machine-2.corp",
     ],
@@ -234,4 +234,46 @@ remote_run_test(
     wrapper = ":decorated-wrapper",
     wrapper_opts = ["--wrapper_opt1=foo"],
     destdir = "hw-dev-$USER/home/$USER",
+)
+
+remote_run_test(
+    name = "with-remote-dir",
+    dests = [
+        "non-existant-machine-1.corp",
+        "non-existant-machine-2.corp:my-specific-dir/test/",
+    ],
+    target = ":hello-world",
+    target_opts = ["--target_opt1=foo"],
+    destdir = "hw-dev-$USER/home/$USER",
+)
+
+remote_run_test(
+    # The ssh command should have the correct path.
+    name = "with-remote-dir-inverted",
+    dests = [
+        "non-existant-machine-2.corp:my-specific-dir/test/",
+        "non-existant-machine-1.corp",
+    ],
+    target = ":hello-world",
+    target_opts = ["--target_opt1=foo"],
+    destdir = "hw-dev-$USER/home/$USER",
+)
+
+remote_run_test(
+    name = "with-local-dir",
+    dests = [
+        "non-existant-machine-1.corp",
+        "/tmp/testdir/",
+    ],
+    target = ":hello-world",
+    target_opts = ["--target_opt1=foo"],
+    destdir = "hw-dev-$USER/home/$USER",
+)
+
+remote_run_test(
+    name = "with-non-run-target",
+    dests = [
+        "/tmp/testdir/",
+    ],
+    target = ":quote01",
 )

--- a/bazel/utils/remote.bzl
+++ b/bazel/utils/remote.bzl
@@ -1,5 +1,8 @@
 """
-Simple rules to allow running targets on remote machines using rsync + ssh.
+Simple rules to export targets and their inputs to a local or remote
+directory, and to allow running targets on remote machines.
+
+Defaults to using rsync + ssh.
 
 Basic usage is trivial. For example, by defining:
 
@@ -11,7 +14,7 @@ Basic usage is trivial. For example, by defining:
     remote_run(
         name = "test-on-remote-machine",
         target = ":my_test",
-        machines = ["test-machine-00.corp"],
+        dests = ["test-machine-00.corp"],
     )
 
 You can then run `bazel run :test-on-remote-machine` which will result in:
@@ -168,8 +171,21 @@ _known_attributes = [
     )),
     ("ssh_opts", attr.string_list, dict(default = [
     ], doc = "Additional flags to pass to the ssh binary")),
-    ("machines", attr.string_list, dict(default = [
-    ], doc = "List of machines to copy the output to, target is run on the first machine listed. If not supplied, it must be supplied at run time when invoking the target.")),
+    ("dests", attr.string_list, dict(default = [
+    ], doc = """\
+List of destinations to copy the output to.
+
+When the target is executable, the target is run from the first destination supplied.
+If no destination is supplied, at least one destination MUST be supplied manually
+when invoking the target (use `bazel run //name/of:target -- -h` to see the options available).
+
+The destination can be any string accepsted by the rsync_cmd. If it's a string
+containing no ':' and no '/', it is assumed to be a machine name, and data is copied
+to `machine:{destdir}/{targetname with invalid characters replaced with _}`, where
+`destdir` is a parameter to this rule, and defaults to the user home directory.
+
+Any other string is interpreted as a literal path. If interpreted as literal path,
+no ssh command is invoked - if the target is executable, it is run directly.""")),
     ("only_copy", attr.bool, dict(default = False, doc = "If true, does not execute any target on the remote machine.")),
     ("template", attr.label, dict(
         default = "@enkit//bazel/utils/remote:runner.template.sh",
@@ -225,7 +241,7 @@ def _common_attrs_to_dict(ctx, default = True):
 
     return attrs
 
-def _remote_run_impl(ctx):
+def _export_and_run_impl(ctx):
     has_wrapper = ctx.attr.wrapper and not package(ctx.attr.wrapper.label) == package(ctx.attr.noop.label)
 
     attrs = _common_attrs_to_dict(ctx)
@@ -236,21 +252,30 @@ def _remote_run_impl(ctx):
     if package(ctx.attr.target.label) == package(attrs.noop.label):
         fail(location(ctx) + "A target must be supplied via flags - read the file '//" + ctx.build_file_path + "' for details")
 
-    target_exec = ctx.attr.target[DefaultInfo].files_to_run.executable
-    target_runfiles = ctx.attr.target[DefaultInfo].default_runfiles
+    tdi = ctx.attr.target[DefaultInfo]
+    runfiles = ctx.runfiles()
     target_opts = attrs.target_opts
+    target_exec = ""
+    if getattr(tdi, "files_to_run") and getattr(tdi.files_to_run, "executable") and tdi.files_to_run.executable:
+      no_execute = False
+      target_exec = tdi.files_to_run.executable.short_path
+      target_runfiles = tdi.default_runfiles
 
-    runfiles = ctx.runfiles(files = [target_exec])
-    runfiles = runfiles.merge(target_runfiles)
+      runfiles = runfiles.merge(ctx.runfiles(files = [tdi.files_to_run.executable]))
+      runfiles = runfiles.merge(target_runfiles)
 
-    if has_wrapper:
-        wrapper_exec = ctx.attr.wrapper[DefaultInfo].files_to_run.executable
-        wrapper_runfiles = ctx.attr.wrapper[DefaultInfo].default_runfiles
-        runfiles = runfiles.merge(wrapper_runfiles)
-        runfiles = runfiles.merge(ctx.runfiles(files = [wrapper_exec]))
+      if has_wrapper:
+          wrapper_exec = ctx.attr.wrapper[DefaultInfo].files_to_run.executable
+          wrapper_runfiles = ctx.attr.wrapper[DefaultInfo].default_runfiles
+          runfiles = runfiles.merge(wrapper_runfiles)
+          runfiles = runfiles.merge(ctx.runfiles(files = [wrapper_exec]))
 
-        target_opts = attrs.wrapper_opts + ["--", target_exec.short_path] + target_opts
-        target_exec = wrapper_exec
+          target_opts = attrs.wrapper_opts + ["--", target_exec] + target_opts
+          target_exec = wrapper_exec.short_path
+    else:
+      no_execute = True
+      print("FILES", tdi.files.to_list())
+      runfiles = runfiles.merge(ctx.runfiles(files = tdi.files.to_list()))
 
     include = ctx.outputs.include
     ctx.actions.write(include, "\n".join([ctx.workspace_name + "/" + f.short_path for f in runfiles.files.to_list()]))
@@ -260,13 +285,14 @@ def _remote_run_impl(ctx):
         destdir = shell.quote(attrs.destdir),
         target = shell.quote(package(ctx.attr.target.label)),
         target_opts = shell.array_literal(target_opts),
-        executable = shell.quote(target_exec.short_path),
+        executable = shell.quote(target_exec),
+        no_execute = (no_execute and "true") or "",
         workspace = shell.quote(ctx.workspace_name),
         rsync_opts = shell.array_literal(attrs.rsync_opts),
         rsync_cmd = shell.quote(attrs.rsync_cmd),
         ssh_opts = shell.array_literal(attrs.ssh_opts),
         ssh_cmd = shell.quote(attrs.ssh_cmd),
-        machines = shell.array_literal(attrs.machines),
+        dests = shell.array_literal(attrs.dests),
         only_copy = (attrs.only_copy and "true") or "",
     )
 
@@ -288,12 +314,11 @@ def _remote_run_impl(ctx):
 
     return DefaultInfo(files = depset([runner, include]), executable = runner, runfiles = runfiles)
 
-remote_run_rule = rule(
-    implementation = _remote_run_impl,
+export_and_run_rule = rule(
+    implementation = _export_and_run_impl,
     executable = True,
     attrs = dict(_common_attrs(), **{
         "target": attr.label(
-            executable = True,
             cfg = "host",
             mandatory = True,
             doc = "Target to execute on the remote machine",
@@ -347,4 +372,9 @@ def remote_wrapper(name, **kwargs):
     remote_wrapper_rule(name = name, script = name + "-wrapper", **kwargs)
 
 def remote_run(name, **kwargs):
-    remote_run_rule(name = name, script = name + "-copy-and-run.sh", include = name + ".files_to_copy", **kwargs)
+    """Defines a target to run a specific target on a remote machine."""
+    export_and_run_rule(name = name, script = name + "-copy-and-run.sh", include = name + ".files_to_copy", **kwargs)
+
+def export(name, **kwargs):
+    """Defines a target to export files by a target in a specified directory."""
+    export_and_run_rule(name = name, script = name + "-export.sh", include = name + ".files_to_copy", only_copy = True, **kwargs)

--- a/bazel/utils/remote.bzl
+++ b/bazel/utils/remote.bzl
@@ -274,7 +274,6 @@ def _export_and_run_impl(ctx):
           target_exec = wrapper_exec.short_path
     else:
       no_execute = True
-      print("FILES", tdi.files.to_list())
       runfiles = runfiles.merge(ctx.runfiles(files = tdi.files.to_list()))
 
     include = ctx.outputs.include

--- a/bazel/utils/remote/runner.template.sh
+++ b/bazel/utils/remote/runner.template.sh
@@ -3,8 +3,9 @@
 RSYNC_OPTS={rsync_opts}
 SSH_OPTS={ssh_opts}
 TARGET_OPTS={target_opts}
-MACHINES={machines}
+DESTS={dests}
 ONLY_COPY={only_copy}
+NO_EXECUTE={no_execute}
 SSH_CMD={ssh_cmd}
 RSYNC_CMD={rsync_cmd}
 
@@ -14,23 +15,37 @@ help() {
   } 
 
   cat <<END
-This script runs a target on a remote machine, after copying all its dependencies.
+This script runs a target from a specified destination, after copying all its dependencies.
 
 Use as:
 
-  bazel run $TARGET -- [-r rsync options]... [-s ssh options]... [-t target options]... [-o|-h] [MACHINE]...
+  bazel run $TARGET -- [-r rsync options]... [-s ssh options]... [-t target options]... [-o|-h] [DEST]...
 
 Accepted options:
 
-  MACHINE      List of machines to copy the target to. The target will then be
-               run on the first machine specified, unless -o is used.
+  DEST         List of dests to copy the target to. The target will then be
+               run on the first dest specified, unless -o is used.
 
-               The list of machines is MANDATORY, unless it is already specified
+               The list of dests is MANDATORY, unless it is already specified
                in the rule in the BUILD.bazel file. In that case, if you pass any
-               machine on the command line the list will REPLACE the one supplied
+               dest on the command line the list will REPLACE the one supplied
                in the BUILD.bazel file.
 
-  -o           Don't run the binary, only copy all the files to the remote machines.
+               DEST can be:
+                 1) A string without / or :, assumed to be a machine name.
+		    In this case, ssh will be used to run the remote command,
+                    and the defined destination directory will be appended.
+                 2) A string containing / or :, assumed to be a full path
+                    specified by the user. No path will be appended. ssh will
+                    be used if there's a ':' in the name.
+
+                 This roughly matches rsync and scp syntax: a string like
+                 'machine00.corp' will be turned into 'machine00.corp:dest/path/',
+                 and use ssh. A string like 'machine00.corp:whatever' is assumed
+                 to already contain a path, and will not be mangled. A string like
+                 './tests' will be used as a plain destination directory.
+
+  -o           Don't run the binary, only copy all the files to the remote dests.
 
   -r [value]   Adds one or more rsync options.
 
@@ -43,6 +58,11 @@ Accepted options:
      option. Those options are highly dependant on the target.
 
   -h           Prints this astonishingly helpful message.
+
+****************************************************************************************
+IMPORTANT/DANGER/ACHTUNG: rsync will overwrite and delete files in the output directory.
+         Make sure to never point this script to your home, or to a populated directory.
+****************************************************************************************
 END
 
   test -z "$*" || {
@@ -66,11 +86,11 @@ done
 shift $((OPTIND - 1))
 
 [ "$#" -le 0 ] || {
-  MACHINES=("$@")
+  DESTS=("$@")
 }
 
-[ "${#MACHINES[@]}" -ge 1 ] || {
-  help "You must specify one or more MACHINE to copy the output to"
+[ "${#DESTS[@]}" -ge 1 ] || {
+  help "You must specify one or more DEST to copy the output to"
 }
 
 target={target}
@@ -81,15 +101,31 @@ executable={executable}
 workspace={workspace}
 
 printrun() { echo "+ $*"; "$@"; }
+is_fullpath() { [[ "$1" =~ [/:] ]] || return 1; return 0; }
+is_remote() {
+  if [[ "$1" =~ [:] ]] || ! [[ "$1" =~ [/:] ]]; then 
+    return 0
+  fi
+  return 1 
+}
 
 echo "Copying files..."
 set -e
-for machine in "${MACHINES[@]}"; do
-  printrun $RSYNC_CMD --files-from="$include" "${RSYNC_OPTS[@]}" .. "$machine:$destpath/"
+destrun="" # Actual location where the test will be run from.
+for dest in "${DESTS[@]}"; do
+  # Machine already specifies a path, or it's a local directory.
+  # Don't mess with the path supplied by the user.
+  if is_fullpath "$dest"; then
+    printrun $RSYNC_CMD --files-from="$include" "${RSYNC_OPTS[@]}" .. "$dest"
+    test -n "$destrun" || destrun="$dest/$workspace"
+  else
+    printrun $RSYNC_CMD --files-from="$include" "${RSYNC_OPTS[@]}" .. "$dest:$destpath/"
+    test -n "$destrun" || destrun="$destpath/$workspace"
+  fi
 done
 
 # TODO(cccontavalli): better escaping, will fix it once we have more tests.
-command="cd $destpath/$workspace; MACHINES='${MACHINES[*]}' ./$executable ${TARGET_OPTS[*]}"
+command="cd $destrun; MACHINES='${DESTS[*]}' ./$executable ${TARGET_OPTS[*]}"
 [ "$ONLY_COPY" != "true" ] || {
   echo "Copy only mode was requesting - not running any command"
   echo "Would have run:"
@@ -97,5 +133,15 @@ command="cd $destpath/$workspace; MACHINES='${MACHINES[*]}' ./$executable ${TARG
   exit 0
 }
 
-echo "Running '$command' on ${MACHINES[0]}..."
-printrun $SSH_CMD "${SSH_OPTS[@]}" "${MACHINES[0]}" -- "$command"
+[ "$NO_EXECUTE" != "true" ] || {
+  echo "Target $target is not executable - only copied"
+  exit 0
+}
+
+target="${DESTS[0]}"
+echo "Running '$command' on $target..."
+if is_remote "$target"; then
+  printrun $SSH_CMD "${SSH_OPTS[@]}" "$target" -- "$command"
+else
+  printrun "$command"
+fi

--- a/bazel/utils/remote/runner.template.sh
+++ b/bazel/utils/remote/runner.template.sh
@@ -124,17 +124,17 @@ for dest in "${DESTS[@]}"; do
   fi
 done
 
-# TODO(cccontavalli): better escaping, will fix it once we have more tests.
-command="cd $destrun; MACHINES='${DESTS[*]}' ./$executable ${TARGET_OPTS[*]}"
-[ "$ONLY_COPY" != "true" ] || {
-  echo "Copy only mode was requesting - not running any command"
-  echo "Would have run:"
-  echo "    $command" 
+[ "$NO_EXECUTE" != "true" ] || {
+  [ "$ONLY_COPY" == "true" ] || echo "Target $target is not executable - only copied"
   exit 0
 }
 
-[ "$NO_EXECUTE" != "true" ] || {
-  echo "Target $target is not executable - only copied"
+# TODO(cccontavalli): better escaping, will fix it once we have more tests.
+command="cd $destrun; MACHINES='${DESTS[*]}' ./$executable ${TARGET_OPTS[*]}"
+[ "$ONLY_COPY" != "true" ] || {
+  echo "Copy only mode was requested - not running any command"
+  echo "Would have run:"
+  echo "    $command" 
   exit 0
 }
 

--- a/bazel/utils/remote_test.bzl
+++ b/bazel/utils/remote_test.bzl
@@ -18,14 +18,14 @@ def remote_run_test(**remote_run_opts):
         srcs = [],
         outs = [rsyncfile, sshfile],
         cmd = """
-  script="$(location {name})";
+  script="$(location {name})"
   filename=$$(basename "$$script")
   dirname=$$(dirname "$$script")
   export OUTDIR="$$(mktemp -d)"
   set -e
   (cd ./"$$script.runfiles/enkit" && ../../"$$filename") && (
-    cp "$$OUTDIR"/{rsyncfile} $(location {rsyncfile}) || touch $(location {rsyncfile})
-    cp "$$OUTDIR"/{sshfile} $(location {sshfile}) || touch $(location {sshfile})
+    cp "$$OUTDIR"/{rsyncfile} $(location {rsyncfile}) &>/dev/null || touch $(location {rsyncfile})
+    cp "$$OUTDIR"/{sshfile} $(location {sshfile}) &>/dev/null || touch $(location {sshfile})
   )
   """.format(name = name, rsyncfile = rsyncfile, sshfile = sshfile),
         tools = [":" + name],

--- a/bazel/utils/testdata/remote/with-local-dir.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-local-dir.files_to_copy.expected
@@ -1,0 +1,6 @@
+enkit/bazel/utils/hello-world
+enkit/bazel/utils/testdata/remote/quote00.txt
+enkit/bazel/utils/quote01.txt
+enkit/tools/codegen/tests/gen-test.actual
+enkit/../com_google_absl/AUTHORS
+enkit/_solib_k8/libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so

--- a/bazel/utils/testdata/remote/with-local-dir.rsync.expected
+++ b/bazel/utils/testdata/remote/with-local-dir.rsync.expected
@@ -1,0 +1,2 @@
+--files-from=bazel/utils/with-local-dir.files_to_copy --delete -avrz --progress --copy-unsafe-links .. non-existant-machine-1.corp:hw-dev-$USER/home/$USER/__bazel_utils_hello-world/
+--files-from=bazel/utils/with-local-dir.files_to_copy --delete -avrz --progress --copy-unsafe-links .. /tmp/testdir/

--- a/bazel/utils/testdata/remote/with-local-dir.ssh.expected
+++ b/bazel/utils/testdata/remote/with-local-dir.ssh.expected
@@ -1,0 +1,1 @@
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp /tmp/testdir/' ./bazel/utils/hello-world --target_opt1=foo

--- a/bazel/utils/testdata/remote/with-non-run-target.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-non-run-target.files_to_copy.expected
@@ -1,0 +1,1 @@
+enkit/bazel/utils/quote01.txt

--- a/bazel/utils/testdata/remote/with-non-run-target.rsync.expected
+++ b/bazel/utils/testdata/remote/with-non-run-target.rsync.expected
@@ -1,0 +1,1 @@
+--files-from=bazel/utils/with-non-run-target.files_to_copy --delete -avrz --progress --copy-unsafe-links .. /tmp/testdir/

--- a/bazel/utils/testdata/remote/with-remote-dir-inverted.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir-inverted.files_to_copy.expected
@@ -1,0 +1,6 @@
+enkit/bazel/utils/hello-world
+enkit/bazel/utils/testdata/remote/quote00.txt
+enkit/bazel/utils/quote01.txt
+enkit/tools/codegen/tests/gen-test.actual
+enkit/../com_google_absl/AUTHORS
+enkit/_solib_k8/libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so

--- a/bazel/utils/testdata/remote/with-remote-dir-inverted.rsync.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir-inverted.rsync.expected
@@ -1,0 +1,2 @@
+--files-from=bazel/utils/with-remote-dir-inverted.files_to_copy --delete -avrz --progress --copy-unsafe-links .. non-existant-machine-2.corp:my-specific-dir/test/
+--files-from=bazel/utils/with-remote-dir-inverted.files_to_copy --delete -avrz --progress --copy-unsafe-links .. non-existant-machine-1.corp:hw-dev-$USER/home/$USER/__bazel_utils_hello-world/

--- a/bazel/utils/testdata/remote/with-remote-dir-inverted.ssh.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir-inverted.ssh.expected
@@ -1,0 +1,1 @@
+non-existant-machine-2.corp:my-specific-dir/test/ -- cd non-existant-machine-2.corp:my-specific-dir/test//enkit; MACHINES='non-existant-machine-2.corp:my-specific-dir/test/ non-existant-machine-1.corp' ./bazel/utils/hello-world --target_opt1=foo

--- a/bazel/utils/testdata/remote/with-remote-dir.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir.files_to_copy.expected
@@ -1,0 +1,6 @@
+enkit/bazel/utils/hello-world
+enkit/bazel/utils/testdata/remote/quote00.txt
+enkit/bazel/utils/quote01.txt
+enkit/tools/codegen/tests/gen-test.actual
+enkit/../com_google_absl/AUTHORS
+enkit/_solib_k8/libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so

--- a/bazel/utils/testdata/remote/with-remote-dir.rsync.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir.rsync.expected
@@ -1,0 +1,2 @@
+--files-from=bazel/utils/with-remote-dir.files_to_copy --delete -avrz --progress --copy-unsafe-links .. non-existant-machine-1.corp:hw-dev-$USER/home/$USER/__bazel_utils_hello-world/
+--files-from=bazel/utils/with-remote-dir.files_to_copy --delete -avrz --progress --copy-unsafe-links .. non-existant-machine-2.corp:my-specific-dir/test/

--- a/bazel/utils/testdata/remote/with-remote-dir.ssh.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir.ssh.expected
@@ -1,0 +1,1 @@
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp:my-specific-dir/test/' ./bazel/utils/hello-world --target_opt1=foo


### PR DESCRIPTION
With this PR, remote_run is renamed to export_and_run, and can now:
- export a target to a local directory. This will copy the target
  and all its necessary dependencies. This is useful for example
  when there are generated files involved, and you want to use a
  non bazel build or tooling.
- export (or remote copy) a non-executable target. When a target
  is not executable, files are just copied.
- allow for detinations that contain a full path. So to copy files
  in a specific remote directory, one can use 'machine:/path/to/dir'.

Added corresponding tests.
