### PR TITLE
bestie: Handle errors in test xml

### DIFF
--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -49,6 +49,7 @@ type TestCase struct {
 	Time       string     `xml:"time,attr"`
 	Properties Properties `xml:"properties"`
 	Failure    FailureMsg `xml:"failure"`
+	Error      ErrorMsg   `xml:"error"`
 	Skipped    SkippedMsg `xml:"skipped"`
 }
 
@@ -65,6 +66,11 @@ type Property struct {
 
 type FailureMsg struct {
 	XMLName xml.Name `xml:"failure"`
+	Message string   `xml:"message,attr"`
+}
+
+type ErrorMsg struct {
+	XMLName xml.Name `xml:"error"`
 	Message string   `xml:"message,attr"`
 }
 
@@ -220,6 +226,8 @@ func parseStructuredXml(ts *TestSuite) ([]*xmlResult, error) {
 			xr.result = "fail"
 		} else if len(tc.Skipped.Message) > 0 {
 			xr.result = "skip"
+		} else if len(tc.Error.Message) > 0 {
+			xr.result = "error"
 		} else {
 			xr.result = "pass"
 		}

--- a/bestie/server/xml_result.go
+++ b/bestie/server/xml_result.go
@@ -221,7 +221,7 @@ func parseStructuredXml(ts *TestSuite) ([]*xmlResult, error) {
 		// Use the testcase time attribute as its duration.
 		xr.duration = tc.Time
 		// Derive the metric result string
-		// Note: The absence of a 'failure' or 'skipped' section means the test passed.
+		// Note: The absence of a 'failure', 'skipped', or 'error' section means the test passed.
 		if len(tc.Failure.Message) > 0 {
 			xr.result = "fail"
 		} else if len(tc.Skipped.Message) > 0 {


### PR DESCRIPTION
* Updates bestie to handle `<error message="some error message">`
* Fixes issue where testcases that did not pass due to setup error were counted as passing
* Prior to this change, if a test case raised error in a setUp() class, the resultant test xml would have >0 error count, but since the error properties weren't handled they were being treated as passes.