### PR TITLE
Update flextape hash

### DIFF
--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:a3af8d3ddf84d666a064eb4826d2aa8bb8dba42c9ddc1734192a0c8523f64ad4"
+  "gcr.io/devops-284019/infra/flextape@sha256:f2de37b84cfdb699442ac4f1013a4400bd0f8a01be2d0b9fd28904cb7a125377"


### PR DESCRIPTION
Update the default flextape hash to point to the latest release.

Testing:
- Deployed on infra-04.sea

JIRA: INFRA-1500