### PR TITLE
gee: fix enkit auth invocation

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -444,7 +444,7 @@ function _check_enkit_cert() {
   if (( COUNT == 0 )); then
     _warn "enkit certificate is expired."
     _info "Please authenticate:"
-    "${ENKIT}" login
+    "${ENKIT}" login "${USER}@enfabrica.net"
     COUNT="$("${ENKIT}" agent print | wc -l)"
     if (( COUNT == 0 )); then
       _fatal "No enkit certificate, aborting."
@@ -752,7 +752,7 @@ function _ssh_enroll() {
   if (( COUNT == 0 )); then
     _warn "No enkit certificates are present."
     _info "Let's try authenticating:"
-    "${ENKIT}" auth
+    "${ENKIT}" auth "${USER}@enfabrica.net"
     COUNT="$("${ENKIT}" agent list | wc -l)"
     if (( COUNT == 0 )); then
       _die "Still could not find any enkit certificates."
@@ -764,7 +764,7 @@ function _ssh_enroll() {
   if (( COUNT == 0 )); then
     _warn "No enkit certificates are present."
     _info "Let's try authenticating:"
-    "${ENKIT}" auth
+    "${ENKIT}" auth "${USER}@enfabrica.net"
     COUNT="$("${ENKIT}" agent list | wc -l)"
     if (( COUNT == 0 )); then
       _die "Still could not find any enkit certificates."

--- a/scripts/gee
+++ b/scripts/gee
@@ -444,7 +444,7 @@ function _check_enkit_cert() {
   if (( COUNT == 0 )); then
     _warn "enkit certificate is expired."
     _info "Please authenticate:"
-    "${ENKIT}" login "${USER}@enfabrica.net"
+    "${ENKIT}" auth "${USER}@enfabrica.net"
     COUNT="$("${ENKIT}" agent print | wc -l)"
     if (( COUNT == 0 )); then
       _fatal "No enkit certificate, aborting."

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -4,6 +4,7 @@
 
 ### 0.2.34
 
+* `gee`: always specify full email address when authenticating to gh (#731)
 * `gee init`: use the new gh auth flow more consistently (#732)
 * `gee`: do our best regardless of which directory gee is invoked from (#699)
 * `gee gcd`: fix bug where savelog output would break gcd (#728)


### PR DESCRIPTION
While it appears that `enkit auth` is capable of inferring the username
to use during authentication, it turns out that it just caches this
information after the user does it for the first time.  We want gee
to work correctly on a completely clean install, and so the safest
option is to always specify the full `enkit auth $USER@enfabrica.net`
commandline.

Tested: rm ~/.config/enkit/* and then run `gee init`

