### PR TITLE
machinist server: Add HTTP endpoint for discovering nodes to scrape

### DIFF
--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -263,8 +263,7 @@ func Start(targetURL, cookieDomain, oAuthType string, astoreFlags *astore.Flags,
 		ShowResult(w, r, "angry", "Nothing to see here", messageNothing, http.StatusUnauthorized)
 	})
 
-	server.Run(mux, grpcs)
-	return nil
+	return server.Run(mux, grpcs, nil)
 }
 
 func main() {

--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -292,25 +292,25 @@ remote_run_test(
     dests = [
         "non-existant-machine-1.corp",
     ],
-    target = ":hello-world",
     # Should be equivalent to no inputs specified.
     inputs = "@enkit//bazel/utils/remote:noop",
+    target = ":hello-world",
 )
 
 remote_run_test(
     name = "with-all-inputs",
+    alldeps = True,
     dests = [
         "non-existant-machine-1.corp",
     ],
-    alldeps = True,
     inputs = ":hello-world",
 )
 
 remote_run_test(
     name = "with-all-basic",
+    alldeps = True,
     dests = [
         "non-existant-machine-1.corp",
     ],
-    alldeps = True,
     target = ":wrapper",
 )

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -131,5 +131,5 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	server.Run(mux, grpcs)
+	glog.Exit(server.Run(mux, grpcs, nil))
 }

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -74,5 +74,5 @@ func main() {
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/queue", fe)
 
-	server.Run(mux, grpcs)
+	exitIf(server.Run(mux, grpcs, nil))
 }

--- a/machinist/mserver/BUILD.bazel
+++ b/machinist/mserver/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//lib/client:go_default_library",
         "//lib/knetwork/kdns:go_default_library",
         "//lib/logger:go_default_library",
+        "//lib/server:go_default_library",
         "//machinist/config:go_default_library",
         "//machinist/rpc:machinist-go",
         "//machinist/state:go_default_library",

--- a/machinist/testing/machinist_e2e_test.go
+++ b/machinist/testing/machinist_e2e_test.go
@@ -116,7 +116,6 @@ func TestJoinServerAndPoll(t *testing.T) {
 	assert.ElementsMatch(t, []string{"{name:test01,ip:10.0.0.4}", "{name:test02,ip:10.0.0.1}"}, infoRecords)
 
 	assert.Nil(t, s.Stop())
-	assert.Nil(t, lis.Close())
 	assert.ElementsMatch(t, []string{"10.0.0.4", "10.0.0.1"}, allRecordsRes)
 	time.Sleep(20 * time.Millisecond)
 	//Test serialization

--- a/test/example/server/main.go
+++ b/test/example/server/main.go
@@ -28,5 +28,5 @@ func main() {
 	ec := EchoController{}
 	echopb.RegisterEchoControllerServer(grpcs, ec)
 	h := cors.AllowAll().Handler(http.NewServeMux())
-	server.Run(h, grpcs)
+	server.Run(h, grpcs, nil)
 }


### PR DESCRIPTION
Prometheus is currently fetching the list of nodes to scrape for metrics
from `mserver` via DNS A records. This means that metrics have
`instance=<IP>` on each, with no hope of ever mapping that back to a
hostname.

As it turns out, we can (and do) expose other types of DNS records, but
there is no way to get Prometheus both IP and hostname information via
DNS (it doesn't allow for fetching from the right kind of record, or
limits the fields it fetches from records that could contain both).

This change adds a separate mechanism that Prometheus does support: an
HTTP handler. By fetching `/metrics_targets`, a JSON array will be
generated that Prometheus understands that specifies scrape IPs and
their associated hostname. Port is not part of the address exposed, so
this must match node_exporter config and Prometheus config - but this is
no different than what we have today (A records don't export metrics
ports either).

Tested:
* Started server with `bazel run //machinist/mserver/cmd -- --loglevel-console=info`
* Fetch: `curl localhost:6433/metrics_targets` returns:

  ```
  []
  ```

* Started client with `bazel build //machinist/cmd && sudo bazel-bin/machinist/cmd/cmd_/cmd node poll --loglevel-console=info --auth-server=https://auth.corp.enfabrica.net --control-port=6433 --ips=192.168.1.220`
* Fetch: `curl localhost:6433/metrics_targets` returns:

  ```
  [{"labels":{"hostname":"pop-os"},"targets":["192.168.1.220"]}]
  ```