### PR TITLE
astore_download fix: add default value for timeout

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -127,7 +127,7 @@ With this rule, you can easily download
 files from an artifact store.""",
 )
 
-def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = None):
+def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = None, timeout = 10 * 60):
     """Fetch and extract a package from astore.
 
     This method downloads a package stored as an archive in astore, verifies
@@ -149,7 +149,9 @@ def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = Non
         f,
         "--overwrite",
     ]
-    res = ctx.execute(enkit_args, timeout = ctx.attr.timeout)
+    if "timeout" in ctx.attr:
+      timeout = ctx.attr.timeout
+    res = ctx.execute(enkit_args, timeout = timeout)
     if res.return_code:
         fail("Astore download failed\nArgs: {}\nStdout:\n{}\nStderr:\n{}\n".format(
             enkit_args,

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -149,8 +149,8 @@ def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = Non
         f,
         "--overwrite",
     ]
-    if "timeout" in ctx.attr:
-      timeout = ctx.attr.timeout
+    if hasattr(ctx.attr, "timeout"):
+        timeout = ctx.attr.timeout
     res = ctx.execute(enkit_args, timeout = timeout)
     if res.return_code:
         fail("Astore download failed\nArgs: {}\nStdout:\n{}\nStderr:\n{}\n".format(

--- a/bazel/linux/repository.bzl
+++ b/bazel/linux/repository.bzl
@@ -224,6 +224,10 @@ kernel_package = repository_rule(
         "uid": attr.string(
             doc = "Astore UID of the desired version of the object.",
         ),
+        "timeout": attr.int(
+            doc = "Timeout to apply when downloading from astore, in seconds.",
+            default = 10 * 60,
+        ),
         "required": attr.string_list(
             doc = """\
 Sets of components that must be provided in the package.


### PR DESCRIPTION
Fixing presubmit failures blocking enkit integration with internal.  The
issue was that `astore_download_and_extract` was being called from an
unexpected context, and the "timeout" attribute wasn't being populated
in the ctx context.

Since `astore_download_and_extract` is a public function, it has to support
being invoked with arbitrary ctx contexts.  (Really, these kinds of
implementation functions should never be public.)

This PR adds "timeout" attributes at tthe call sites I could find, and adds
reasonable defaults to support the call sites I couldn't find
(fail-functional).

Tested: Ran the following test from internal/master:

```
blaze query --override_repository=enkit=${HOME}/gee/enkit/astore_timeout @testing-latest-kernel//:all
```

The above command fails without these changes, and passes with.

