### PR TITLE
bazel/linux: print qemu_test output to stdout

### DIFF
--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -34,7 +34,11 @@ run_test() {
     printf "%-73s" "${title}"
     start_time_ns=$(($(date +%s%N)))
 
-    output=$("${script}" "${args[@]}" 2>&1) && failed=0
+    # Print stdout and stderr to the terminal and capture it into a variable.
+    # That way, bazel run shows the output in real time and bazel test can show
+    # the output of only the failed commands at the end of the test.
+    exec 5>&1
+    output=$("${script}" "${args[@]}" 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]}) && failed=0
 
     tests=$[tests + 1]
     if [ $failed -eq 0 ]; then


### PR DESCRIPTION
The output of commands executed by qemu_test is captured to a variable
and printed if the command fails. This behavior works fine with bazel
test which hides output by default. When the user executes a qemu_test
with bazel run, the expectation is to see the output in real time.

Signed-off-by: George Prekas <george@enfabrica.net>