### PR TITLE
gee pr_checks: report which tests failed

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1158,7 +1158,7 @@ function _read_cmd() {
     RC="${!TMP}"  # indirect
     unset "${VAR}[-1]"
     if [[ "${RC}" -ne 0 ]]; then
-      _warn "Command returned non-zero exit code: ${RC}"
+      [[ $DONT_WARN -eq 0 ]] && _warn "Command returned non-zero exit code: ${RC}"
       if [[ -n "${NOFAIL}" ]]; then
         RC=0
       fi
@@ -3732,39 +3732,73 @@ Usage: gee pr_check
 Checks presubmit tests.
 EOT
 
+function _parse_gh_pr_checks() {
+  local -n CHECK_COUNTS_REF="$1"  # reference to an associative array
+  shift
+  local -n FAILED_BUILDS_REF="$1"  # reference to an array
+  shift
+  local -a LINES=( "$@" )
+  CHECK_COUNTS_REF=( [fail]=0 )
+  FAILED_BUILDS_REF=()
+
+  local LINE
+  local -a FIELDS=()
+  for LINE in "${LINES[@]}"; do
+    read -r -a FIELDS <<< "${LINE}"
+    (( CHECK_COUNTS_REF["${FIELDS[2]}"]++ )) || /bin/true
+    if [[ "${FIELDS[2]}" == "fail" ]]; then
+      if [[ "${FIELDS[4]}" =~ builds/([a-f0-9-]*)\?project ]]; then
+        FAILED_BUILDS_REF+=( "${BASH_REMATCH[1]}" )
+      else
+        _warn "Could not parse build number from URL: ${FIELDS[4]}"
+      fi
+    fi
+  done
+  return 0
+}
+
 function gee__check_pr() { gee__pr_check "$@"; }
 function gee__pr_checks() { gee__pr_check "$@"; }
 function gee__pr_check() {
   _startup_checks "pr_check"
 
+  # This command parses the output of "gh pr checks" and does something useful with it.  Example output:
+  #
+  #   $ gh pr checks | cat
+  #   internal-bazel-presubmit (cloud-build-290921)   fail    27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493
+  #   linter-checks (cloud-build-290921)      pass    30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493
+  #   Pushes-preview-version-of-web-pages (cloud-build-290921)        skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
+  #   external-dependencies (cloud-build-290921)      skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
+
+  local PREV_CHECKS=""
   local -a CHECKS=()
   local -A CHECK_COUNTS=()
+  local -a FAILED_BUILDS=()
   local PENDING=1
   local CHECKS_FAILED=0
   local WAIT=0
+  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" "${GH} pr checks"  # show user was we're doing
   while [[ "${PENDING}" -ne 0 ]]; do
-    if _read_cmd CHECKS "${GH}" pr checks; then
+    if VERBOSE=0 DONT_WARN=1 _read_cmd CHECKS "${GH}" pr checks; then
       _info "${CHECKS[@]}"
       # no failures, nothing pending.
       _info "All checks successful."
       CHECKS_FAILED=0
       PENDING=0
     else
-      _info "${CHECKS[@]}"
       # something went wrong.  Is a test pending, or did we get a failure?
-      CHECK_COUNTS=( [fail]=0 )
-      local LINE
-      for LINE in "${CHECKS[@]}"; do
-        local -a FIELDS=()
-        read -r -a FIELDS <<< "${LINE}"
-        (( CHECK_COUNTS["${FIELDS[2]}"]++ )) || /bin/true
-      done
-      local REPORT="gh pr checks:"
-      local KEY
-      for KEY in "${!CHECK_COUNTS[@]}"; do
-        REPORT+="$(printf " %s=%d" "${KEY}" "${CHECK_COUNTS["${KEY}"]}")"
-      done
-      _info "${REPORT}"
+      _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
+      # Only inform the user when a result changes:
+      if [[ "${PREV_CHECKS}" != "{CHECKS[*]}"  ]]; then
+        _info "${CHECKS[@]}"
+        PREV_CHECKS="${CHECKS[*]}"
+        local REPORT="gh pr checks:"
+        local KEY
+        for KEY in "${!CHECK_COUNTS[@]}"; do
+          REPORT+="$(printf " %s=%d" "${KEY}" "${CHECK_COUNTS["${KEY}"]}")"
+        done
+        _info "${REPORT}"
+      fi
       CHECKS_FAILED="${CHECK_COUNTS["fail"]}"
       PENDING="${CHECK_COUNTS["pending"]}"
       if [[ "${PENDING}" -ne 0 ]]; then
@@ -3787,6 +3821,13 @@ function gee__pr_check() {
   done
   if (( CHECKS_FAILED > 0 )); then
     _warn "Some presubmit checks have failed."
+    if command -v gcloud &> /dev/null; then
+      local BUILD
+      for BUILD in "${FAILED_BUILDS[@]}"; do
+        _warn "Failed build: ${BUILD}"
+        gcloud builds log "${BUILD}" | grep -i FAILED
+      done
+    fi
   fi
   return "${CHECKS_FAILED}"
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.34"
+readonly VERSION="0.2.35"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3785,7 +3785,7 @@ function gee__pr_check() {
   local PENDING=1
   local CHECKS_FAILED=0
   local WAIT=0
-  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" " ${GH} pr checks"  # show user was we're doing
+  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" " ${GH} pr checks"  # show user what we're doing
   while [[ "${PENDING}" -ne 0 ]]; do
     if VERBOSE=0 DONT_WARN=1 _read_cmd CHECKS "${GH}" pr checks; then
       printf "%s\n" "${CHECKS[@]}" | column -t >&2

--- a/scripts/gee
+++ b/scripts/gee
@@ -3733,6 +3733,22 @@ Checks presubmit tests.
 EOT
 
 function _parse_gh_pr_checks() {
+  # Usage: _parse_gh__pr_checks COUNTS BUILDS "${LINES[@]}"
+  # where:
+  #   COUNTS is the name of the associative array to populate with counts of each result type.
+  #   BUILDS is the name of the array to populate with the build identifiers of failed tests.
+  #   LINES is the output of `gh pr checks`, in array form.
+  #
+  # This function parses the output of "gh pr checks" and converts it to a more useful form.
+  #
+  # Example output of gh pr checks command:
+  #
+  #   $ gh pr checks | column -t
+  #   internal-bazel-presubmit             (cloud-build-290921)  fail      27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493
+  #   linter-checks                        (cloud-build-290921)  pass      30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493
+  #   Pushes-preview-version-of-web-pages  (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
+  #   external-dependencies                (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
+
   local -n CHECK_COUNTS_REF="$1"  # reference to an associative array
   shift
   local -n FAILED_BUILDS_REF="$1"  # reference to an array
@@ -3761,14 +3777,6 @@ function gee__check_pr() { gee__pr_check "$@"; }
 function gee__pr_checks() { gee__pr_check "$@"; }
 function gee__pr_check() {
   _startup_checks "pr_check"
-
-  # This command parses the output of "gh pr checks" and does something useful with it.  Example output:
-  #
-  #   $ gh pr checks | cat
-  #   internal-bazel-presubmit (cloud-build-290921)   fail    27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493
-  #   linter-checks (cloud-build-290921)      pass    30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493
-  #   Pushes-preview-version-of-web-pages (cloud-build-290921)        skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
-  #   external-dependencies (cloud-build-290921)      skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
 
   local PREV_CHECKS=""
   local -a CHECKS=()

--- a/scripts/gee
+++ b/scripts/gee
@@ -3777,10 +3777,10 @@ function gee__pr_check() {
   local PENDING=1
   local CHECKS_FAILED=0
   local WAIT=0
-  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" "${GH} pr checks"  # show user was we're doing
+  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" " ${GH} pr checks"  # show user was we're doing
   while [[ "${PENDING}" -ne 0 ]]; do
     if VERBOSE=0 DONT_WARN=1 _read_cmd CHECKS "${GH}" pr checks; then
-      _info "${CHECKS[@]}"
+      printf "%s\n" "${CHECKS[@]}" | column -t >&2
       # no failures, nothing pending.
       _info "All checks successful."
       CHECKS_FAILED=0
@@ -3790,7 +3790,7 @@ function gee__pr_check() {
       _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
       # Only inform the user when a result changes:
       if [[ "${PREV_CHECKS}" != "{CHECKS[*]}"  ]]; then
-        _info "${CHECKS[@]}"
+        printf "%s\n" "${CHECKS[@]}" | column -t >&2
         PREV_CHECKS="${CHECKS[*]}"
         local REPORT="gh pr checks:"
         local KEY

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,12 @@
 
 ## Releases
 
+### 0.2.35
+
+* `gee pr_checks`: report the specific failing test that caused a presubmit check to fail. (#739)
+* `gee config`: turn on rerere.enabled for all users. (#738)
+* `gee pr_rerun`: re-trigger PR presubmit tests. (#737)
+
 ### 0.2.34
 
 * `gee`: always specify full email address when authenticating to gh (#731)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.34
+gee version: 0.2.35
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful

--- a/scripts/gee_test.sh
+++ b/scripts/gee_test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#
+# TODO(jonathan): fix this test now that github-playground has been deleted.
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 GEE="${SCRIPT_DIR}/gee"
@@ -7,7 +9,7 @@ TIMESTAMP="$(date +%s)"
 # Clean test environment.
 cd
 rm -rf ~/testgee
-export TESTMODE=1
+export TESTMODE=1  # currently broken github-playground repo has been deleted.  :-()
 declare ERRORS=0
 declare CHECKS=0
 
@@ -56,7 +58,6 @@ function _expect_gee() {
   fi
 }
 
-
 _expect_gee init
 _expect_test -d ~/testgee
 _expect_test -d ~/testgee/.gee
@@ -79,3 +80,39 @@ _expect_test -f "geetest/${TIMESTAMP}/file1.txt"
 
 # cleanup
 "
+
+function test_parse_gh_pr_checks() {
+  declare -a FOO=( 1 2 3 )
+  declare -a CHECKS=(
+    "internal-bazel-presubmit (cloud-build-290921)   fail    27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493"
+    "linter-checks (cloud-build-290921)      pass    30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493"
+    "Pushes-preview-version-of-web-pages (cloud-build-290921)        skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493"
+    "external-dependencies (cloud-build-290921)      skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493"
+  )
+  declare -A CHECK_COUNTS=( [fail]=999 )
+  declare -a FAILED_BUILDS=( foobar )
+  _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
+  echo RC=$? >&3
+  typeset -p CHECK_COUNTS >&3
+  typeset -p FAILED_BUILDS" >&3
+}
+
+@test "_parse_gh_pr_checks test" {
+  run test_parse_gh_pr_checks
+  assert_success
+}
+
+
+
+
+  #   declare -A CHECK_COUNTS=( [fail]=999 )
+  #   declare -a FAILED_BUILDS=( foobar )
+  #   run _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
+  #   assert_success
+  #   assert_equal  1  "${CHECK_COUNTS[fail]}"
+  #   assert_equal  2  "${CHECK_COUNTS[skipping]}"
+  #   assert_equal  1  "${CHECK_COUNTS[pass]}"
+  #   assert_equal  1  "${#FAILED_BUILDS[@]}"
+  #   assert_equal  "104e0ed9-6dd6-443d-8afd-1aa05c649fac" "${FAILED_BUILDS[0]}"
+  # }
+  #


### PR DESCRIPTION
Current process is slow: check for failing tests, copy-paste the link into a browser,
scroll through a very long test log, hopefully find the tests that failed.

This PR accelerates that process for at least some cases, by extracting
the build ID from any failed test, pulling the log down directly using the
gcloud binary, and grepping that log for failures.

Tested:

I added a bats test for the function that parses the output of gh pr checks, and also tested manually in a branch with a failing test:

```
$ /home/jonathan/gee/enkit/gee_diagnose_checks/scripts/gee pr_checks
CMD: /usr/bin/gh pr checks
internal-bazel-presubmit             (cloud-build-290921)  fail      27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493
linter-checks                        (cloud-build-290921)  pass      30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493
Pushes-preview-version-of-web-pages  (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
external-dependencies                (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
gh pr checks: skipping=2 pass=1 fail=1
WARNING: Some presubmit checks have failed.
WARNING: Failed build: 104e0ed9-6dd6-443d-8afd-1aa05c649fac
Step #6: [9,796 / 10,151] 668 / 1240 tests, 1 failed; [Prepa] kernel: compiling csr_kernel_c_api_test.ko for arch:um kernel:enf-5.13.14-1-1655410008-g71368d4e7d83-test [for host]; 41s ... (42 actions, 0 running)
Step #6: [12,299 / 12,319] 1233 / 1240 tests, 1 failed; [Prepa] kernel: compiling enf.ko for arch:host kernel:enf-5.13.0-19-1-1655410008-g71368d4e7d83-generic; 26s ... (4 actions, 0 running)
Step #6: INFO: Build completed, 1 test FAILED, 6304 total actions
Step #6: //guidelines/bazel:tools_csr-diff_test                                   FAILED in 0.8s
Step #6: INFO: Build completed, 1 test FAILED, 6304 total actions
Step #6: INFO: Build completed, 1 test FAILED, 6304 total actions
ERROR: build step 6 "gcr.io/devops-284019/developer:internal-bazel-presubmit" failed: step exited with non-zero status: 3
```

