### PR TITLE
enkit tunnel: Support listening on Unix Domain Sockets

### DIFF
--- a/proxy/ptunnel/commands/BUILD.bazel
+++ b/proxy/ptunnel/commands/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//lib/kcerts:go_default_library",
         "//lib/kflags:go_default_library",
         "//lib/kflags/kcobra:go_default_library",
-        "//lib/khttp:go_default_library",
         "//lib/khttp/krequest:go_default_library",
         "//lib/khttp/protocol:go_default_library",
         "//lib/knetwork:go_default_library",
@@ -31,6 +30,7 @@ go_test(
     srcs = [
         "agent_test.go",
         "ssh_test.go",
+        "tunnel_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/proxy/ptunnel/commands/tunnel_test.go
+++ b/proxy/ptunnel/commands/tunnel_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/enfabrica/enkit/lib/errdiff"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeListenAddr(t *testing.T) {
+	testCases := []struct{
+		desc string
+		addr string
+		wantNet string
+		wantAddr string
+		wantErr string
+	} {
+		{
+			desc: "port number only",
+			addr: "6443",
+			wantNet: "tcp",
+			wantAddr: ":6443",
+		},
+		{
+			desc: "port with no host",
+			addr: ":6443",
+			wantNet: "tcp",
+			wantAddr: ":6443",
+		},
+		{
+			desc: "port with host",
+			addr: "127.0.0.1:6443",
+			wantNet: "tcp",
+			wantAddr: "127.0.0.1:6443",
+		},
+		{
+			desc: "tcp url",
+			addr: "tcp://127.0.0.1:6443",
+			wantNet: "tcp",
+			wantAddr: "127.0.0.1:6443",
+		},
+		{
+			desc: "unix domain socket",
+			addr: "unix:///tmp/some.sock",
+			wantNet: "unix",
+			wantAddr: "/tmp/some.sock",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func (t *testing.T) {
+			gotNet, gotAddr, gotErr := normalizeListenAddr(tc.addr)
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+			if gotErr != nil {
+				return
+			}
+			assert.Equal(t, gotNet, tc.wantNet)
+			assert.Equal(t, gotAddr, tc.wantAddr)
+		})
+	}
+}


### PR DESCRIPTION
This change extends the functionality of the `-L`/`--listen` flag on
`enkit tunnel` to support Unix Domain Socket URLs as listen targets, in
the form `unix:///path/to/socket`. This involves:

* creating a function to contain the logic that normalizes the contents
  of the flag. The flag needs to continue to support `host:port`, as
  well as just a naked `port`, in addition to the new UDS path.
* fixing dependent code to not assume `TCPAddr`/`TCPConn`. In some
  places, type assertions are necessary, as TCP and Unix variants
  contain necessary methods not in the top-level interface; these should
  be relatively safe as long as we don't expand the network types to
  types that lack these methods.

Additionally, cleanup logic is improved by creating a Context that
becomes done on SIGINT, and plumbing that Context to relevant locations.
Care is taken to ensure that the listener is cleaned up at the
appropriate time depending on the listener's type and whether the tunnel
is running in background mode.

Tested: For each following case, ran `grpc_cli ls <endpoint>` to ensure that the tunnel was operational:
* TCP tunnel in background mode: `bazel run //enkit -- tunnel --proxy=https://gw.gcp01.corp.enfabrica.net --background -L 10000 buildbarn-stage-frontend.service.consul. 13011`
* TCP tunnel in foreground mode: `bazel run //enkit -- tunnel --proxy=https://gw.gcp01.corp.enfabrica.net -L 10000 buildbarn-stage-frontend.service.consul. 13011`
* UDS tunnel in background mode: `bazel run //enkit -- tunnel --proxy=https://gw.gcp01.corp.enfabrica.net --background -L unix:///tmp/enkit_test.sock buildbarn-stage-frontend.service.consul. 13011` (after `kill -2 <pid>`, confirmed socket file is deleted)
* UDS tunnel in foreground mode: `bazel run //enkit -- tunnel --proxy=https://gw.gcp01.corp.enfabrica.net -L unix:///tmp/enkit_test.sock buildbarn-stage-frontend.service.consul. 13011` (after `Ctrl-C`, confirmed socket file is deleted)


Jira: INFRA-1505
Jira: INFRA-1460