### PR TITLE
enkit: Enable cgo

### DIFF
--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -20,6 +20,7 @@ go_binary(
     goarch = "amd64",
     goos = "linux",
     static = "on",
+    cgo = True,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This change enables cgo in the enkit build, which gives it access to the
cgo DNS resolver, which uses glibc on applicable machines to do DNS
resolution. This is necessary for DNS resolution to work properly in
constrained environments, such as the Cadence VCAD chamber.

Tested: `GODEBUG=netdns=cgo+2 enkit tunnel...` shows successful DNS
resolution, whereas `GODEBUG=netdns=go+2` shows continuous failures when
DNS resolution is done via NIS.