### PR TITLE
astore_upload: add "uidfile" functionality

### DIFF
--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -1,4 +1,23 @@
+load("@//bazel/astore:defs.bzl", "astore_upload")
+
 exports_files([
     "astore_upload_file.sh",
     "astore_upload_dir.sh",
 ])
+
+# This target can be used to validate the "uidfile" functionality
+# of the astore_upload rule.  Running this rule will cause the
+# UID_ASTORE_UPLOAD_FILE_SH variable, below, to be updated.
+astore_upload(
+    name = "test_astore_upload_file",
+    file = "tmp/astore_upload_file_testdata",
+    targets = [
+        ":astore_upload_file.sh",
+    ],
+    visibility = [
+        "//developer:__subpackages__",
+    ],
+    uidfile = "BUILD.bazel",
+)
+
+UID_ASTORE_UPLOAD_FILE_SH = "6iaexnhkshxbbbmacmtw2euuoxmcjet2"

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -20,4 +20,5 @@ astore_upload(
     uidfile = "BUILD.bazel",
 )
 
-UID_ASTORE_UPLOAD_FILE_SH = "6iaexnhkshxbbbmacmtw2euuoxmcjet2"
+UID_ASTORE_UPLOAD_FILE_SH = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
+SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -1,3 +1,49 @@
 #!/bin/sh
 
-{astore} upload -G -f {file} {targets} 
+set -e
+
+FILE="{file}"
+TARGETS=( {targets} )
+UIDFILE="{uidfile}"
+
+TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
+trap 'rm -f "${TEMPTOML}"' EXIT
+
+function update_build_file() {
+  local UIDFILE="$1"
+  local TARGET="$2"
+  local FILE_UID="$3"
+
+  if [[ ! -f "${UIDFILE}" ]]; then
+    echo >&2 "Error: ${UIDFILE}: file not found"
+    exit 3
+  fi
+  UIDFILE="$(readlink -f "${UIDFILE}")"
+  local VARNAME="UID_$(basename "${TARGET}" | tr a-z A-Z | tr -c A-Z0-9\\r\\n _ )"
+  local SEDSCRIPT="s/^${VARNAME} = \".*\"/${VARNAME} = \"${FILE_UID}\"/"
+  if ! sed -i "${SEDSCRIPT}" "${UIDFILE}"; then
+    echo >&2 "Error: sed script failed: ${SEDSCRIPT}"
+    exit 4
+  fi
+  if ! grep "^${VARNAME} = \"${FILE_UID}\"" "${UIDFILE}" >&2 ; then
+    echo >&2 "Error: failed to update ${VARNAME} in ${UIDFILE}"
+    echo >&2 "       Is this variable missing from this file?"
+    exit 5
+  fi
+  echo >&2 "Updated ${VARNAME} in ${UIDFILE}"
+}
+
+# astore doesn't tell us which metadata entry corresponds to which target, so
+# we work around the issue by uploading the targets sequentially:
+for TARGET in "${TARGETS[@]}"; do
+  {astore} upload -G -f "${FILE}" "${TARGET}" -m "${TEMPTOML}"
+  FILE_UID="$(grep -E "^  Uid = " "${TEMPTOML}" | awk '{print $3}' | tr -d \")"
+  if [[ -z "${FILE_UID}" ]]; then
+    echo >&2 "Error: no UID found for ${TARGET} uploaded as ${FILE}".
+    exit 2
+  fi
+  echo >&2 "${TARGET} uploaded as ${FILE}: assigned UID ${FILE_UID}"
+  if [[ -n "${UIDFILE}"  ]]; then
+    update_build_file "${UIDFILE}" "${TARGET}" "${FILE_UID}"
+  fi
+done

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -13,24 +13,30 @@ function update_build_file() {
   local UIDFILE="$1"
   local TARGET="$2"
   local FILE_UID="$3"
+  local FILE_SHA="$4"
 
   if [[ ! -f "${UIDFILE}" ]]; then
     echo >&2 "Error: ${UIDFILE}: file not found"
     exit 3
   fi
   UIDFILE="$(readlink -f "${UIDFILE}")"
-  local VARNAME="UID_$(basename "${TARGET}" | tr a-z A-Z | tr -c A-Z0-9\\r\\n _ )"
-  local SEDSCRIPT="s/^${VARNAME} = \".*\"/${VARNAME} = \"${FILE_UID}\"/"
-  if ! sed -i "${SEDSCRIPT}" "${UIDFILE}"; then
-    echo >&2 "Error: sed script failed: ${SEDSCRIPT}"
+  local VARNAME="$(basename "${TARGET}" | tr a-z A-Z | tr -c A-Z0-9\\r\\n _ )"
+  local UID_VARNAME="UID_${VARNAME}"
+  local SHA_VARNAME="SHA_${VARNAME}"
+  local UID_SEDSCRIPT="s/^${UID_VARNAME} = \".*\"/${UID_VARNAME} = \"${FILE_UID}\"/"
+  local SHA_SEDSCRIPT="s/^${SHA_VARNAME} = \".*\"/${SHA_VARNAME} = \"${FILE_SHA}\"/"
+  if ! sed -i -e "${UID_SEDSCRIPT}" -e "${SHA_SEDSCRIPT}" "${UIDFILE}"; then
+    echo >&2 "Error: sed command failed to execute script:"
+    echo >&2 "  ${UID_SEDSCRIPT}"
+    echo >&2 "  ${SHA_SEDSCRIPT}"
     exit 4
   fi
-  if ! grep "^${VARNAME} = \"${FILE_UID}\"" "${UIDFILE}" >&2 ; then
-    echo >&2 "Error: failed to update ${VARNAME} in ${UIDFILE}"
+  if ! grep "^${UID_VARNAME} = \"${FILE_UID}\"" "${UIDFILE}" >&2 ; then
+    echo >&2 "Error: failed to update ${UID_VARNAME} in ${UIDFILE}"
     echo >&2 "       Is this variable missing from this file?"
     exit 5
   fi
-  echo >&2 "Updated ${VARNAME} in ${UIDFILE}"
+  echo >&2 "Updated ${UID_VARNAME} in ${UIDFILE}"
 }
 
 # astore doesn't tell us which metadata entry corresponds to which target, so
