### PR TITLE
enkit: add `version has-feature` subcommand

### DIFF
--- a/enkit/version/BUILD.bazel
+++ b/enkit/version/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["version.go"],
+    srcs = [
+        "version.go",
+        "features.go",
+    ],
     importpath = "github.com/enfabrica/enkit/enkit/version",
     visibility = ["//visibility:public"],
     deps = [

--- a/enkit/version/features.go
+++ b/enkit/version/features.go
@@ -1,0 +1,23 @@
+package version
+
+import (
+	"sort"
+)
+
+// Add entries to this list for every feature that we may want to be able to
+// manually/programmatically detect.
+//
+// Features can be a dash-delimited string, like: `tunnel-local-uds`
+// Features can be a bug fix, like: `INFRA-1234-fix`
+var features = []string{
+	"tunnel-local-uds", // Tunnels support listening on a UNIX domain socket locally
+}
+
+func init() {
+	sort.Strings(features)
+}
+
+func featuresContains(entry string) bool {
+	i := sort.SearchStrings(features, entry)
+	return i < len(features) && features[i] == entry
+}

--- a/enkit/version/version.go
+++ b/enkit/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/enfabrica/enkit/lib/client"
@@ -26,6 +27,9 @@ func New(base *client.BaseFlags) *Root {
 		BaseFlags: base,
 	}
 	rc.Command.RunE = rc.Run
+
+	rc.AddCommand(NewHasFeature().Command)
+
 	return rc
 }
 
@@ -38,5 +42,36 @@ func (r *Root) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Builder: %s\n", stamp.BuildUser)
 	fmt.Printf("Clean build: %v\n", stamp.IsClean())
 	fmt.Printf("Official build: %v\n", stamp.IsOfficial())
+	return nil
+}
+
+type HasFeature struct {
+	*cobra.Command
+}
+
+func NewHasFeature() *HasFeature {
+	c := &HasFeature {
+		Command: &cobra.Command{
+			Use: "has-feature <feature> [<feature> ...]",
+			Short: "Interrogate if this enkit binary has the named feature/fix. Sets exit code to 0 for yes, non-zero for no.",
+			Example: `  $ enkit version has-feature INFRA-1234-fix
+	Checks for a fix for INFRA-1234.`,
+		},
+	}
+	c.Command.RunE = c.Run
+	return c
+}
+
+func (hf *HasFeature) Run(cmd *cobra.Command, args []string) error {
+	hasAll := true
+	for _, feature := range args {
+		if !featuresContains(feature) {
+			hasAll = false
+			fmt.Printf("Feature not found: %s\n", feature)
+		}
+	}
+	if !hasAll {
+		return errors.New("not all features present in this enkit version")
+	}
 	return nil
 }


### PR DESCRIPTION
This change allows for a list of arbitrary "feature" strings to be
embedded into the enkit binary. These features could denote a new
capability within the binary, or a fix for a particular bug, and are
manually added by maintainers as fixes/features are added.

This change also adds a subcommand `has-feature` to `enkit version`.
This subcommand takes a list of feature strings, and exits 0 if they are
all present in this binary, or non-zero if at least one is missing.

Tested:
* `bazel run //enkit -- version has-feature tunnel-local-uds` - exits 0
* `bazel run //enkit -- version has-feature tunnel-local-uds foo` -
  exits nonzero