### PR TITLE
gee: don't be so restrictive about what directory gee is run from

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -576,6 +576,9 @@ function _startup_checks() {
     exit 1
   fi
 
+  # 1.5. Make sure we're not in one of bazel's weird symlink directories.
+  while [[ "$(pwd -P)" != "$(pwd -L)"  ]]; do cd ..; done
+
   # 2. Ensure that we are in a gee-controlled git repo.  If not,
   #    switch to the main branch of one.
   local GITDIR

--- a/scripts/gee
+++ b/scripts/gee
@@ -563,17 +563,35 @@ function _startup_checks() {
   # Ensure that (most) gee commands are run from within the gee repository,
   # otherwise strange things might happen (if the user's home directory is a
   # git repository, for instance).
-  local GITDIR
-  GITDIR="$(readlink -f "$("${GIT}" rev-parse --git-common-dir)")"
-  if [[ "${GITDIR}" != "${GEE_DIR}"/*/.git ]]; then
-    _warn "Error: refusing to run this gee command outside of the gee" \
-          "repository."
-    if [[ -d "${GEE_DIR}" ]]; then
-      _info "Use \"gcd\" to switch to a gee branch and try again."
-    else
-      _info "No gee repository found, run \"gee init\" to create one."
-    fi
+
+  # 1. Ensure that a gee repository exists.
+  if [[ ! -d "${GEE_DIR}/${REPO}" ]]; then
+    _info "Directory ${GEE_DIR}/${REPO} not found, run \"gee init\" to create."
     exit 1
+  fi
+  _set_main
+  if [[ ! -d "${GEE_DIR}/${REPO}/${MAIN}" ]]; then
+    _die "Directory ${GEE_DIR}/${REPO}/${MAIN} not found." \
+      "Somehow your ${MAIN} branch got removed?"
+    exit 1
+  fi
+
+  # 2. Ensure that we are in a gee-controlled git repo.  If not,
+  #    switch to the main branch of one.
+  local GITDIR
+  if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
+    # not in a git directory
+    _set_main
+    _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
+    cd "${GEE_DIR}/${REPO}/${MAIN}"
+    if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
+      _die "Somehow, ${GEE_DIR}/${REPO}/${MAIN} is not a git repository."
+    fi
+  fi
+  GITDIR="$(readlink -f "${GITDIR}")"
+  if [[ "${GITDIR}" != "${GEE_DIR}"/*/.git ]]; then
+    _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
+    cd "${GEE_DIR}/${REPO}/${MAIN}"
   fi
 
   # Troubleshoot our environment before running (most) commands.

--- a/scripts/gee
+++ b/scripts/gee
@@ -600,7 +600,7 @@ function _startup_checks() {
   fi
   GITDIR="$(readlink -f "${GITDIR}")"
   if [[ "${GITDIR}" != "${GEE_DIR}"/*/.git ]]; then
-    if [[ *" ${COMMAND} "* == "${SAFE_COMMANDS}" ]]; then
+    if [[ "${SAFE_COMMANDS}" == *" ${COMMAND} "* ]]; then
       _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
       cd "${GEE_DIR}/${REPO}/${MAIN}"
     else

--- a/scripts/gee
+++ b/scripts/gee
@@ -563,6 +563,7 @@ function _startup_checks() {
   # Ensure that (most) gee commands are run from within the gee repository,
   # otherwise strange things might happen (if the user's home directory is a
   # git repository, for instance).
+  local COMMAND="$1"
 
   # 1. Ensure that a gee repository exists.
   if [[ ! -d "${GEE_DIR}/${REPO}" ]]; then
@@ -580,7 +581,13 @@ function _startup_checks() {
   while [[ "$(pwd -P)" != "$(pwd -L)"  ]]; do cd ..; done
 
   # 2. Ensure that we are in a gee-controlled git repo.  If not,
-  #    switch to the main branch of one.
+  #    switch to the main branch of the git repo, if we are running
+  #    a command on the "safe" list.
+  local SAFE_COMMANDS=" bash_setup bazelgc cleanup codeowners config create_ssh_key diagnose"
+  SAFE_COMMANDS+=" diff gcd get_parent hello help log lsbranches make_branch pack pr_check"
+  SAFE_COMMANDS+=" pr_checkout pr_edit pr_list pr_make pr_push pr_rollback pr_submit pr_view"
+  SAFE_COMMANDS+=" remove_branch repair restore_all_branches rupdate share update update_all"
+  SAFE_COMMANDS+=" upgrade version whatsout "
   local GITDIR
   if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
     # not in a git directory
@@ -593,8 +600,12 @@ function _startup_checks() {
   fi
   GITDIR="$(readlink -f "${GITDIR}")"
   if [[ "${GITDIR}" != "${GEE_DIR}"/*/.git ]]; then
-    _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
-    cd "${GEE_DIR}/${REPO}/${MAIN}"
+    if [[ *" ${COMMAND} "* == "${SAFE_COMMANDS}" ]]; then
+      _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
+      cd "${GEE_DIR}/${REPO}/${MAIN}"
+    else
+      _die "${COMMAND} must be run from within a gee branch."
+    fi
   fi
 
   # Troubleshoot our environment before running (most) commands.
@@ -883,6 +894,10 @@ function _update_branch_to_worktree() {
       BR="${BASH_REMATCH[1]}"
       BRANCH_TO_WORKTREE["${BR}"]="${WT}"
     elif [[ "${LINE}" =~ ^detached ]]; then
+      if [[ ! -d "${WT}" ]]; then
+        # ignore pruneable worktrees that don't exist anymore.
+        continue
+      fi
       BR="$(
         cd "${WT}";
         for loc in rebase-merge rebase-apply; do
@@ -2183,7 +2198,7 @@ EOT
 
 function gee__mkbr() { gee__make_branch "$@"; }
 function gee__make_branch() {
-  _startup_checks
+  _startup_checks "make_branch"
 
   local BRNAME SHA CURRENT_BRANCH
   # TODO(jonathan): Let the user name the branch to branch from.
@@ -2231,7 +2246,7 @@ Usage: gee log
 EOT
 
 function gee__log() {
-  _startup_checks
+  _startup_checks "log"
 
   _check_cwd
   local -a ARGS=( "$@" )
@@ -2269,7 +2284,7 @@ If <files...> are omited, shows changes to all files.
 EOT
 
 function gee__diff() {
-  _startup_checks
+  _startup_checks "diff"
 
   _check_cwd
   local PARENT_BRANCH
@@ -2306,7 +2321,7 @@ Flags:
 EOT
 
 function gee__pack() {
-  _startup_checks
+  _startup_checks "pack"
 
   _check_cwd
   _set_main
@@ -2355,7 +2370,7 @@ Usage: gee unpack <file.pack>
 EOT
 
 function gee__unpack() {
-  _startup_checks
+  _startup_checks "unpack"
 
   _check_cwd
   _set_main
@@ -2403,7 +2418,7 @@ function gee__unpack() {
 ## EOT
 ##
 ## function gee__squash() {
-##  _startup_checks
+##  _startup_checks "squash"
 ##
 ##   _check_cwd
 ##   # Note: there is no longer any need to squash before sending out for review,
@@ -2493,7 +2508,7 @@ EOT
 
 function gee__up() { gee__update "$@"; }
 function gee__update() {
-  _startup_checks
+  _startup_checks "update"
 
   _check_cwd
   local CURRENT_BRANCH
@@ -2596,7 +2611,7 @@ function _add_parent_branches_to_chain() {
 
 function gee__rup() { gee__rupdate "$@"; }
 function gee__rupdate() {
-  _startup_checks
+  _startup_checks "rupdate"
 
   _check_cwd
   local CURRENT_BRANCH
@@ -2669,7 +2684,7 @@ EOT
 
 function gee__up_all() { gee__update_all "$@"; }
 function gee__update_all() {
-  _startup_checks
+  _startup_checks "update_all"
 
   local -a CONFLICTS=()
   local CURRENT_BRANCH
@@ -2731,7 +2746,7 @@ Reports which files in this branch differ from parent branch.
 EOT
 
 function gee__whatsout() {
-  _startup_checks
+  _startup_checks "whatsout"
 
   _check_cwd
   local BRANCH PARENT
@@ -2772,7 +2787,7 @@ EOT
 function gee__owners() { gee__codeowners "$@"; }
 function gee__reviewers() { gee__codeowners "$@"; }
 function gee__codeowners() {
-  _startup_checks
+  _startup_checks "codeowners"
 
   local OPT_COMMENT=0
   if [[ "$1" == "--comment" ]]; then
@@ -2824,7 +2839,7 @@ EOT
 function gee__lsb() { gee__lsbranches "$@"; }
 function gee__lsbr() { gee__lsbranches "$@"; }
 function gee__lsbranches() {
-  _startup_checks
+  _startup_checks "lsbranches"
 
   _set_main
   if ! _in_gee_repo; then
@@ -2857,7 +2872,7 @@ Automatically removes branches without local changes.
 EOT
 
 function gee__cleanup() {
-  _startup_checks
+  _startup_checks "cleanup"
 
   _set_main
   _read_parents_file
@@ -2968,7 +2983,7 @@ Usage: gee get_parent
 EOT
 
 function gee__get_parent() {
-  _startup_checks
+  _startup_checks "get_parent"
 
   _check_cwd
   local BRANCH
@@ -2992,7 +3007,7 @@ to do a "gee update" operation afterwards.
 EOT
 
 function gee__set_parent() {
-  _startup_checks
+  _startup_checks "set_parent"
 
   _check_cwd
   local BRANCH PARENT
@@ -3039,7 +3054,7 @@ EOT
 function gee__push() { gee__commit "$@"; }
 function gee__c() { gee__commit "$@"; }
 function gee__commit() {
-  _startup_checks
+  _startup_checks "commit"
 
   _check_cwd
   local CURRENT_BRANCH
@@ -3099,7 +3114,7 @@ Example:
 EOT
 
 function gee__revert() {
-  _startup_checks
+  _startup_checks "revert"
 
   _check_cwd
   local CURRENT_BRANCH
@@ -3151,7 +3166,7 @@ See also:
 EOT
 
 function gee__pr_checkout() {
-  _startup_checks
+  _startup_checks "pr_checkout"
 
   _check_gh_auth
   _set_main
@@ -3299,7 +3314,7 @@ function gee__lspr() { gee__pr_list "$@"; }
 function gee__list_pr() { gee__pr_list "$@"; }
 function gee__prls() { gee__pr_list "$@"; }
 function gee__pr_list() {
-  _startup_checks
+  _startup_checks "pr_list"
 
   _check_gh_auth
   local WHO WHO_3RD_PERSON USER YOUR
@@ -3380,7 +3395,7 @@ function gee__edpr() { gee__pr_edit "$@"; }
 function gee__pred() { gee__pr_edit "$@"; }
 function gee__edit_pr() { gee__pr_edit "$@"; }
 function gee__pr_edit() {
-  _startup_checks
+  _startup_checks "pr_edit"
 
   _check_cwd
   _check_gh_auth
@@ -3408,7 +3423,7 @@ function gee__pr_edit() {
 ##########################################################################
 
 function gee__pr_debug() {
-  _startup_checks
+  _startup_checks "pr_debug"
 
   _check_cwd
   _check_gh_auth
@@ -3434,7 +3449,7 @@ EOT
 
 function gee__view_pr() { gee__pr_view "$@"; }
 function gee__pr_view() {
-  _startup_checks
+  _startup_checks "pr_view"
 
   _check_cwd
   _check_gh_auth
@@ -3470,7 +3485,7 @@ function gee__make_pr() { gee__pr_make "$@"; }
 function gee__pr_create() { gee__pr_make "$@"; }
 function gee__create_pr() { gee__pr_make "$@"; }
 function gee__pr_make() {
-  _startup_checks
+  _startup_checks "pr_make"
 
   _check_cwd
   _check_gh_auth
@@ -3653,7 +3668,7 @@ EOT
 function gee__check_pr() { gee__pr_check "$@"; }
 function gee__pr_checks() { gee__pr_check "$@"; }
 function gee__pr_check() {
-  _startup_checks
+  _startup_checks "pr_check"
 
   local -a CHECKS=()
   local -A CHECK_COUNTS=()
@@ -3723,7 +3738,7 @@ EOT
 function gee__submit_pr() { gee__pr_submit "$@"; }
 function gee__merge() { gee__pr_submit "$@"; }
 function gee__pr_submit() {
-  _startup_checks
+  _startup_checks "pr_submit"
 
   _check_cwd
   _check_gh_auth
@@ -4062,7 +4077,7 @@ function _remove_a_branch() {
 
 function gee__rmbr() { gee__remove_branch "$@"; }
 function gee__remove_branch() {
-  _startup_checks
+  _startup_checks "remove_branch"
 
   local -a BRANCHES=( "$@" )
 
@@ -4098,7 +4113,7 @@ out as formatting rules are highly project specific.
 EOT
 
 function gee__fix() {
-  _startup_checks
+  _startup_checks "fix"
 
   local BDIR
   BDIR="$(_get_branch_rootdir)"
@@ -4298,7 +4313,7 @@ your branch with other users (in advance of sending out a PR).
 EOT
 
 function gee__share() {
-  _startup_checks
+  _startup_checks "share"
 
   local CURRENT_BRANCH PARENT_BRANCH
   CURRENT_BRANCH="$(_get_current_branch)"

--- a/scripts/gee
+++ b/scripts/gee
@@ -592,20 +592,21 @@ function _startup_checks() {
   if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
     # not in a git directory
     _set_main
-    _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
+    if [[ "${SAFE_COMMANDS}" != *" ${COMMAND} "* ]]; then
+      _fatal "${COMMAND} must be run from within a gee branch."
+    fi
     cd "${GEE_DIR}/${REPO}/${MAIN}"
     if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
-      _die "Somehow, ${GEE_DIR}/${REPO}/${MAIN} is not a git repository."
+      _fatal "Somehow, ${GEE_DIR}/${REPO}/${MAIN} is not a git repository."
     fi
   fi
   GITDIR="$(readlink -f "${GITDIR}")"
   if [[ "${GITDIR}" != "${GEE_DIR}"/*/.git ]]; then
-    if [[ "${SAFE_COMMANDS}" == *" ${COMMAND} "* ]]; then
-      _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
-      cd "${GEE_DIR}/${REPO}/${MAIN}"
-    else
-      _die "${COMMAND} must be run from within a gee branch."
+    if [[ "${SAFE_COMMANDS}" != *" ${COMMAND} "* ]]; then
+      _fatal "${COMMAND} must be run from within a gee branch."
     fi
+    _info "Switching to ${GEE_DIR}/${REPO}/${MAIN}"
+    cd "${GEE_DIR}/${REPO}/${MAIN}"
   fi
 
   # Troubleshoot our environment before running (most) commands.

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -4,6 +4,7 @@
 
 ### 0.2.34
 
+* `gee`: do our best regardless of which directory gee is invoked from (#699)
 * `gee gcd`: fix bug where savelog output would break gcd (#728)
 * `gee lsbr`: fix bug where upstream branches would break lsbr (#710)
 * `gee restore_all_branches`: interactively pick which branches to restore (#682)


### PR DESCRIPTION
This PR fixes a minor annoyance: previously, gee would refuse to run certain
commands if executed outside of a gee-controlled git repository.  In the
spirit of "do what I mean not what I say", gee will now switch to a valid
gee-controlled git repository before proceeding.

Thus, gee commands can continue to operate under the assumption that
they are running from a gee-controlled git repository, and the user
has one less failure mode.

Tested: Ran "gee lspr" from a variety of directories.

In ~/gee/enkit: shows PRs associated with the enkit repository.
In ~/gee/internal: shows PRs associated with the internal repository.
In ~/gee: shows PRs associated with the internal (default) repo.

Previously, all 3 operations would fail.

