### PR TITLE
kbuildbarn: Tolerate bytestreams from UDS URLs

### DIFF
--- a/lib/kbuildbarn/BUILD.bazel
+++ b/lib/kbuildbarn/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//lib/bes:go_default_library",
+        "//lib/errdiff:go_default_library",
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "//third_party/buildbuddy/proto:buildbuddy_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",


### PR DESCRIPTION
When bazel is talking to the BES endpoint via UNIX domain socket, it embeds bytestream URLs that have:
* an excessive number of slashes (bytestream://////rest/of/path)
* no host - only a path
* path is absolute path to the UDS on the client joined with the normal path (/blobs/hash/size)

This change modifies the parse code to tolerate and rewrite these URLs correctly.

Tested: unit tests

Jira: INFRA-1836