### PR TITLE
bazel: Upgrade gazelle

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -36,11 +36,11 @@ def stage_1():
 
     maybe(
         name = "bazel_gazelle",
-        sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
         repo_rule = http_archive,
+        sha256 = "501deb3d5695ab658e82f6f6f549ba681ea3ca2a5fb7911154b5aa45596183fa",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Upgrading gazelle to the latest release fixes an issue where
com_github_docker_docker takes many minutes to fetch (see
https://github.com/bazelbuild/bazel-gazelle/issues/1190#issuecomment-1069673991)

Tested: `bazel clean --expunge; bazel build //...` saw no noticeable
hangup on go repositories for once