### PR TITLE
fixing tunnel

### DIFF
--- a/proxy/ptunnel/tunnel.go
+++ b/proxy/ptunnel/tunnel.go
@@ -431,10 +431,10 @@ func (t *Tunnel) KeepConnected(proxy *url.URL, host string, port uint16, mods ..
 		})
 
 		waiter := t.browser.Set(conn, ack, pos)
-		if err := waiter.Wait(); errors.Is(err, CloseRequested) {
-			return nil
+		if err := waiter.Wait(); !errors.Is(err, CloseRequested) {
+			return err
 		}
-		return err
+		return nil
 	})
 }
 


### PR DESCRIPTION
- proxy/enproxy: improve enproxy_test to move more data and print status.
- proxy/tunnel: fix retry strategy.
- proxy/tunnel: fix handling of short reads.
