### PR TITLE
WORKSPACE - Extract go_repositories Call From Step2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,10 @@ load("//bazel/init:stage_1.bzl", "stage_1")
 
 stage_1()
 
+# This call is placed here intentionally outside of the steps so that enkit and
+# any downstream repos can keep seperate go dependencies.
+go_repositories()
+
 load("//bazel/init:stage_2.bzl", "stage_2")
 
 stage_2()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,8 @@ load("//bazel/init:stage_1.bzl", "stage_1")
 
 stage_1()
 
+load("//bazel:go_repositories.bzl", "go_repositories")
+
 # This call is placed here intentionally outside of the steps so that enkit and
 # any downstream repos can keep seperate go dependencies.
 go_repositories()

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -54,8 +54,6 @@ def stage_2():
         requirements_lock = "//:requirements.txt",
     )
 
-    go_repositories()
-
     # SDKs that can be used to build Go code. We need:
     # * the most recent version we can support
     # * the most recent version AppEngine can support (currently 1.16)

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -3,7 +3,6 @@
 See README.md for more information.
 """
 
-load("//bazel:go_repositories.bzl", "go_repositories")
 load("//bazel/meson:meson.bzl", "meson_register_toolchains")
 load("//bazel/ui:deps.bzl", "install_ui_deps")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")


### PR DESCRIPTION
We're starting to write go in our repo, but we don't want to pull in two sets of go_repositories - one from enkit and one from our repo.

Extracting the go_repositories call from step 2 allows us to bring in enkit into our repository but not it's go_repositories. This way our repo can pull in our own go_repositories.

This will also require all things enkit to be built from enkit and no other repo.

Tested by building enkit after changes (`bazel build enkit`)

Jira: INFRA-1834