### PR TITLE
bazel/astore: update astore_download to take optional uid/digest attributes

### DIFF
--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@//bazel/astore:defs.bzl", "astore_upload")
+load("@//bazel/astore:defs.bzl", "astore_upload", "astore_download")
 
 exports_files([
     "astore_upload_file.sh",
@@ -22,3 +22,16 @@ astore_upload(
 
 UID_ASTORE_UPLOAD_FILE_SH = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
 SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
+
+astore_download(
+  name = "test_astore_download_file",
+  download_src = "tmp/astore_upload_file_testdata",
+  uid = UID_ASTORE_UPLOAD_FILE_SH,
+)
+
+astore_download(
+  name = "test_astore_download_file_with_digest",
+  download_src = "tmp/astore_upload_file_testdata",
+  uid = UID_ASTORE_UPLOAD_FILE_SH,
+  digest = SHA_ASTORE_UPLOAD_FILE_SH,
+)

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -29,9 +29,18 @@ V1_SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d626
 astore_download(
   name = "test_astore_download_file",
   download_src = "tmp/astore_upload_file_testdata",
+  tags = ["manual", "no-presubmit"],
+)
+
+# downloads whatever the latest version is:
+astore_download(
+  name = "test_astore_download_file_by_uid",
+  download_src = "tmp/astore_upload_file_testdata",
+  output= "by_uid.txt",
   uid = UID_ASTORE_UPLOAD_FILE_SH,
   tags = ["manual", "no-presubmit"],
 )
+
 
 # downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH, which is automatically
 # updated by the astore_upload rule above.

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -32,7 +32,7 @@ astore_download(
   tags = ["manual", "no-presubmit"],
 )
 
-# downloads whatever the latest version is:
+# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH
 astore_download(
   name = "test_astore_download_file_by_uid",
   download_src = "tmp/astore_upload_file_testdata",
@@ -42,8 +42,8 @@ astore_download(
 )
 
 
-# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH, which is automatically
-# updated by the astore_upload rule above.
+# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH
+# and verifies it using SHA_ASTORE_UPLOAD_FILE_SH
 astore_download(
   name = "test_astore_download_file_with_digest",
   download_src = "tmp/astore_upload_file_testdata",

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -20,18 +20,36 @@ astore_upload(
     uidfile = "BUILD.bazel",
 )
 
-UID_ASTORE_UPLOAD_FILE_SH = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
+UID_ASTORE_UPLOAD_FILE_SH = "skh2ux3sdyijzxdny33g32sst7bw42od"
 SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
+V1_UID_ASTORE_UPLOAD_FILE_SH = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
+V1_SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
 
+# downloads whatever the latest version is:
 astore_download(
   name = "test_astore_download_file",
   download_src = "tmp/astore_upload_file_testdata",
   uid = UID_ASTORE_UPLOAD_FILE_SH,
+  tags = ["manual", "no-presubmit"],
 )
 
+# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH, which is automatically
+# updated by the astore_upload rule above.
 astore_download(
   name = "test_astore_download_file_with_digest",
   download_src = "tmp/astore_upload_file_testdata",
+  output = "with_digest.txt",  # must be specified to avoid output collision with previous rule.
   uid = UID_ASTORE_UPLOAD_FILE_SH,
   digest = SHA_ASTORE_UPLOAD_FILE_SH,
+  tags = ["manual", "no-presubmit"],
+)
+
+# downloads a "frozen" V1 version of the uploaded file.  This UID is manually updated only.
+astore_download(
+  name = "test_astore_download_file_v1",
+  download_src = "tmp/astore_upload_file_testdata",
+  output = "v1_with_digest.txt",  # must be specified to avoid output collision with previous rule.
+  uid = V1_UID_ASTORE_UPLOAD_FILE_SH,
+  digest = V1_SHA_ASTORE_UPLOAD_FILE_SH,
+  tags = ["manual", "no-presubmit"],
 )

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -115,27 +115,36 @@ TODO(jonathan): add support for the "dir" attribute.
 
 def _astore_download(ctx):
     output = ctx.actions.declare_file(ctx.attr.download_src.split("/")[-1])
-    command = ("%s download --no-progress -o %s %s" %
-               (ctx.executable._astore_client.path, output.path, ctx.attr.download_src))
+    command = ("%s download --no-progress --overwrite -o %s" %
+               (ctx.executable._astore_client.path, output.path))
+    execution_requirements = {
+            # We can't run these remotely since remote workers won't have
+            # credentials to fetch from astore.
+            "no-remote": "Don't run remotely or cache remotely",
+            "requires-network": "Downloads from astore",
+            "timeout": "%d" % ctx.attr.timeout,
+        }
     if ctx.attr.arch:
         command += " -a " + ctx.attr.arch
+    if ctx.attr.uid:
+        command += " --force-uid %s" % ctx.attr.uid
+    else:
+        command += " %s" % ctx.attr.download_src
+        execution_requirements["no-cache"] = "Not hermetic, since uid was not specified."
+        # TODO(ccontavalli): an old comment claimed the following, is it
+        # still true?
+        # # We should also avoid remotely caching since:
+        # # * this means we need to give individuals permissions to remotely
+        # #   cache local actions, which we currently don't do
+        # # * we might spend lots of disk/network caching astore artifacts
+        # #   remotely
+    if ctx.attr.digest:
+      command += " && (echo \"%s\" %s | sha256sum --check -)" % (ctx.attr.digest, output.path)
     ctx.actions.run_shell(
         command = command,
         tools = [ctx.executable._astore_client],
         outputs = [output],
-        execution_requirements = {
-            # We can't run these remotely since remote workers won't have
-            # credentials to fetch from astore.
-            # We should also avoid remotely caching since:
-            # * this means we need to give individuals permissions to remotely
-            #   cache local actions, which we currently don't do
-            # * we might spend lots of disk/network caching astore artifacts
-            #   remotely
-            "no-remote": "Don't run remotely or cache remotely",
-            "requires-network": "Downloads from astore",
-            "no-cache": "Not hermetic, since it doesn't refer to packages by hash",
-            "timeout": "%d" % ctx.attr.timeout,
-        },
+        execution_requirements = execution_requirements,
     )
     return [DefaultInfo(
         files = depset([output]),
@@ -157,6 +166,16 @@ astore_download = rule(
         "timeout": attr.int(
             doc = "Timeout for astore download operation, in seconds.",
             default = 10 * 60,
+        ),
+        "uid": attr.string(
+          doc = "The UID of a specific version of the file to download.",
+          mandatory = False,
+          default = "",
+        ),
+        "digest": attr.string(
+          doc = "The sha256 digest of the file that we expect to receive.",
+          mandatory = False,
+          default = "",
         ),
         "_astore_client": attr.label(
             default = Label("//astore/client:astore"),

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -114,7 +114,10 @@ TODO(jonathan): add support for the "dir" attribute.
 )
 
 def _astore_download(ctx):
-    output = ctx.actions.declare_file(ctx.attr.download_src.split("/")[-1])
+    if ctx.attr.output:
+      output = ctx.outputs.output
+    else:
+      output = ctx.actions.declare_file(ctx.attr.download_src.split("/")[-1])
     command = ("%s download --no-progress --overwrite -o %s" %
                (ctx.executable._astore_client.path, output.path))
     execution_requirements = {
@@ -166,6 +169,9 @@ astore_download = rule(
         "timeout": attr.int(
             doc = "Timeout for astore download operation, in seconds.",
             default = 10 * 60,
+        ),
+        "output": attr.output(
+          doc = "Overrides the default output path, if used.",
         ),
         "uid": attr.string(
           doc = "The UID of a specific version of the file to download.",


### PR DESCRIPTION
This PR adds optional uid/digest attributes to astore_download, and
then uses those values to validate the variables that were automatically
updated by astore_upload.

Tested: Ran the new download targets manually:

```
$ blaze build :test_astore_download_file :test_astore_download_file_with_digest
```

Automated presubmit testing isn't possible due to the lack of enkit
credentials in the presubmit environment.

