### PR TITLE
codegen: switch to libyaml parser

### DIFF
--- a/tools/codegen/BUILD.bazel
+++ b/tools/codegen/BUILD.bazel
@@ -30,6 +30,15 @@ py_test(
     ],
 )
 
+py_test(
+    name = "data_loader_benchmark",
+    srcs = ["data_loader_benchmark.py"],
+    deps = [
+        ":data_loader",
+    ],
+    tags = ["no-presubmit"],
+)
+
 py_binary(
     name = "codegen",
     srcs = ["codegen.py"],

--- a/tools/codegen/data_loader.py
+++ b/tools/codegen/data_loader.py
@@ -42,7 +42,7 @@ def _merge(a: MERGEABLE, b: MERGEABLE, path: str = None) -> MERGEABLE:
 
 
 # https://stackoverflow.com/questions/44904290/getting-duplicate-keys-in-yaml-using-python
-class _MergingLoader(yaml.loader.SafeLoader):
+class _MergingLoader(yaml.CSafeLoader):
     pass
 
 

--- a/tools/codegen/data_loader_benchmark.py
+++ b/tools/codegen/data_loader_benchmark.py
@@ -1,0 +1,50 @@
+"""Benchmark the data_loader block."""
+
+# standard libraries
+import textwrap
+import timeit
+import unittest
+import yaml
+
+# third party libraries
+from absl import app
+
+from tools.codegen import data_loader
+
+
+class BenchDataLoader(unittest.TestCase):
+    """A collection of regression tests for data_loader."""
+
+    def test_time_loader(self):
+        big_yaml = []
+        n = 6  # 15
+        for i0 in range(n):
+            big_yaml.append(f"foo{i0}:")
+            for i1 in range(n):
+                big_yaml.append(f"  bar{i1}:")
+                for i2 in range(n):
+                    big_yaml.append(f"    fum{i2}:")
+                    for i3 in range(n):
+                        big_yaml.append(f"      - foe{i3}")
+        big_text = "\n".join(big_yaml)
+        print(f"len(big_text)={len(big_text)}")
+        print(f"yaml version = {yaml.__version__}")
+        bm={}
+        def benchmark(name, fn):
+            bm[name] = timeit.timeit(fn, number=50)
+            print(f"{name}: {bm[name]}")
+        benchmark("yaml.Loader", lambda: yaml.load(big_text, Loader=yaml.Loader))
+        benchmark("yaml.SafeLoader", lambda: yaml.load(big_text, Loader=yaml.SafeLoader))
+        benchmark("yaml.CSafeLoader", lambda: yaml.load(big_text, Loader=yaml.CSafeLoader))
+        d = data_loader.DataLoader()
+        benchmark("data_loader", lambda: d.ParseYaml(big_text))
+
+
+
+def run_everything(_):
+    # unittest.main uses args differently than app.run.
+    unittest.main()
+
+
+if __name__ == "__main__":
+    app.run(run_everything)

--- a/tools/codegen/data_loader_benchmark.py
+++ b/tools/codegen/data_loader_benchmark.py
@@ -17,7 +17,7 @@ class BenchDataLoader(unittest.TestCase):
 
     def test_time_loader(self):
         big_yaml = []
-        n = 6  # 15
+        n = 7  # 15
         for i0 in range(n):
             big_yaml.append(f"foo{i0}:")
             for i1 in range(n):

--- a/tools/codegen/data_loader_test.py
+++ b/tools/codegen/data_loader_test.py
@@ -2,7 +2,9 @@
 
 # standard libraries
 import textwrap
+import timeit
 import unittest
+import yaml
 
 # third party libraries
 from absl import app
@@ -12,6 +14,31 @@ from tools.codegen import data_loader
 
 class TestDataLoader(unittest.TestCase):
     """A collection of regression tests for data_loader."""
+
+    def test_time_loader(self):
+        big_yaml = []
+        n = 6  # 15
+        for i0 in range(n):
+            big_yaml.append(f"foo{i0}:")
+            for i1 in range(n):
+                big_yaml.append(f"  bar{i1}:")
+                for i2 in range(n):
+                    big_yaml.append(f"    fum{i2}:")
+                    for i3 in range(n):
+                        big_yaml.append(f"      - foe{i3}")
+        big_text = "\n".join(big_yaml)
+        print(f"len(big_text)={len(big_text)}")
+        print(f"yaml version = {yaml.__version__}")
+        bm={}
+        def benchmark(name, fn):
+            bm[name] = timeit.timeit(fn, number=50)
+            print(f"{name}: {bm[name]}")
+        benchmark("yaml.Loader", lambda: yaml.load(big_text, Loader=yaml.Loader))
+        benchmark("yaml.SafeLoader", lambda: yaml.load(big_text, Loader=yaml.SafeLoader))
+        benchmark("yaml.CSafeLoader", lambda: yaml.load(big_text, Loader=yaml.CSafeLoader))
+        d = data_loader.DataLoader()
+        benchmark("data_loader", lambda: d.ParseYaml(big_text))
+        self.assertAlmostEqual(bm["data_loader"], bm["yaml.CSafeLoader"], delta=0.1)
 
     def test_parse_yaml(self):
         d = data_loader.DataLoader()

--- a/tools/codegen/data_loader_test.py
+++ b/tools/codegen/data_loader_test.py
@@ -2,7 +2,6 @@
 
 # standard libraries
 import textwrap
-import timeit
 import unittest
 import yaml
 
@@ -14,30 +13,6 @@ from tools.codegen import data_loader
 
 class TestDataLoader(unittest.TestCase):
     """A collection of regression tests for data_loader."""
-
-    def test_time_loader(self):
-        big_yaml = []
-        n = 6  # 15
-        for i0 in range(n):
-            big_yaml.append(f"foo{i0}:")
-            for i1 in range(n):
-                big_yaml.append(f"  bar{i1}:")
-                for i2 in range(n):
-                    big_yaml.append(f"    fum{i2}:")
-                    for i3 in range(n):
-                        big_yaml.append(f"      - foe{i3}")
-        big_text = "\n".join(big_yaml)
-        print(f"len(big_text)={len(big_text)}")
-        print(f"yaml version = {yaml.__version__}")
-        bm={}
-        def benchmark(name, fn):
-            bm[name] = timeit.timeit(fn, number=50)
-            print(f"{name}: {bm[name]}")
-        benchmark("yaml.Loader", lambda: yaml.load(big_text, Loader=yaml.Loader))
-        benchmark("yaml.SafeLoader", lambda: yaml.load(big_text, Loader=yaml.SafeLoader))
-        benchmark("yaml.CSafeLoader", lambda: yaml.load(big_text, Loader=yaml.CSafeLoader))
-        d = data_loader.DataLoader()
-        benchmark("data_loader", lambda: d.ParseYaml(big_text))
 
     def test_parse_yaml(self):
         d = data_loader.DataLoader()

--- a/tools/codegen/data_loader_test.py
+++ b/tools/codegen/data_loader_test.py
@@ -38,7 +38,6 @@ class TestDataLoader(unittest.TestCase):
         benchmark("yaml.CSafeLoader", lambda: yaml.load(big_text, Loader=yaml.CSafeLoader))
         d = data_loader.DataLoader()
         benchmark("data_loader", lambda: d.ParseYaml(big_text))
-        self.assertAlmostEqual(bm["data_loader"], bm["yaml.CSafeLoader"], delta=0.1)
 
     def test_parse_yaml(self):
         d = data_loader.DataLoader()


### PR DESCRIPTION
A user was complaining that parsing a particular YAML file (`mrng_map.elab.yaml`, 18MB)
was taking minutes of build time, so I decided to look into it.  It turns out that
if I switch from using the native python yaml parser to the compiled libyaml library,
I get a 15x performance improvement with no apparent downside.

I added a benchmark for loading a medium-sized yaml file:

```
len(big_text)=19331
yaml version = 6.0
yaml.Loader: 4.944591138999385
yaml.SafeLoader: 4.906097150000278
yaml.CSafeLoader: 0.35437141400143446
data_loader: 0.39925295200009714
```

"data_loader" is the slightly customized version of yaml.CSafeLoader that codegen
now employs.

Tested: Re-ran all //tools/codegen/... tests.  I also added a small benchmark
to data_loader_test.py.

