### PR TITLE
gee: fix lsbr query of upstream branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1127,6 +1127,20 @@ function _git_can_fail() {
   NOFAIL=1 _git "$@"
 }
 
+function _git_rev_list_counts() {
+  local B="$1"
+  local P="$2"
+  if [[ "${P}" == upstream/refs/pull/*/head ]]; then
+    "${GIT}" fetch upstream "${P#upstream/refs/}" >/dev/null 2>/dev/null
+    P=FETCH_HEAD
+  fi
+  if [[ "${P}" == upstream/* ]]; then
+    "${GIT}" fetch upstream "${P#upstream}" >/dev/null 2>/dev/null
+    P=FETCH_HEAD
+  fi
+  "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true
+}
+
 function _install_tools() {
   # Checks for and installs any missing tools.
 
@@ -1183,7 +1197,7 @@ function _branch_ahead_behind() {
     obr="$(_get_parent_branch "${branch}")"
   fi
   local -a counts
-  read -r -a counts < <("${GIT}" rev-list --left-right --count "${branch}...${obr}") || /bin/true
+  read -r -a counts < <(_git_rev_list_counts "${branch}" "${obr}") || /bin/true
   if (( "${counts[0]}" == 0 )) && (( "${counts[1]}" == 0 )); then
     printf "%-20s: same as %s" "${branch}" "${obr}"
   else

--- a/scripts/gee
+++ b/scripts/gee
@@ -1131,11 +1131,10 @@ function _git_rev_list_counts() {
   local B="$1"
   local P="$2"
   if [[ "${P}" == upstream/refs/pull/*/head ]]; then
-    "${GIT}" fetch upstream "${P#upstream/refs/}" >/dev/null 2>/dev/null
+    "${GIT}" fetch upstream "${P#upstream/refs/}" >/dev/null 2>&1
     P=FETCH_HEAD
-  fi
-  if [[ "${P}" == upstream/* ]]; then
-    "${GIT}" fetch upstream "${P#upstream}" >/dev/null 2>/dev/null
+  elif [[ "${P}" == upstream/* ]]; then
+    "${GIT}" fetch upstream "${P#upstream}" >/dev/null 2>&1
     P=FETCH_HEAD
   fi
   "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true


### PR DESCRIPTION
Reported by Leonid: "gee lsbranches" reports errors when attempting
to count whether the local branch is a head or behind the parent branch.
The underlying issue is "git rev-list" doesn't automatically fetch the
ustream branch reference when needed, but instead must be prefetched.

"gee pr_checkout" invokes "gh pr checkout" which does some very particular
things.  The parent property for the generated branch is set to
"upstream/refs/pull/NNN/head" which works for most but not all git commands.

"git rev-list", in particular, needs special handling: we have to use "git fetch"
to remap the upstream branch onto a local branch reference ("FETCH_HEAD" by default).

This PR wraps "git rev-list" in a helper function that insures that any upstream
PR reference gets mapped to a local reference, before running git rev-list.

Tested: gee lsbr used to produce errors, now it produces correct commit counts.