@@ -38,12 +44,13 @@ function update_build_file() {
 for TARGET in "${TARGETS[@]}"; do
   {astore} upload -G -f "${FILE}" "${TARGET}" -m "${TEMPTOML}"
   FILE_UID="$(grep -E "^  Uid = " "${TEMPTOML}" | awk '{print $3}' | tr -d \")"
+  FILE_SHA="$(sha256sum "${TARGET}" | awk '{print $1}')"
   if [[ -z "${FILE_UID}" ]]; then
     echo >&2 "Error: no UID found for ${TARGET} uploaded as ${FILE}".
     exit 2
   fi
   echo >&2 "${TARGET} uploaded as ${FILE}: assigned UID ${FILE_UID}"
   if [[ -n "${UIDFILE}"  ]]; then
-    update_build_file "${UIDFILE}" "${TARGET}" "${FILE_UID}"
+    update_build_file "${UIDFILE}" "${TARGET}" "${FILE_UID}" "${FILE_SHA}"
   fi
 done

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -105,6 +105,11 @@ of the target in the following manner:
 
 For example: a target named foo/bar:some-script.sh would correspond with the
 UID variable name "UID_SOME_SCRIPT_SH".
+
+Note that the "uidfile" functionality is currently only supported when using
+the "file" attribute, but not the "dir" attribute.
+
+TODO(jonathan): add support for the "dir" attribute.
 """,
 )
 

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -9,33 +9,38 @@ def astore_url(package, uid, instance = "https://astore.corp.enfabrica.net"):
     )
 
 def _astore_upload(ctx):
-    push = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
-
     if ctx.attr.dir and ctx.attr.file:
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
-    inputs = [ctx.executable._astore_client]
+    files = [ctx.executable._astore_client]
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
-        inputs.extend([f for f in target.files.to_list()])
+        files.extend([f for f in target.files.to_list()])
 
     template = ctx.file._astore_upload_file
     if ctx.attr.dir:
         template = ctx.file._astore_upload_dir
 
+    uidfile=""
+    if ctx.attr.uidfile:
+        uidfile=ctx.files.uidfile[0].short_path
+        files.append(ctx.files.uidfile[0])
+
     ctx.actions.expand_template(
         template = template,
-        output = push,
+        output = ctx.outputs.executable,
         substitutions = {
             "{astore}": ctx.executable._astore_client.short_path,
             "{targets}": " ".join(targets),
             "{file}": ctx.attr.file,
             "{dir}": ctx.attr.dir,
+            "{uidfile}": uidfile,
         },
         is_executable = True,
     )
-    return [DefaultInfo(executable = push, runfiles = ctx.runfiles(inputs))]
+    runfiles = ctx.runfiles(files = files)
+    return [DefaultInfo(runfiles = runfiles)]
 
 astore_upload = rule(
     implementation = _astore_upload,
@@ -53,6 +58,12 @@ astore_upload = rule(
             doc = "All the targets outputs will be uploaded as the same file in an astore directory. " +
                   "This is useful when you have multiple targets to build the same binary for different " +
                   "architectures or operating systems.",
+        ),
+        "uidfile": attr.label(
+          allow_files = True,
+          providers = [DefaultInfo],
+          mandatory = False,
+          doc = "If specified, will attempt to update the UID variable in this (build) file."
         ),
         "_astore_upload_file": attr.label(
             default = Label("//bazel/astore:astore_upload_file.sh"),
@@ -73,7 +84,28 @@ astore_upload = rule(
     doc = """Uploads artifacts to an artifact store - astore.
 
 With this rule, you can easily upload the output of a build rule
-to an artifact store.""",
+to an artifact store.
+
+Optionally, this rule can update a BUILD file (or other text file) to contain
+the generated UID for each uploaded target.  This functionality is enabled
+by specifying the "uidfile" attribute.
+
+The script will search that file for a line matching:
+
+UID_TARGETNAME = "some-uid-string"
+
+And update "some-uid-string" with the UID of the file that was just uploaded.
+
+The variable name "UID_TARGETNAME" is formed by transforming the base name
+of the target in the following manner:
+
+  - all non-alphanumeric characters are replaced with underscores.
+  - all alphabetic characters are converted to uppercase.
+  - "UID_" is prepended.
+
+For example: a target named foo/bar:some-script.sh would correspond with the
+UID variable name "UID_SOME_SCRIPT_SH".
+""",
 )
 
 def _astore_download(ctx):

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -142,6 +142,8 @@ def _astore_download(ctx):
         runfiles = ctx.runfiles([output]),
     )]
 
