### PR TITLE
gee gcd: redirect savelog output to stderr

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -266,7 +266,7 @@ function _rotate_gee_log() {
     local size
     size="$(stat -c%s "${GEE_LOG_FILE}")"
     if (( size > 65536 )); then
-      savelog -n -c 9 -C -p "${GEE_LOG_FILE}" || /bin/true
+      savelog -n -c 9 -C -p "${GEE_LOG_FILE}" 1>&2 || /bin/true
     fi
   fi
   if [[ ! -f "${GEE_LOG_FILE}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.33"
+readonly VERSION="0.2.34"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,13 @@
 
 ## Releases
 
+### 0.2.34
+
+* `gee gcd`: fix bug where savelog output would break gcd (#728)
+* `gee lsbr`: fix bug where upstream branches would break lsbr (#710)
+* `gee restore_all_branches`: interactively pick which branches to restore (#682)
+* `gee init`: improve `gh auth login` flow, use right options instead of asking (#676)
+
 ### 0.2.33
 
 * `gee update`: improve merge conflict resolution flow (#715)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.33
+gee version: 0.2.34
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
Just a quick bugfix: gee periodically invokes `savelog` to rotate it's log
file.  `savelog` sometimes writes to stdout, which then interferes with
the `gee gcd` command, which requires that the only thing written to
stdout is supposed to be the generated path.

This PR quick-fixes the behavior so that savelog triggering a log rotation
won't interfere with the functioning of gcd.

Tested: inflated ~/gee.log to be larger than 64K, forcing a log rotation
on the next gee invocation, and then ran `gee gcd master > /tmp/foo.txt`
to capture the stdout of gee under those conditions.  Confirmed that
savelog output no longer pollutes our results.

