### PR TITLE
# The first line should be the PR title.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3555,8 +3555,9 @@ function gee__pr_make() {
   local -a PARENT_PRS
   mapfile -t PARENT_PRS < <( _list_open_pr_numbers "$(_get_parent_branch)" )
 
-  local BODYFILE
+  local BODYFILE TRIMMED
   BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
+  TRIMMED="${BODYFILE}.trimmed"
   (
     cat <<'EndOfPrTemplate'
 # The first line should be the PR title.
@@ -3588,30 +3589,38 @@ EndOfPrTemplate
     #                 PR description.
   ) >"${BODYFILE}"
 
-  if [[ -n "${EDITOR}" ]]; then
-    "${EDITOR}" "${BODYFILE}"
-  else
-    declare -g RESP=""
-    _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
-        "vVeEaA" "v"
-    case "${RESP}" in
-      [vV]*) vim "${BODYFILE}"; ;;
-      [eE]*) emacs "${BODYFILE}"; ;;
-      [aA]*) _fatal "Aborted."; ;;
-    esac
-  fi
+  DONE=0
+  while (( DONE == 0 )); do
+    if [[ -n "${EDITOR}" ]]; then
+      "${EDITOR}" "${BODYFILE}"
+    else
+      declare -g RESP=""
+      _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
+          "vVeEaA" "v"
+      case "${RESP}" in
+        [vV]*) vim "${BODYFILE}"; ;;
+        [eE]*) emacs "${BODYFILE}"; ;;
+        [aA]*) _fatal "Aborted."; ;;
+      esac
+    fi
 
-  # Remove all comments from the description and squeeze multiple blank
-  # lines into single blank lines:
-  sed -i 's/^ *#.*//;/\S/,/^\s*$/!d' "${BODYFILE}"
+    # Remove all comments from the description and squeeze multiple blank
+    # lines into single blank lines:
+    sed 's/^ *#.*//;/\S/,/^\s*$/!d' "${BODYFILE}" > "${TRIMMED}"
 
-  if grep --quiet -E "^\s*ABORT" "${BODYFILE}"; then
-    _fatal "Aborting creation of new PR, as requested."
-    exit 1
-  fi
+    if grep --quiet -E "^\s*ABORT" "${TRIMMED}"; then
+      _fatal "Aborting creation of new PR, as requested."
+      exit 1
+    fi
 
-  # Check that the PR description looks valid
-  _check_pr_description "${BODYFILE}"
+    # Check that the PR description looks valid
+    if _check_pr_description "${TRIMMED}"; then
+      DONE=1
+    else
+      _info "Please fix your PR description."
+      sleep 1
+    fi
+  done
 
   # Parse metadata from PR description.
   local TITLE


### PR DESCRIPTION
# For example: "scripts/gee: Add new PR template."
gee: allow user to re-edit if their PR description has errors

gee has some checks to make sure a user's PR description is well-formed.
In particular, it expects a title line, a blank line, and then the rest
of the description.  It used to error out if a PR description was bad.
The user could recover their PR description if they knew where in tmp
to look, but it's probably better if gee just tells the user whats
wrong and opens the editor again.

Tested:

Created a PR with the contents:

```
this is
a
bad
pr
description
```

Using the previous gee, this resulted in a terminating error.

Using this patched gee, I was able to edit the same file a second time.

# In this section, explain why the PR is necessary and what the PR desires to
# achieve.  List any relevant Jira tickets.

# In this section, describe what testing was done to validate your change.

# Having second thoughts?  Uncomment one of these two lines:
# DRAFT   # To mark this PR as a "draft"
# ABORT   # To abort the creation of a PR.


# The following files were modified in this PR:
# scripts/gee
#
# Here is your commit log:
# commit 331252003f1b18c9e68b3bfcad53a2a2e190ff22
# Author: Jonathan Mayer <jonathan@enfabrica.net>
# Date:   Thu Aug 11 09:23:11 2022 -0700
#
#     retry on bad pr description
