### PR TITLE
bazel affected-targets: Fix target name bug

### DIFF
--- a/lib/bazel/query.go
+++ b/lib/bazel/query.go
@@ -117,10 +117,11 @@ func (r *QueryResult) addChecksumsAttributeToExternals() error {
 		// corresponds to the checksum(s) used when downloading the repo in which it
 		// resides. Therefore, this target's hash will change iff one or more
 		// downloads for its repo has a checksum change.
+		nameCopy := targetName
 		*target.Target = bpb.Target{
 			Type: bpb.Target_RULE.Enum(),
 			Rule: &bpb.Rule{
-				Name:      &targetName,
+				Name:      &nameCopy,
 				RuleInput: deps,
 				Attribute: []*bpb.Attribute{
 					&bpb.Attribute{


### PR DESCRIPTION
The external-target-attribute-rewrite logic has a bug where it captures
a loop variable by reference, causing targets to get renamed with the
incorrect name. This change makes a copy of the loop variable and
assigns a reference to the copy instead, so that it is not mutated as
the loop continues.

This fixes an issue where affected-targets will return extra targets that
aren't actually changed between the two revisions.

Tested: `bazel affected-targets list --loglevel-console=info --start=4b551678e --end=swc_copy`
with this change doesn't yield erroneous targets, whereas it used to
roughly ~20% of the time.

Jira: INFRA-1548