### PR TITLE
enproxy: Allow forwarding of user info via headers

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"strings"
 )
@@ -180,4 +181,16 @@ func IndentAndQuoteLines(buffer, indent string) string {
 		}
 	}
 	return string(result)
+}
+
+func SetCtx(ctx context.Context, l Logger) context.Context {
+	return context.WithValue(ctx, "logger", l)
+} 
+
+func GetCtx(ctx context.Context) Logger {
+	l, ok := ctx.Value("logger").(Logger)
+	if !ok {
+		return Nil
+	}
+	return l
 }

--- a/tools/codegen/BUILD.bazel
+++ b/tools/codegen/BUILD.bazel
@@ -33,10 +33,10 @@ py_test(
 py_test(
     name = "data_loader_benchmark",
     srcs = ["data_loader_benchmark.py"],
+    tags = ["no-presubmit"],
     deps = [
         ":data_loader",
     ],
-    tags = ["no-presubmit"],
 )
 
 py_binary(


### PR DESCRIPTION
This change adds transform options to enproxy mappings to tell enproxy
to optionally add some headers on forwarded requests that signal the
authenticated user's identity to the backend.

Each value of the `Identity` object associated with the user is exposed
in its own header, and then an email-like string is exposed as well.

This is inspired by Grafana, which has a special ["Auth Proxy"](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/auth-proxy/)
authentication mode, whereby it will respect the values of particular
headers as a pre-authenticated user.

Since these header values are configurable within Grafana, there is no
need to stick to their default-selected `X-WEBAUTH-USER`; we can choose
our own names and configure Grafana appropriately. This PR selects names
that map more closely to the underlying field from which it is
populated, in an attempt to minimize confusion caused by additional
renames.

This will also be useful in setting up API authentication in Airflow,
which allows us to inject some Python code as a [custom auth backend](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/auth-proxy/).
Writing code that examines these headers and matches them to current
users should be trivial by following [existing examples](https://sourcegraph.com/github.com/apache/airflow@8070a781b6292ce0795ceed6f36217dd61023dad/-/blob/airflow/providers/google/common/auth_backend/google_openid.py?L110)

Tested: no