### PR TITLE
gee gcd: fix incorrect mapping of branch-to-dir

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -835,8 +835,10 @@ function _update_branch_to_worktree() {
   #   HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
   #   detached
   #
-  # For "detached" branches, we're stuck just using the directory
-  # name to infer the branch.
+  # For "detached" branches, we need to directly query .git meta
+  # data directories to determine the branch name.  This is a bit
+  # hacky, so I fall back on using the basename of the directory
+  # as the branch name if all else fails.
   BRANCH_TO_WORKTREE=()  # global
   local LINE WT BR
   _set_main

--- a/scripts/gee
+++ b/scripts/gee
@@ -822,6 +822,21 @@ function _gee_get_all_children_of() {
 function _update_branch_to_worktree() {
   # Initialize the global BRANCH_TO_WORKTREE associative array with
   # a mapping of branch names onto worktree paths.
+  #
+  # Unfortunatelym, the output of git worktree list isn't exactly what
+  # we need.  For branches that are in a detached state, git only
+  # tells us that the branch is "detached".  For example:
+  #
+  #   worktree /home/hanu/gee/internal/master
+  #   HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
+  #   branch refs/heads/master
+  #
+  #   worktree /home/hanu/gee/internal/cmn_reg
+  #   HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
+  #   detached
+  #
+  # For "detached" branches, we're stuck just using the directory
+  # name to infer the branch.
   BRANCH_TO_WORKTREE=()  # global
   local LINE WT BR
   _set_main
@@ -830,10 +845,26 @@ function _update_branch_to_worktree() {
       WT="${BASH_REMATCH[1]}"
     elif [[ "${LINE}" =~ ^branch\ refs/heads/(.+) ]]; then
       BR="${BASH_REMATCH[1]}"
-    elif [[ "${LINE}" == "" ]]; then
-      if [[ -n "${BR}" ]]; then
-        BRANCH_TO_WORKTREE["${BR}"]="${WT}"
+      BRANCH_TO_WORKTREE["${BR}"]="${WT}"
+    elif [[ "${LINE}" =~ ^detached ]]; then
+      BR="$(
+        cd "${WT}";
+        for loc in rebase-merge rebase-apply; do
+          GDIR=$("${GIT}" rev-parse --git-path "${loc}");
+          if [[ -d "${GDIR}" ]]; then
+            HEADNAME=$(<${GDIR}/head-name)
+            echo "${HEADNAME##refs/heads/}"
+            break
+          fi
+        done
+      )"
+      if [[ -z "${BR}" ]]; then
+        BR="$(basename "${WT}")"
       fi
+      BRANCH_TO_WORKTREE["${BR}"]="${WT}"
+    elif [[ "${LINE}" == "" ]]; then
+      WT=""
+      BR=""
     fi
   done < <(cd "${GEE_DIR}/${REPO}/${MAIN}"; "${GIT}" worktree list --porcelain ) \
     || /bin/true

--- a/scripts/gee
+++ b/scripts/gee
@@ -854,7 +854,7 @@ function _update_branch_to_worktree() {
         for loc in rebase-merge rebase-apply; do
           GDIR=$("${GIT}" rev-parse --git-path "${loc}");
           if [[ -d "${GDIR}" ]]; then
-            HEADNAME=$(<${GDIR}/head-name)
+            HEADNAME="$(<"${GDIR}/head-name")"
             echo "${HEADNAME##refs/heads/}"
             break
           fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -823,7 +823,7 @@ function _update_branch_to_worktree() {
   # Initialize the global BRANCH_TO_WORKTREE associative array with
   # a mapping of branch names onto worktree paths.
   #
-  # Unfortunatelym, the output of git worktree list isn't exactly what
+  # Unfortunately, the output of git worktree list isn't exactly what
   # we need.  For branches that are in a detached state, git only
   # tells us that the branch is "detached".  For example:
   #


### PR DESCRIPTION
@hanu-enf reported a bug in which "gcd master" was taking him to a feature
branch directory instead of master.  We root-caused the problem to gee's
parsing of the output of `git worktree list --porcelain` which produces
output like this if a branch is in a rebase-in-progress state:

```
worktree /home/hanu/gee/internal/master
HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
branch refs/heads/master

worktree /home/hanu/gee/internal/cmn_reg
HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
detached
```

`gee` was not parsing the `detached` line correctly.  This PR fixes the issue
by parsing the `detached` line and then falls back on a secondary technique to
find the branch name if the branch is in a rebase-in-progress state.

If all else fails, gee gives up and uses the basename of the worktree directory
as the branchname, which is almost always correct, but we prefer to use the
.git metadata as our ground truth whenever possible.

Tested: I put a branch into a rebase-in-progress state.  I observed the
failure.  Implemented workaround.  Ran `gee gcd` again for a variety of
directories and got the correct behavior.

