### PR TITLE
gee: let the user retry if their PR description is misformatted

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3555,8 +3555,9 @@ function gee__pr_make() {
   local -a PARENT_PRS
   mapfile -t PARENT_PRS < <( _list_open_pr_numbers "$(_get_parent_branch)" )
 
-  local BODYFILE
+  local BODYFILE TRIMMED
   BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
+  TRIMMED="${BODYFILE}.trimmed"
   (
     cat <<'EndOfPrTemplate'
 # The first line should be the PR title.
@@ -3588,30 +3589,38 @@ EndOfPrTemplate
     #                 PR description.
   ) >"${BODYFILE}"
 
-  if [[ -n "${EDITOR}" ]]; then
-    "${EDITOR}" "${BODYFILE}"
-  else
-    declare -g RESP=""
-    _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
-        "vVeEaA" "v"
-    case "${RESP}" in
-      [vV]*) vim "${BODYFILE}"; ;;
-      [eE]*) emacs "${BODYFILE}"; ;;
-      [aA]*) _fatal "Aborted."; ;;
-    esac
-  fi
+  DONE=0
+  while (( DONE == 0 )); do
+    if [[ -n "${EDITOR}" ]]; then
+      "${EDITOR}" "${BODYFILE}"
+    else
+      declare -g RESP=""
+      _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
+          "vVeEaA" "v"
+      case "${RESP}" in
+        [vV]*) vim "${BODYFILE}"; ;;
+        [eE]*) emacs "${BODYFILE}"; ;;
+        [aA]*) _fatal "Aborted."; ;;
+      esac
+    fi
 
-  # Remove all comments from the description and squeeze multiple blank
-  # lines into single blank lines:
-  sed -i 's/^ *#.*//;/\S/,/^\s*$/!d' "${BODYFILE}"
+    # Remove all comments from the description and squeeze multiple blank
+    # lines into single blank lines:
+    sed 's/^ *#.*//;/\S/,/^\s*$/!d' "${BODYFILE}" > "${TRIMMED}"
 
-  if grep --quiet -E "^\s*ABORT" "${BODYFILE}"; then
-    _fatal "Aborting creation of new PR, as requested."
-    exit 1
-  fi
+    if grep --quiet -E "^\s*ABORT" "${TRIMMED}"; then
+      _fatal "Aborting creation of new PR, as requested."
+      exit 1
+    fi
 
-  # Check that the PR description looks valid
-  _check_pr_description "${BODYFILE}"
+    # Check that the PR description looks valid
+    if _check_pr_description "${TRIMMED}"; then
+      DONE=1
+    else
+      _info "Please fix your PR description."
+      sleep 1
+    fi
+  done
 
   # Parse metadata from PR description.
   local TITLE

--- a/scripts/gee
+++ b/scripts/gee
@@ -3618,7 +3618,6 @@ EndOfPrTemplate
       DONE=1
     else
       _info "Please fix your PR description."
-      sleep 1
     fi
   done
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3617,7 +3617,11 @@ EndOfPrTemplate
     if _check_pr_description "${TRIMMED}"; then
       DONE=1
     else
