### PR TITLE
gee restore_all_branches: work outside gee directory

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4733,6 +4733,9 @@ function gee__restore_all_branches() {
   # Make sure all tools are available
   _install_tools
 
+  # Make sure we're in a valid git repo
+  _startup_checks "restore_all_branches"
+
   _gee_fix_remote_origin_fetch_config
 
   local OLDEST_COMMIT


### PR DESCRIPTION
This is a small tweak to restore_all_branches to make it "do the right thing" if
invoked from outside a gee directory.

Tested: manually ran it.