+# TODO: add an optional "uid" attribute to this rule
+# TODO: add an optional "digest" attribute to this rule
 astore_download = rule(
     implementation = _astore_download,
     attrs = {


### PR DESCRIPTION
Problem: our users are routinely updating collateral in astore, but
are neither tracking nor using the UID of each upload to keep files
strictly version controlled.  When asked to specify all files by
UID, users replied that this was too much extra manual work.

This PR attempts to address this problem by automating the updating of a
UID-specifying variable in an arbitrary text file (ie. a bazel BUILD file).
This way, the user can commit this change into source control to keep all
astore_download targets strongly version controlled.

Two variables are updated for each target:

`UID_<TARGETNAME>` -- the astore-assigned UID for the uploaded file
`SHA_<TARGETNAME>` -- the sha256sum of the uploaded file

where `TARGETNAME` is a transformation of the uploaded target filename
(see docstring).

Right now, this only works with the "file" attribute but not the "dir"
attribute of astore_upload.  That should probably be fixed, eventually.

Tested:

I added a :test_astore_upload_file target that uploads a very small file into astore's tmp
directory, and updates the UID of the most recently uploaded file in the BUILD file.

It looks like this when it runs:

```
$ bazel run :test_astore_upload_file
INFO: Invocation ID: 169572ff-7dd6-4437-bc00-89bc42a6d016
DEBUG: /home/jonathan/.cache/bazel/_bazel_jonathan/303a1d2000a5418b7a2e2e55ba101be1/external/bazel_gazelle/internal/go_repository.bzl:209:18: org_golang_google_protobuf: gazelle: /home/jonathan/.cache/bazel/_bazel_jonathan/303a1d2000a5418b7a2e2e55ba101be1/external/org_golang_google_protobuf/cmd/protoc-gen-go/testdata/imports/test_b_1: directory contains multiple proto packages. Gazelle can only generate a proto_library for one package.
INFO: Analyzed target //bazel/astore:test_astore_upload_file (2 packages loaded, 7 targets configured).
INFO: Found 1 target...
Target //bazel/astore:test_astore_upload_file up-to-date:
  bazel-bin/bazel/astore/test_astore_upload_file
INFO: Elapsed time: 0.274s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
bazel/astore/astore_upload_file.sh: uploading 1.51 KiB / 1.51 KiB [------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4.90 KiB p/s 0s
bazel/astore/astore_upload_file.sh: committing all 1.51 KiB / 1.51 KiB [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4.90 KiB p/s 0s
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2022-10-05 12:53:35.538 jonathan@enfabrica.net         all            22bcfa6b0cc166e36061c642da831d03 6iaexnhkshxbbbmacmtw2euuoxmcjet2 1.5 kB  [latest]
bazel/astore/astore_upload_file.sh uploaded as tmp/astore_upload_file_testdata: assigned UID 6iaexnhkshxbbbmacmtw2euuoxmcjet2
UID_ASTORE_UPLOAD_FILE_SH = "6iaexnhkshxbbbmacmtw2euuoxmcjet2"
Updated UID_ASTORE_UPLOAD_FILE_SH in /home/jonathan/gee/enkit/master/bazel/astore/BUILD.bazel

$ grep UID_ASTORE_UPLOAD_FILE ./BUILD.bazel

UID_ASTORE_UPLOAD_FILE_SH = "6iaexnhkshxbbbmacmtw2euuoxmcjet2"
```

