### PR TITLE
gee init: make sure we use the new gh auth flow

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -692,7 +692,7 @@ function _gh_authenticate() {
   local TRIES="${1:-3}"
 
   while ! _gh auth status; do
-    if [[ "$TRIES" == 0 ]]; then
+    if [[ "$TRIES" -eq 0 ]]; then
       _warn "Failed to authenticate to github.  Ask an administrator for help?"
       return
     fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -532,9 +532,7 @@ function _check_gh_auth() {
   RC=$?
   set -e
   if (( RC != 0 )); then
-    _info "Could not authenticate to github.  Got:" "${OUTPUT}"
-    _info "Let's try refreshing your access token:"
-    _cmd "${GH}" auth login
+    _gh_authenticate
     if ! "${GH}" auth status; then
       _fatal "Still can't authenticate to github."
     fi
@@ -690,6 +688,41 @@ function _startup_checks() {
   fi
 }
 
+function _gh_authenticate() {
+  local TRIES="${1:-3}"
+
+  while ! _gh auth status; do
+    if [[ "$TRIES" == 0 ]]; then
+      _warn "Failed to authenticate to github.  Ask an administrator for help?"
+      return
+    fi
+    _info \
+      "You are not currently authenticated to github.  We need to create a github" \
+      "authentication token for you before we can proceed." \
+      "" \
+      "To create a github authentication token:" \
+      "" \
+      "1. Open in a web browser: https://github.com/settings/tokens/new" \
+      "2. Log in to github, if you aren't already." \
+      "3. Fill in the \"Note\" field with something descriptive." \
+      "4. Select a reasonable Expiration duration (90 days is recommended)." \
+      "5. Click to enable the following permissions:" \
+      "   * \"repo\" (enables the whole sub-tree of permissions)" \
+      "   * \"read:org\" (below the \"admin:org\" permission tree)" \
+      "   * \"admin:public_key\" (enables the whole sub-tree of permissions)" \
+      "6. Finally, click \"Generate token\" at the bottom of the form." \
+      ""
+    local TOKEN=""
+    read -rp "Paste your github authentication token here: " TOKEN
+    _info "Trying to authenticate using your token..."
+    if ! _gh auth login -p ssh -h github.com --with-token <<< "${TOKEN}"; then
+      _warn "\"gh auth login\" failed with exit code $?" ""
+      echo ""
+    fi
+    TRIES="$(( TRIES - 1 ))"
+  done
+}
+
 function _ssh_enroll() {
   # Enroll the user for ssh access to github by creating and uploading a keyfile.
   if [[ -z "${SSH_AUTH_SOCK}" ]]; then
@@ -753,30 +786,7 @@ EOT
   _gh config set git_protocol ssh
 
   _info "Checking your access to github using the \"gh\" tool:"
-  while ! _gh auth status; do
-    _info \
-      "You are not currently authenticated to github.  We need to create a github" \
-      "authentication token for you before we can proceed." \
-      "" \
-      "To create a github authentication token:" \
-      "" \
-      "1. Open in a web browser: https://github.com/settings/tokens/new" \
-      "2. Log in to github, if you aren't already." \
-      "3. Fill in the \"Note\" field with something descriptive." \
-      "4. Select a reasonable Expiration duration (90 days is recommended)." \
-      "5. Click to enable the following permissions:" \
-      "   * \"repo\" (enables the whole sub-tree of permissions)" \
-      "   * \"read:org\" (below the \"admin:org\" permission tree)" \
-      "   * \"admin:public_key\" (enables the whole sub-tree of permissions)" \
-      "6. Finally, click \"Generate token\" at the bottom of the form." \
-      ""
-    local TOKEN=""
-    read -rp "Paste your github authentication token here: " TOKEN
-    _info "Trying to authenticate using your token..."
-    if ! _gh auth login -p ssh -h github.com --with-token <<< "${TOKEN}"; then
-      _warn "\"gh auth login\" failed with exit code $?" ""
-    fi
-  done
+  _gh_authenticate
 
   if ! _gh ssh-key add "${SSHKEYFILE}.pub" --title "gee-created-key"; then
     _warn "Could not add your key to github (maybe it's already there?)."
@@ -4481,16 +4491,7 @@ function gee__repair() {
   # check that we can connect to github via ssh
   _check_ssh
 
-  if ! _gh auth status; then
-    _warn "Looks like you were not able to authenticate to the github REST API."
-    _info "Let's try re-authenticating to github:"
-    _gh auth login
-
-    if ! _gh auth status; then
-      _warn "Still can't authenticate to github!  You might need more help."
-      # Gallantly attempt to carry on in the face of adversity...
-    fi
-  fi
+  _gh_authenticate
 
   if ! _in_gee_repo; then
     _fatal "Not in a gee repo directory, aborting further repairs."

--- a/scripts/gee
+++ b/scripts/gee
@@ -689,12 +689,11 @@ function _startup_checks() {
 }
 
 function _gh_authenticate() {
-  local TRIES="${1:-3}"
+  local TRIES=3
 
   while ! _gh auth status; do
     if [[ "$TRIES" -eq 0 ]]; then
-      _warn "Failed to authenticate to github.  Ask an administrator for help?"
-      return
+      _fatal "Failed to authenticate to github.  Join \"git help\" chatroom and ask for help?"
     fi
     _info \
       "You are not currently authenticated to github.  We need to create a github" \

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -4,6 +4,7 @@
 
 ### 0.2.34
 
+* `gee init`: use the new gh auth flow more consistently (#732)
 * `gee`: do our best regardless of which directory gee is invoked from (#699)
 * `gee gcd`: fix bug where savelog output would break gcd (#728)
 * `gee lsbr`: fix bug where upstream branches would break lsbr (#710)


### PR DESCRIPTION
On a clean VM, I ran "gee init" and didn't get quite the right gh auth flow:

```
$ REPO=enkit gee init
...
CMD: /usr/bin/gh config set git_protocol ssh
Could not authenticate to github.  Got:
You are not logged into any GitHub hosts. Run gh auth login to authenticate.
Let's try refreshing your access token:
CMD: /usr/bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations?  [Use arrows to move, type to filter]
> HTTPS
  SSH

```

whoops!  we want to avoid that prompt because if the user picks the wrong
options, it's confusing and tough to fix.

I modified gee to make sure our new gh authentication flow gets used
consistently, regardless of where in the code we're attempting to authenticate
to github.

Now I see:

```
$ REPO=enkit /home/jonathan/bin/gee.new init
...
CMD: /usr/bin/gh config set git_protocol ssh
CMD: /usr/bin/gh auth status
You are not logged into any GitHub hosts. Run gh auth login to authenticate.
WARNING: Command failed with exit code 1
You are not currently authenticated to github.  We need to create a github
authentication token for you before we can proceed.

To create a github authentication token:

1. Open in a web browser: https://github.com/settings/tokens/new
2. Log in to github, if you aren't already.
3. Fill in the "Note" field with something descriptive.
4. Select a reasonable Expiration duration (90 days is recommended).
5. Click to enable the following permissions:
   * "repo" (enables the whole sub-tree of permissions)
   * "read:org" (below the "admin:org" permission tree)
   * "admin:public_key" (enables the whole sub-tree of permissions)
6. Finally, click "Generate token" at the bottom of the form.

Paste your github authentication token here: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
Trying to authenticate using your token...
CMD: /usr/bin/gh auth login -p ssh -h github.com --with-token
CMD: /usr/bin/gh auth status
github.com
  ✓ Logged in to github.com as jonathan-enf (oauth_token)
  ✓ Git operations for github.com configured to use ssh protocol.
  ✓ Token: *******************

github.com
  ✓ Logged in to github.com as jonathan-enf (oauth_token)
  ✓ Git operations for github.com configured to use ssh protocol.
  ✓ Token: *******************

Initializing /home/jonathan/gee/enkit/ for enkit/main
```

Woot!

Tested: ran `gee init` on a clean VM