-      _info "Please fix your PR description."
+      declare -g RESP=""
+      _choose_one "PR description needs a fix.  [R]e-edit or [a]bort?  " \ "rRaA" "r"
+      case "${RESP}" in
+        [aA]*) _fatal "Aborted."; ;;
+      esac
     fi
   done
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -1912,7 +1912,7 @@ function _check_pr_description() {
     return 1
   fi
   if [[ "${LINES[0]}" == "Tested:" ]]; then
-    # This will happen if the user saves the PR description template without saving.
+    # This will happen if the user saves the PR description template without editing
     _warn "\"Tested:\" can't be the title of the PR description." \
       "(Did you not make any edits to the PR description template?)"
     return 1

--- a/scripts/gee
+++ b/scripts/gee
@@ -1911,6 +1911,12 @@ function _check_pr_description() {
     _warn "The first line of the description must be the title."
     return 1
   fi
+  if [[ "${LINES[0]}" == "Tested:" ]]; then
+    # This will happen if the user saves the PR description template without saving.
+    _warn "\"Tested:\" can't be the title of the PR description." \
+      "(Did you not make any edits to the PR description template?)"
+    return 1
+  fi
   if [[ -n "${LINES[1]}" ]]; then
     _warn "The second line of the description must be blank."
     return 1
@@ -3613,7 +3619,6 @@ EndOfPrTemplate
       exit 1
     fi
 
-    # Check that the PR description looks valid
     if _check_pr_description "${TRIMMED}"; then
       DONE=1
     else

--- a/scripts/gee
+++ b/scripts/gee
@@ -1912,7 +1912,7 @@ function _check_pr_description() {
     return 1
   fi
   if [[ "${LINES[0]}" == "Tested:" ]]; then
-    # This will happen if the user saves the PR description template without editing
+    # This will happen if the user saves the PR description template without any edits.
     _warn "\"Tested:\" can't be the title of the PR description." \
       "(Did you not make any edits to the PR description template?)"
     return 1

--- a/scripts/gee
+++ b/scripts/gee
@@ -3624,10 +3624,10 @@ EndOfPrTemplate
 
   # Parse metadata from PR description.
   local TITLE
-  TITLE="$(head -1 "${BODYFILE}")"
+  TITLE="$(head -1 "${TRIMMED}")"
   # We remove the title from the body file to avoid "stuttering" the
   # title when we eventually submit the PR:
-  sed -i '1{d};2{/^$/d}' "${BODYFILE}"
+  sed -i '1{d};2{/^$/d}' "${TRIMMED}"
 
   _push_to_origin "${CURRENT_BRANCH}"
   # gh pr is arcane and confusing, but this works:
@@ -3640,11 +3640,11 @@ EndOfPrTemplate
     --repo "${UPSTREAM}/${REPO}"
     --title "${TITLE}"
     -H "${GHUSER}:${CURRENT_BRANCH}"
-    --body-file "${BODYFILE}"
+    --body-file "${TRIMMED}"
   )
 
   local DRAFT=0
-  if grep --quiet -E "^\s*DRAFT" "${BODYFILE}"; then
+  if grep --quiet -E "^\s*DRAFT" "${TRIMMED}"; then
     DRAFT=1
     PR_ARGS+=( --draft )
   fi
@@ -3669,7 +3669,7 @@ EndOfPrTemplate
       _warn "Don't forget to add reviewers!"
     fi
   fi
-  rm "${BODYFILE}"
+  rm "${BODYFILE}" "${TRIMMED}"
 }
 
 ##########################################################################


### PR DESCRIPTION
gee pr_make runs some basic checks on the PR description the user
provides, namely there must be at least a title line, a blank line,
and a description body.  Customer error report complained that if
an error was detected, gee would exit and the user would lose their
PR description.  This fix gives the user an opportunity to re-edit
their PR description until they get it right.

I also added a check to make sure we don't mistake an unedited
PR template for a valid PR description.

Tested:

Ran `gee pr_make` with a bad PR description consisting of:

```
this is a
bad pr
description
```

gee informed me of the error and prompted me to re-edit the file.
This PR is the updated description.

Behavior when failing to make edits to the PR template:

```
$ ./gee pr_make
CMD: /usr/bin/git fetch upstream
Current branch: gee_test1
Destination branch: upstream/master
Merge base: a5aa2703436a2abf43d0dd1ef5b64d0b6679cef3
no pull requests found for branch "jonathan-enf:gee_test1"
How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  v
WARNING: "Tested:" can't be the title of the PR description.
WARNING: (Did you not make any edits to the PR description template?)
PR description needs a fix.  [R]e-edit or [a]bort?  a
FATAL: Aborted.
```

