### PR TITLE
bazel/linux: force colored GCC output when building modules

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -106,6 +106,9 @@ def _kernel_modules(ctx):
                 compilation_mode = compilation_mode,
             ))
 
+        # Force GCC to produce colored output
+        cflags += " -fdiagnostics-color=always"
+
         extra.append("EXTRA_CFLAGS='%s'" % cflags)
 
         ctx.actions.run_shell(


### PR DESCRIPTION
Signed-off-by: George Prekas <george@enfabrica.net>