### PR TITLE
enkit: Enable cgo resolver for deployed linux binary

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -40,7 +40,12 @@ def _astore_upload(ctx):
 astore_upload = rule(
     implementation = _astore_upload,
     attrs = {
-        "targets": attr.label_list(allow_files = True, providers = [DefaultInfo], mandatory = True),
+        "targets": attr.label_list(
+            allow_files = True,
+            providers = [DefaultInfo],
+            mandatory = True,
+            cfg = "target",
+        ),
         "dir": attr.string(
             doc = "All the targets outputs will be uploaded as different files in an astore directory.",
         ),
@@ -96,8 +101,8 @@ def _astore_download(ctx):
         },
     )
     return [DefaultInfo(
-       files = depset([output]),
-       runfiles = ctx.runfiles([output]),
+        files = depset([output]),
+        runfiles = ctx.runfiles([output]),
     )]
 
 astore_download = rule(
@@ -112,7 +117,7 @@ astore_download = rule(
         ),
         "timeout": attr.int(
             doc = "Timeout for astore download operation, in seconds.",
-            default = 10*60,
+            default = 10 * 60,
         ),
         "_astore_client": attr.label(
             default = Label("//astore/client:astore"),

--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/astore:defs.bzl", "astore_upload")
 
 go_library(
     name = "go_default_library",
@@ -19,8 +20,10 @@ go_binary(
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
-    static = "on",
-    cgo = True,
+    # Force cgo DNS resolver to be used, which is required in certain
+    # environments (those using NIS to resolve addresses, for one). Also disable
+    # `static`, since this causes segfaults when forcing cgo to be enabled.
+    pure = "off",
     visibility = ["//visibility:public"],
 )
 
@@ -41,8 +44,6 @@ go_binary(
     static = "on",
     visibility = ["//visibility:public"],
 )
-
-load("//bazel/astore:defs.bzl", "astore_upload")
 
 astore_upload(
     name = "deploy",


### PR DESCRIPTION
This change ensures that cgo is enabled and used in the Linux binary, so that it can resolve addresses in the Cadence VCAD chamber machines, where NIS is used (via nsswitch.conf/glibc).

It would seem that as soon as either goos/goarch and/or static is set on the binary, rules_go uses a bazel "transition" that loses any `cgo` attribute set on the binary. This is visible when building with `--subcommands`, as the `CGO_ENABLED` env var is not set, and the resulting binary cannot use the cgo DNS resolver.

Setting `pure=off` and not setting `static` seems to be the most reliable way to get a working cgo binary.

Tested:
* Built with `bazel build //enkit:deploy`, which builds the versions that will actually be pushed to astore
* Ran `GODEBUG=netdns=cgo+2 bazel-bin/enkit/deploy.sh.runfiles/enkit/enkit/enkit-linux-amd64_/enkit-linux-amd64 ssh scott@build-04.sea` - saw that cgo resolver is actually used

Jira: INFRA-1774