### PR TITLE
bazel/linux/runner: add support for hard coding wrapper flags.

### DIFF
--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -25,6 +25,16 @@ If not specified, the current root of the filesystem will be used as rootfs.
             mandatory = True,
             doc = "List of executable targets to run in the emulator.",
         ),
+        "wrapper_flags": attr.string_list(
+            doc = """\
+Flags to append after '--' at the end of the qemu command line.
+
+This is useful when the emulator is being invoked through a wrapper, or
+when a wrapper is invoked by the emulator. It allows to separate the
+emulator flags from those passed to the wrapper.
+""",
+            default = [],
+        ),
         "template_init": attr.label(
             allow_single_file = True,
             default = template_init_default,
@@ -181,6 +191,7 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
         "rootfs": rootfs,
         "init": init.short_path,
         "runtime": runtime_root.short_path,
+	"wrapper_flags": shell.array_literal(ctx.attr.wrapper_flags),
     }, **extra)
 
     subs["code"] = code.format(**subs)

--- a/bazel/linux/templates/runner.template.sh
+++ b/bazel/linux/templates/runner.template.sh
@@ -14,6 +14,7 @@ RELRUNTIME="{runtime}"
 ROOTFS="{rootfs}"
 KERNEL="{kernel}"
 TARGET="{target}"
+WRAPPER_OPTS={wrapper_flags} # Array, no quotes!
 
 # A script in charge of verifying the output of the run.
 CHECKER="{checker}"
@@ -120,7 +121,7 @@ while getopts "k:e:r:hsx" opt; do
 done
 shift $((OPTIND - 1))
 
-WRAPPER_OPTS=("$@")
+WRAPPER_OPTS+=("$@")
 
 showstate
 


### PR DESCRIPTION
Without this PR, it's not possible to supply wrapper flags to
the rule - only through the command line.

The only alternative is to create a sh_binary wrapper to the
wrapper wrapping the emulator wrapping our code invoked by
the bazel wrappers. In short this PR can avoid yet one more
wrapping.
