### PR TITLE
enkit agent print: don't rely on SSH_AGENT_PID

### DIFF
--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -84,6 +84,9 @@ type SSHAgent struct {
 }
 
 func (a SSHAgent) Kill() error {
+  if a.PID == 0 {
+    return nil
+  }
 	p, err := os.FindProcess(a.PID)
 	if err != nil {
 		return err
@@ -190,15 +193,22 @@ func FindSSHAgent(store cache.Store, logger logger.Logger) (*SSHAgent, error) {
 
 // FindSSHAgentFromEnv
 func FindSSHAgentFromEnv() *SSHAgent {
+  // If the SSH agent was started locally, both SSH_AGENT_SOCK and
+  // SSH_AGENT_PID will be set.  However, when using ssh-agent forwarding over
+  // an SSH or CRD session, only SSH_AUTH_SOCK will be set.
 	envSSHSock := os.Getenv("SSH_AUTH_SOCK")
 	envSSHPID := os.Getenv("SSH_AGENT_PID")
-	if envSSHSock == "" || envSSHPID == "" {
+	if envSSHSock == "" {
 		return nil
 	}
-	pid, err := strconv.Atoi(envSSHPID)
-	if err != nil {
-		return nil
-	}
+  pid := 0
+  if envSSHPID != "" {
+    var err error
+    pid, err = strconv.Atoi(envSSHPID)
+    if err != nil {
+      return nil
+    }
+  }
 	return &SSHAgent{PID: pid, Socket: envSSHSock, Close: func() {}}
 }
 

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -166,7 +166,11 @@ func (a SSHAgent) AddCertificates(privateKey PrivateKey, publicKey ssh.PublicKey
 }
 
 func (a SSHAgent) GetEnv() []string {
-	return []string{fmt.Sprintf("SSH_AUTH_SOCK=%s", a.Socket), fmt.Sprintf("SSH_AGENT_PID=%d", a.PID)}
+  env := []string{fmt.Sprintf("SSH_AUTH_SOCK=%s", a.Socket)}
+  if a.PID != 0 {
+    env = append(env, fmt.Sprintf("SSH_AGENT_PID=%d", a.PID))
+  }
+  return env
 }
 
 // FindSSHAgent Will start the ssh agent in the interactive terminal if it isn't present already as an environment variable

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -84,9 +84,9 @@ type SSHAgent struct {
 }
 
 func (a SSHAgent) Kill() error {
-  if a.PID == 0 {
-    return nil
-  }
+	if a.PID == 0 {
+		return nil
+	}
 	p, err := os.FindProcess(a.PID)
 	if err != nil {
 		return err
@@ -166,11 +166,11 @@ func (a SSHAgent) AddCertificates(privateKey PrivateKey, publicKey ssh.PublicKey
 }
 
 func (a SSHAgent) GetEnv() []string {
-  env := []string{fmt.Sprintf("SSH_AUTH_SOCK=%s", a.Socket)}
-  if a.PID != 0 {
-    env = append(env, fmt.Sprintf("SSH_AGENT_PID=%d", a.PID))
-  }
-  return env
+	env := []string{fmt.Sprintf("SSH_AUTH_SOCK=%s", a.Socket)}
+	if a.PID != 0 {
+		env = append(env, fmt.Sprintf("SSH_AGENT_PID=%d", a.PID))
+	}
+	return env
 }
 
 // FindSSHAgent Will start the ssh agent in the interactive terminal if it isn't present already as an environment variable
@@ -197,22 +197,22 @@ func FindSSHAgent(store cache.Store, logger logger.Logger) (*SSHAgent, error) {
 
 // FindSSHAgentFromEnv
 func FindSSHAgentFromEnv() *SSHAgent {
-  // If the SSH agent was started locally, both SSH_AGENT_SOCK and
-  // SSH_AGENT_PID will be set.  However, when using ssh-agent forwarding over
-  // an SSH or CRD session, only SSH_AUTH_SOCK will be set.
+	// If the SSH agent was started locally, both SSH_AGENT_SOCK and
+	// SSH_AGENT_PID will be set.  However, when using ssh-agent forwarding over
+	// an SSH or CRD session, only SSH_AUTH_SOCK will be set.
 	envSSHSock := os.Getenv("SSH_AUTH_SOCK")
 	envSSHPID := os.Getenv("SSH_AGENT_PID")
 	if envSSHSock == "" {
 		return nil
 	}
-  pid := 0
-  if envSSHPID != "" {
-    var err error
-    pid, err = strconv.Atoi(envSSHPID)
-    if err != nil {
-      return nil
-    }
-  }
+	pid := 0
+	if envSSHPID != "" {
+		var err error
+		pid, err = strconv.Atoi(envSSHPID)
+		if err != nil {
+			return nil
+		}
+	}
 	return &SSHAgent{PID: pid, Socket: envSSHSock, Close: func() {}}
 }
 

--- a/proxy/ptunnel/commands/agent.go
+++ b/proxy/ptunnel/commands/agent.go
@@ -103,7 +103,10 @@ func NewPrintCommand(parent *cobra.Command, bf *client.BaseFlags) *cobra.Command
 				return err
 			}
 			defer agent.Close()
-			fmt.Printf(PrintSSHTemplate, agent.Socket, agent.PID, agent.PID)
+      fmt.Printf("SSH_AUTH_SOCK=%s; export SSH_AUTH_SOCK;\n", agent.Socket)
+      if agent.PID != 0 {
+        fmt.Printf("SSH_AGENT_PID=%d; export SSH_AGENT_PID;\necho Agent pid %d;\n", agent.PID, agent.PID)
+      }
 			return nil
 		},
 	}

--- a/proxy/ptunnel/commands/agent.go
+++ b/proxy/ptunnel/commands/agent.go
@@ -103,10 +103,10 @@ func NewPrintCommand(parent *cobra.Command, bf *client.BaseFlags) *cobra.Command
 				return err
 			}
 			defer agent.Close()
-      fmt.Printf("SSH_AUTH_SOCK=%s; export SSH_AUTH_SOCK;\n", agent.Socket)
-      if agent.PID != 0 {
-        fmt.Printf("SSH_AGENT_PID=%d; export SSH_AGENT_PID;\necho Agent pid %d;\n", agent.PID, agent.PID)
-      }
+			fmt.Printf("SSH_AUTH_SOCK=%s; export SSH_AUTH_SOCK;\n", agent.Socket)
+			if agent.PID != 0 {
+				fmt.Printf("SSH_AGENT_PID=%d; export SSH_AGENT_PID;\necho Agent pid %d;\n", agent.PID, agent.PID)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
When forwarding access to ssh-agent using ssh, `SSH_AUTH_SOCK` gets configured
but `SSH_AGENT_PID` does not.  `enkit agent print` was checking for both
environment variables to be set, otherwise it would start a new agent.

This PR causes enkit to only check `SSH_AUTH_SOCK`, and if that variable
is set and the agent can be connected to, that agent gets used.

Tested: tests build and pass.

Manual testing:

```
$ $BROOT/bazel-bin/enkit/enkit_/enkit agent print
SSH_AUTH_SOCK=/tmp/ssh-jonathan/agent; export SSH_AUTH_SOCK;
SSH_AGENT_PID=123; export SSH_AGENT_PID;
echo Agent pid 123;

$ unset SSH_AGENT_PID
(enk:enkit_agent* S=2) [565] ~/gee/enkit/enkit_agent

$ $BROOT/bazel-bin/enkit/enkit_/enkit agent print
SSH_AUTH_SOCK=/tmp/ssh-jonathan/agent; export SSH_AUTH_SOCK;
```

