### PR TITLE
enkit version: Add build time info

### DIFF
--- a/enkit/version/version.go
+++ b/enkit/version/version.go
@@ -36,6 +36,7 @@ func (r *Root) Run(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Built from branch: %s\n", stamp.GitBranch)
 	fmt.Printf("Builder: %s\n", stamp.BuildUser)
+	fmt.Printf("Built at: %s\n", stamp.BuildTimestamp())
 	fmt.Printf("Clean build: %v\n", stamp.IsClean())
 	fmt.Printf("Official build: %v\n", stamp.IsOfficial())
 	return nil

--- a/lib/stamp/BUILD.bazel
+++ b/lib/stamp/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
         "GitSha": "{STABLE_GIT_SHA}",
         "GitMasterSha": "{STABLE_GIT_MASTER_SHA}",
         "changedFiles": "{STABLE_GIT_CHANGES}",
+        "buildTimestamp": "{BUILD_TIMESTAMP}",
     },
 )

--- a/lib/stamp/stamp.go
+++ b/lib/stamp/stamp.go
@@ -1,7 +1,9 @@
 package stamp
 
 import (
+	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -10,7 +12,8 @@ var (
 	GitSha       = "<unknown>"
 	GitMasterSha = "<unknown>"
 
-	changedFiles = "<unknown>"
+	changedFiles   = "<unknown>"
+	buildTimestamp = "<unknown>"
 )
 
 func IsClean() bool {
@@ -19,4 +22,12 @@ func IsClean() bool {
 
 func IsOfficial() bool {
 	return strings.TrimSpace(changedFiles) == "" && GitBranch == "master"
+}
+
+func BuildTimestamp() time.Time {
+	ts, err := strconv.ParseInt(buildTimestamp, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(ts, 0)
 }


### PR DESCRIPTION
This change adds a "Built at" line to `enkit version`, which displays
when the binary was built.

Tested:
* `bazel run //enkit -- version` - shows that it was built at the "zero"
  time
* `bazel run --stamp //enkit -- version` - shows that it was built now