### PR TITLE
binaries: Add top-level target to release all

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,7 @@
+load("//bazel/enkit:defs.bzl", "multirun")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
 
 # To update and generate the BUILD.bazel files, run:
 #     bazelisk run //:gazelle
@@ -48,10 +51,19 @@ exports_files(
     visibility = ["//:__subpackages__"],
 )
 
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
-
 # To automatically format all .bzl files and all BUILD.bzl files, run:
 #     bazelisk run //:buildifier
 buildifier(
     name = "buildifier",
+)
+
+multirun(
+    name = "binaries_release",
+    commands = [
+        "//enkit:deploy",
+        "//faketree:astore_push",
+        "//flextape/server:astore_push",
+        # TODO(scott): Move the main to //flextape/client, delete this dir
+        "//manager/client:astore_push",
+    ],
 )

--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel/astore:defs.bzl", "astore_upload")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//bazel/astore:defs.bzl", "astore_upload")
 
@@ -17,6 +18,7 @@ go_binary(
 
 go_binary(
     name = "enkit-linux-amd64",
+    cgo = True,
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -53,4 +55,5 @@ astore_upload(
         ":enkit-darwin-amd64",
         ":enkit-win-amd64",
     ],
+    visibility = ["//:__pkg__"],
 )

--- a/faketree/BUILD.bazel
+++ b/faketree/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel/astore:defs.bzl", "astore_upload")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
@@ -33,4 +34,13 @@ sh_test(
         # Cloud Build cannot run privileged containers
         "no-cloudbuild",
     ],
+)
+
+astore_upload(
+    name = "astore_push",
+    file = "infra/tools/faketree",
+    targets = [
+        ":faketree",
+    ],
+    visibility = ["//:__pkg__"]
 )

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel/astore:defs.bzl", "astore_upload")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -22,3 +23,13 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
+
+astore_upload(
+    name = "astore_push",
+    file = "infra/flextape/flextape_server",
+    targets = [
+        ":flextape",
+    ],
+    visibility = ["//:__pkg__"]
+)
+

--- a/manager/client/BUILD.bazel
+++ b/manager/client/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel/astore:defs.bzl", "astore_upload")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -20,4 +21,13 @@ go_binary(
     name = "client",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+astore_upload(
+    name = "astore_push",
+    file = "infra/flextape/flextape_client",
+    targets = [
+        ":client",
+    ],
+    visibility = ["//:__pkg__"]
 )


### PR DESCRIPTION
This change adds a multirun target at the top level BUILD file to release all binaries that internal needs to use, adding `astore_push` rules for each where they are missing.

Tested: Ran, pushing binaries:

```
...it-linux-amd64: uploading 24.27 MiB / 24.27 MiB [----------] 100.00% 22.10 MiB p/s 1s
...it-linux-amd64: committing amd64-linux 24.27 MiB / 24.27 MiB  100.00% 20.14 MiB p/s 1
...t-darwin-amd64: uploading 23.98 MiB / 23.98 MiB [----------] 100.00% 25.70 MiB p/s 1s
...t-darwin-amd64: committing amd64-mac 23.98 MiB / 23.98 MiB [ 100.00% 22.07 MiB p/s 1s
...-win-amd64.exe: uploading 24.46 MiB / 24.46 MiB [----------] 100.00% 26.20 MiB p/s 1s
...-win-amd64.exe: committing amd64-win 24.46 MiB / 24.46 MiB [ 100.00% 23.16 MiB p/s 1s
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2022-09-22 20:01:35.180 scott@enfabrica.net            amd64-linux    35ddb8deb978952f447b825a34fabe1f zz4jhhmn5e7m63f24tcppf7m77b62873 25 MB   [latest]
| 2022-09-22 20:01:36.482 scott@enfabrica.net            amd64-mac      6947a77200e7e2d97dffabf28cff150c 5mpia7jvaqspihyh8zrhea2t7p3fqtrq 25 MB   [latest]
| 2022-09-22 20:01:37.792 scott@enfabrica.net            amd64-win      e347fb75fd8cc427960d5595885a1e94 cqfxk2khqhw3a2e5pcsujmr8s4nk2h44 26 MB   [latest]
Running //faketree:astore_push
...tree_/faketree: uploading 2.81 MiB / 2.81 MiB [------------] 100.00% 11.87 MiB p/s 0s
...tree_/faketree: committing amd64-linux 2.81 MiB / 2.81 MiB [] 100.00% 7.81 MiB p/s 1s
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2022-09-22 20:01:38.737 scott@enfabrica.net            amd64-linux    17767282c50a85a07b6d4186e7607114 w2qgb8czfu6a88taaz3pqd2cpjoek2hr 3.0 MB  [latest]
Running //flextape/server:astore_push
...tape_/flextape: uploading 14.65 MiB / 14.65 MiB [----------] 100.00% 21.93 MiB p/s 1s
...tape_/flextape: committing amd64-linux 14.65 MiB / 14.65 MiB  100.00% 19.49 MiB p/s 1
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2022-09-22 20:01:40.065 scott@enfabrica.net            amd64-linux    3ea260488d2e6359bba56280c6548abc msdnkqpdd5gexmapksbge6ymgp8krf27 15 MB   [latest]
Running //manager/client:astore_push
...client_/client: uploading 11.33 MiB / 11.33 MiB [----------] 100.00% 16.03 MiB p/s 1s
...client_/client: committing amd64-linux 11.33 MiB / 11.33 MiB  100.00% 7.30 MiB p/s 2s
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2022-09-22 20:01:42.157 scott@enfabrica.net            amd64-linux    b1b576ab5d2557f5d0b33087af30003b 4t6oso4eifajic8r4sui66jobyfmkz58 12 MB   [latest]
```

Jira: INFRA-1822