### PR TITLE
enkit: improve enkit agent error message

### DIFF
--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -123,12 +123,12 @@ func (a *SSHAgent) GetStandardSocketPath() (string, error) {
 }
 
 func (a *SSHAgent) UseStandardPaths() error {
-	socket, err := a.GetStandardSocketPath()
+	standard_socket_path, err := a.GetStandardSocketPath()
 	if err != nil {
 		return err
 	}
 
-	if a.Socket == socket {
+	if a.Socket == standard_socket_path {
 		// no standardization needed.
 		return nil
 	}
@@ -144,12 +144,12 @@ func (a *SSHAgent) UseStandardPaths() error {
 		return fmt.Errorf("UseStandardPaths symlink failed: %w", err)
 	}
 	// Rename symlink to the standard name
-	os.Remove(socket) // if it exists
-	if err := os.Rename(tempname, socket); err != nil {
+	os.Remove(standard_socket_path) // if it exists
+	if err := os.Rename(tempname, standard_socket_path); err != nil {
 		return fmt.Errorf("UseStandardPaths rename failed: %w", err)
 	}
 
-	a.Socket = socket
+	a.Socket = standard_socket_path
 	return nil
 }
 

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -141,12 +141,12 @@ func (a *SSHAgent) UseStandardPaths() error {
 	tempname := fmt.Sprintf("%s/enkit.tmp%016x", path, mathrand.New(srand.Source).Uint64())
 	defer os.Remove(tempname)
 	if err := os.Symlink(a.Socket, tempname); err != nil {
-		return err
+		return fmt.Errorf("UseStandardPaths symlink failed: %w", err)
 	}
 	// Rename symlink to the standard name
 	os.Remove(socket) // if it exists
 	if err := os.Rename(tempname, socket); err != nil {
-		return err
+		return fmt.Errorf("UseStandardPaths rename failed: %w", err)
 	}
 
 	a.Socket = socket

--- a/lib/kcerts/ssh.go
+++ b/lib/kcerts/ssh.go
@@ -144,7 +144,6 @@ func (a *SSHAgent) UseStandardPaths() error {
 		return fmt.Errorf("UseStandardPaths symlink failed: %w", err)
 	}
 	// Rename symlink to the standard name
-	os.Remove(standard_socket_path) // if it exists
 	if err := os.Rename(tempname, standard_socket_path); err != nil {
 		return fmt.Errorf("UseStandardPaths rename failed: %w", err)
 	}


### PR DESCRIPTION
One time while logging in I saw the following message:

```
2022-10-04T16:12:08.202Z        WARN    error saving credentials, err: symlink /tmp/ssh-wKEavpGmnw/agent.41963 /home/jonathan/.config/enkit/agent: file exists
ERROR: symlink /tmp/ssh-wKEavpGmnw/agent.41963 /home/jonathan/.config/enkit/agent: file exists
```

Everything seemed to work, but this message wasn't sufficient for me to debug
the code, especially since we're never performing the operation in question.
Nothing seems broken, but let's improve the error messages anyway so we can
root cause this properly in the future.

Tested: All existing tests still pass.

