### PR TITLE
bazel/utils/remote.bzl: remove leftover debug print.

### DIFF
--- a/bazel/utils/remote.bzl
+++ b/bazel/utils/remote.bzl
@@ -196,7 +196,6 @@ def _inputs_aspect(target, ctx):
 
         for atarget in attrvalue:
             if atarget and InputFiles in atarget:
-                print("FOUND INPUTS", atarget[InputFiles])
                 allfiles.extend(atarget[InputFiles].all.to_list())
 
     return [InputFiles(direct = depset(direct), all = depset(allfiles))]


### PR DESCRIPTION
Really, that print should never have been merged.
Operator error. Removed.
