### PR TITLE
lib/bazel: add support for serial builds, more flags, more workspace

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -31,6 +31,11 @@ type GetModeOptions struct {
 	// Bazel query to use to find all the targets. Must be set.
 	// A good default is "deps(//...)"
 	Query string
+
+	// Extra startup flags to pass to bazel.
+	// Those flags are appended after other common flags (but before
+        // subcommand flags), so should override any global flag.
+	ExtraStartup []string
 }
 
 // The result of running a GetMode function below.
@@ -161,6 +166,7 @@ func SerialQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 		opt.Start.RepoPath,
 		WithOutputBase(opt.Start.OutputBase),
 		WithLogging(log),
+		WithExtraStartupFlags(opt.ExtraStartup...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bazel workspace: %w", err)
@@ -169,6 +175,7 @@ func SerialQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 		opt.End.RepoPath,
 		WithOutputBase(opt.End.OutputBase),
 		WithLogging(log),
+		WithExtraStartupFlags(opt.ExtraStartup...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bazel workspace: %w", err)
@@ -214,6 +221,7 @@ func ParallelQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 		opt.Start.RepoPath,
 		WithOutputBase(opt.Start.OutputBase),
 		WithLogging(log),
+		WithExtraStartupFlags(opt.ExtraStartup...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bazel workspace: %w", err)
@@ -222,6 +230,7 @@ func ParallelQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 		opt.End.RepoPath,
 		WithOutputBase(opt.End.OutputBase),
 		WithLogging(log),
+		WithExtraStartupFlags(opt.ExtraStartup...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bazel workspace: %w", err)

--- a/lib/bazel/affected_targets_test.go
+++ b/lib/bazel/affected_targets_test.go
@@ -19,10 +19,8 @@ func testWorkspace(t *testing.T) *Workspace {
 		"test/anotherdir/file.txt":     []byte("Another dir"),
 	}
 	sourceFS := testutil.NewFS(t, files)
-	genFS := testutil.NewFS(t, nil)
 	return &Workspace{
-		sourceDir: sourceFS,
-		bazelBin:  genFS,
+		sourceFS: sourceFS,
 	}
 }
 

--- a/lib/bazel/commands/BUILD.bazel
+++ b/lib/bazel/commands/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//enkit/proto:go_default_library",
         "//lib/bazel:go_default_library",
         "//lib/client:go_default_library",
+        "//lib/logger:go_default_library",
         "//lib/git:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",

--- a/lib/bazel/commands/commands.go
+++ b/lib/bazel/commands/commands.go
@@ -110,6 +110,8 @@ func NewAffectedTargetsList(parent *AffectedTargets) *AffectedTargetsList {
 	command.Flags().StringVar(&command.Query, "query", "deps(//...)",
 		"The query to use to find the targets. Only the default query has been tested, "+
 			"not all queries will work correctly, make sure to test your changes carefully")
+	command.Flags().StringArrayVar(&command.ExtraStartup, "extra_startup", nil, "Extra startup flags appended to the bazel command line")
+
 	return command
 }
 
@@ -121,7 +123,7 @@ func setCurrentOutputBaseAsDefault(gitRoot string, options *bazel.GetModeOptions
 		return nil
 	}
 
-	ws, err := bazel.OpenWorkspace(gitRoot, bazel.WithLogging(log))
+	ws, err := bazel.OpenWorkspace(gitRoot, bazel.WithExtraStartupFlags(options.ExtraStartup...), bazel.WithLogging(log))
 	if err != nil {
 		return err
 	}

--- a/lib/bazel/commands/commands.go
+++ b/lib/bazel/commands/commands.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -257,8 +256,4 @@ func bazelGitRoot(dir string) (string, string, error) {
 		return "", "", fmt.Errorf("can't calculate common path between %q and %q: %w", root, bazelRoot, err)
 	}
 	return root, rel, nil
-}
-
-func relativeWorkspace(gitRoot fs.FS, relativeWorkspace string) (fs.FS, error) {
-	return nil, fmt.Errorf("not implemented")
 }

--- a/lib/bazel/exec.go
+++ b/lib/bazel/exec.go
@@ -43,14 +43,15 @@ type Command interface {
 // temporary file.
 type fileCommand struct {
 	cmd           *exec.Cmd
+	// Additional environment variables overridden by API.
+	env	      []string
 	stdoutPath    string
 	stderrPath    string
-	cargoHomePath string
 }
 
 // NewCommand returns a fileCommand wrapping the provided exec.Cmd. It is
 // defined as a var so it can be stubbed in unit tests.
-var NewCommand = func(cmd *exec.Cmd) (Command, error) {
+var NewCommand = func(cmd *exec.Cmd, env ...string) (Command, error) {
 	stdout, err := ioutil.TempFile("", "bazel_stdout_*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stdout file: %w", err)
@@ -62,24 +63,11 @@ var NewCommand = func(cmd *exec.Cmd) (Command, error) {
 	}
 	stderr.Close()
 
-	// BUG(INFRA-140) - By default, cargo will download packages to a well-known
-	// directory under $HOME; this will mean that parallel bazel invocations could
-	// race on this directory if they both fetch Cargo packages. Cargo respects
-	// the $CARGO_HOME environment variable, so set it to something unique for
-	// this invocation.
-	env := os.Environ()
-	cargoHome, err := ioutil.TempDir("", "bazel_cargo_home_*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tmpdir for $CARGO_HOME: %w", err)
-	}
-	env = append(env, "CARGO_HOME="+cargoHome)
-	cmd.Env = env
-
 	return &fileCommand{
 		cmd:           cmd,
+		env:	       env,
 		stdoutPath:    stdout.Name(),
 		stderrPath:    stderr.Name(),
-		cargoHomePath: cargoHome,
 	}, nil
 }
 
@@ -141,13 +129,12 @@ func (c *fileCommand) StderrContents() string {
 }
 
 func (c *fileCommand) String() string {
-	return c.cmd.String()
+	return CommandString(c.cmd, c.env)
 }
 
 // Close removes stdout and stderr temporary files.
 func (c *fileCommand) Close() error {
 	os.Remove(c.stdoutPath)
 	os.Remove(c.stderrPath)
-	os.RemoveAll(c.cargoHomePath)
 	return nil
 }

--- a/lib/bazel/exec.go
+++ b/lib/bazel/exec.go
@@ -30,6 +30,9 @@ type Command interface {
 	// StdoutContents reads all of stdout into a raw byte slice.
 	StdoutContents() ([]byte, error)
 
+	// Returns a string representation of the command itself, for debug purposes.
+	String() string
+
 	// StderrContents reads stderr into a string. This method cannot fail, as it
 	// is intended to be used only in logging/errors; if reading fails, a sentinel
 	// error string will be returned instead.
@@ -135,6 +138,10 @@ func (c *fileCommand) StderrContents() string {
 		return "<failed to read stderr contents>"
 	}
 	return string(bytes.TrimSpace(contents))
+}
+
+func (c *fileCommand) String() string {
+	return c.cmd.String()
 }
 
 // Close removes stdout and stderr temporary files.

--- a/lib/bazel/exec_test.go
+++ b/lib/bazel/exec_test.go
@@ -25,6 +25,10 @@ func (c *fakeCommand) Close() error {
 	return c.closeErr
 }
 
+func (c *fakeCommand) String() string {
+	return "your-fakest-command"
+}
+
 func (c *fakeCommand) Stdout() (io.ReadCloser, error) {
 	if c.stdoutErr != nil {
 		return nil, c.stdoutErr

--- a/lib/bazel/options.go
+++ b/lib/bazel/options.go
@@ -25,6 +25,8 @@ type baseOptions struct {
 	// Additional flags appended to bazel after other common flags,
         // but before any command.
 	ExtraStartupFlags []string
+	// Additional environment variables to set.
+	ExtraEnv []string
 	// Logging object for internal log messages
 	Log logger.Logger
 }
@@ -45,6 +47,13 @@ func WithOutputBase(outputBase string) BaseOption {
 func WithExtraStartupFlags(extra ...string) BaseOption {
 	return func(o *baseOptions) {
 		o.ExtraStartupFlags = append(o.ExtraStartupFlags, extra...)
+	}
+}
+
+// WithExtraEnv adds extra environment variables for this bazel invocation.
+func WithExtraEnv(extra ...string) BaseOption {
+	return func(o *baseOptions) {
+		o.ExtraEnv = append(o.ExtraEnv, extra...)
 	}
 }
 

--- a/lib/bazel/options.go
+++ b/lib/bazel/options.go
@@ -22,6 +22,9 @@ type subcommand interface {
 type baseOptions struct {
 	// Bazel's cache directory for this workspace.
 	OutputBase string
+	// Additional flags appended to bazel after other common flags,
+        // but before any command.
+	ExtraStartupFlags []string
 	// Logging object for internal log messages
 	Log logger.Logger
 }
@@ -38,17 +41,27 @@ func WithOutputBase(outputBase string) BaseOption {
 	}
 }
 
+// WithExtraStartupFlags adds extra startup flags for this bazel invocation.
+func WithExtraStartupFlags(extra ...string) BaseOption {
+	return func(o *baseOptions) {
+		o.ExtraStartupFlags = append(o.ExtraStartupFlags, extra...)
+	}
+}
+
 func WithLogging(log logger.Logger) BaseOption {
 	return func(o *baseOptions) {
 		o.Log = log
 	}
 }
 
-// flags returns the startup flags as passed to bazel.
-func (o *baseOptions) flags() []string {
+// Args returns the startup flags as passed to bazel.
+func (o *baseOptions) Args() []string {
 	var f []string
 	if o.OutputBase != "" {
 		f = append(f, "--output_base", o.OutputBase)
+	}
+	if len(o.ExtraStartupFlags) > 0 {
+		f = append(f, o.ExtraStartupFlags...)
 	}
 	return f
 }

--- a/lib/bazel/query.go
+++ b/lib/bazel/query.go
@@ -150,7 +150,7 @@ func (w *Workspace) Query(query string, options ...QueryOption) (*QueryResult, e
 	defer cmd.Close()
 	err = cmd.Run()
 	if err := queryOpts.filterError(err); err != nil {
-		return nil, fmt.Errorf("bazel query failed: %v\n\nbazel stderr:\n%s", err, cmd.StderrContents())
+		return nil, fmt.Errorf("Command: %s\nError: %v\n\nbazel stderr:\n%s", cmd.String(), err, cmd.StderrContents())
 	}
 
 	targets := map[string]*Target{}

--- a/lib/bazel/query_test.go
+++ b/lib/bazel/query_test.go
@@ -48,7 +48,7 @@ func TestQueryOutput(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			stubs := gostub.Stub(&NewCommand, func(cmd *exec.Cmd) (Command, error) {
+			stubs := gostub.Stub(&NewCommand, func(cmd *exec.Cmd, env ...string) (Command, error) {
 				// Record the command
 				tc.gotCommands = append(tc.gotCommands, cmd)
 				// Return fake results

--- a/lib/bazel/target.go
+++ b/lib/bazel/target.go
@@ -109,7 +109,7 @@ func (t *Target) getHash(w *Workspace) (uint32, error) {
 		if err != nil {
 			return 0, err
 		}
-		f, err := w.sourceDir.Open(lbl.filePath())
+		f, err := w.OpenSource(lbl.filePath())
 		if err != nil {
 			return 0, fmt.Errorf("can't open source file %q: %w", lbl.filePath(), err)
 		}

--- a/lib/bazel/workspace.go
+++ b/lib/bazel/workspace.go
@@ -127,6 +127,7 @@ func (w *Workspace) bazelCommand(subCmd subcommand) (Command, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct bazel command: %w", err)
 	}
+	w.options.Log.Debugf("=> %s", cmd.String())
 	return bazelCmd, nil
 }
 
@@ -142,7 +143,7 @@ func (w *Workspace) Info(options ...InfoOption) (string, error) {
 
 	err = cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("bazel info failed: %v\n\nbazel stderr:\n\n%s", err, cmd.StderrContents())
+		return "", fmt.Errorf("Command: %s\nFailed: %v\n\nbazel stderr:\n\n%s", cmd.String(), err, cmd.StderrContents())
 	}
 
 	b, err := cmd.StdoutContents()

--- a/lib/bazel/workspace.go
+++ b/lib/bazel/workspace.go
@@ -118,7 +118,7 @@ func (w *Workspace) OutputExternal() (string, error) {
 // * subcommand and subcommand args
 // * rooted to the correct workspace directory
 func (w *Workspace) bazelCommand(subCmd subcommand) (Command, error) {
-	args := w.options.flags()
+	args := w.options.Args()
 	args = append(args, subCmd.Args()...)
 	cmd := exec.Command("bazel", args...)
 	cmd.Dir = w.root

--- a/lib/bazel/workspace_test.go
+++ b/lib/bazel/workspace_test.go
@@ -27,6 +27,13 @@ func TestBazelQueryCommand(t *testing.T) {
 			queryOpts: nil,
 			wantArgs:  []string{"bazel", "query", "--output=streamed_proto", "--", cannedQuery},
 		},
+		{
+			desc:      "basic query",
+			baseOpts:  []BaseOption{WithExtraStartupFlags("--blastoff")},
+			queryOpts: nil,
+			wantArgs:  []string{"bazel", "--blastoff", "query", "--output=streamed_proto", "--", cannedQuery},
+		},
+
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/lib/bazel/workspace_test.go
+++ b/lib/bazel/workspace_test.go
@@ -38,7 +38,7 @@ func TestBazelQueryCommand(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			var gotCmd *exec.Cmd
-			stubs := gostub.Stub(&NewCommand, func(cmd *exec.Cmd) (Command, error) {
+			stubs := gostub.Stub(&NewCommand, func(cmd *exec.Cmd, env ...string) (Command, error) {
 				gotCmd = cmd
 				return &fakeCommand{
 					stdout: io.NopCloser(strings.NewReader("")),


### PR DESCRIPTION
Recommendation: review one commit at a time, they are self contained.

This PR and set of commits allows to aggressively re-use the cache by running commands sequentially, while setting all the right flags. It includes some minor refactors.

- enkit/lib/bazel: move the code to compute affected targets in a function.
- /lib/bazel: add support for serial query or parallel query.
- lib/bazel: allow to override output_base and bazel query from command line.
- lib/bazel: remove unused method.
- lib/bazel: minor workspace.go refactor to lazily load variables.
- lib/bazel: set output_base from current client when doing things serially.
- lib/bazel: add ability to pass extra arbitrary flags to bazel.
- lib/bazel: improve debug output.
