### PR TITLE
Flextape - Make Proto Public

### DIFF
--- a/flextape/proto/BUILD.bazel
+++ b/flextape/proto/BUILD.bazel
@@ -9,6 +9,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "flextape_proto",
     srcs = ["flextape.proto"],
+    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],


### PR DESCRIPTION
Makes the flextape proto publicly visible so we can take on some of the messages as dependencies in other repos.