### PR TITLE
Revert "bazel: Upgrade gazelle (#700)"

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -36,11 +36,11 @@ def stage_1():
 
     maybe(
         name = "bazel_gazelle",
+        sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
         repo_rule = http_archive,
-        sha256 = "501deb3d5695ab658e82f6f6f549ba681ea3ca2a5fb7911154b5aa45596183fa",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This reverts commit e0e5990f112b3263bd97675f0d9e367851d500bf.

#700 is causing gazelle errors when building enkit from internal like:

```
ERROR: /home/scott/.cache/bazel/_bazel_scott/d2f3bcdaee533eba5e33487f155bd516/external/org_golang_x_crypto/blake2b/BUILD.bazel:3:11: GoCompilePkg external/org_golang_x_crypto/blake2b/blake2b.a failed: (Exit 1): builder failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src external/org_golang_x_crypto/blake2b/blake2b.go -src ... (remaining 29 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: missing strict dependencies:
        /home/scott/.cache/bazel/_bazel_scott/d2f3bcdaee533eba5e33487f155bd516/sandbox/linux-sandbox/25/execroot/enfabrica/external/org_golang_x_crypto/blake2b/blake2bAVX2_amd64.go: import of "golang.org/x/sys/cpu"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
```

Tested: Enkit builds from internal with this change when tested with `bazel build --override_repository=enkit=/home/scott/dev/enkit @enkit//enkit`