### PR TITLE
bestie: Reduce logspam

### DIFF
--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//lib/multierror:go_default_library",
         "//lib/server:go_default_library",
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+        "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",

--- a/bestie/server/service.go
+++ b/bestie/server/service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/golang/glog"
 )
 
 // List of event ID names defined by build_event_stream.proto.
@@ -156,7 +157,7 @@ func getEventLabel(bevid interface{}) string {
 		label = promId
 	} else {
 		// Make note of this condition. Probably means .proto file definition was updated.
-		logger.Printf("Detected unknown event id: %s\n\n", id)
+		glog.Warningf("Detected unknown event id: %s", id)
 	}
 	return label
 }

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -111,8 +111,7 @@ func getTestMetricsFromXmlData(pbmsg []byte) (*metricTestResult, error) {
 	var testSuites TestSuites
 	if err := xml.Unmarshal(pbmsg, &testSuites); err != nil {
 		cidExceptionXmlParseError.increment()
-		debugPrintf("Error extracting metric data from XML file: %s", err)
-		return nil, nil
+		return nil, fmt.Errorf("Error extracting metric data from XML file: %s", err)
 	}
 
 	// Process each of the testcases contained in the testsuite.
@@ -140,15 +139,13 @@ func getTestMetricsFromXmlData(pbmsg []byte) (*metricTestResult, error) {
 		// (i.e. it requires the test applications to use junitxml style of output).
 		if len(ts.SystemOut) > 0 {
 			cidExceptionXmlUnstructuredError.increment()
-			debugPrintln("Unstructured XML test results not supported (use junitxml)")
-			return nil, nil
+			return nil, fmt.Errorf("Unstructured XML test results not supported (use junitxml)")
 		}
 
 		xmlResults, err := parseStructuredXml(&ts)
 		if err != nil {
 			cidExceptionXmlStructuredError.increment()
-			debugPrintf("Error parsing structured XML test results: %s", err)
-			return nil, nil
+			return nil, fmt.Errorf("Error parsing structured XML test results: %s", err)
 		}
 
 		metricName := "testresult"


### PR DESCRIPTION
Bestie emits lots of data on every bazel invocation, which hides errors
in the log. Disabling the `--debug` flag, counterintuitively, hides the
errors, and emits the other debug data.

This change switches from the golang stdlib logger to glog, which gives
some global functions to log at different levels. While this doesn't use
the enkit logging library, using a global logger is not a regression for
bestie, and glog is strictly more convenient here.

Debug logs are changed to `glog.V(2).Infof()`s by default, which only
show up when passing the `--v=2 --alsologtostderr` flags. The ones that
are worrisome and not propagated as errors up the callstack are logged
as `glog.Error` or `glog.Warning`, appropriately. In some cases, log
statements are removed from deep in the callstack and an error is
propagated instead.

Tested:
* Created tunnel to buildbarn: `enkit tunnel -L 8082 --proxy=https://gw.gcp01.corp.enfabrica.net buildbarn-browser.service.gcp01.consul 8080`
* Started bestie with: `bazel run //bestie/server:bestie -- --base_url=localhost:8082 --dataset=staging --alsologtostderr`
* Ran build: `BAZEL_PROFILE=buildbarn bazel test //systest/src/demo:test_sample_metrics --bes_backend=grpc://localhost:6433`
* Bestie output was:

  ```
  2022/07/14 19:44:11 Opening port 6433 - will be available at http://127.0.0.1:6433/
  I0714 19:44:14.739984   47153 test_result.go:110] Opened output file "test.xml" for processing
  I0714 19:44:15.622610   47153 test_result.go:110] Opened output file "test.outputs__outputs.zip" for processing
  I0714 19:44:15.622719   47153 test_result.go:250] Read output file to process: test.metrics.pb
  ```

  ...which is much improved
* Restarted bestie, adding `--v=2` flag; saw original debug output

Jira: INFRA-1405