### PR TITLE
astore_download: remove no-remote if uid is specified

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -123,7 +123,6 @@ def _astore_download(ctx):
     execution_requirements = {
             # We can't run these remotely since remote workers won't have
             # credentials to fetch from astore.
-            "no-remote": "Don't run remotely or cache remotely",
             "requires-network": "Downloads from astore",
             "timeout": "%d" % ctx.attr.timeout,
         }
@@ -134,6 +133,7 @@ def _astore_download(ctx):
     else:
         command += " %s" % ctx.attr.download_src
         execution_requirements["no-cache"] = "Not hermetic, since uid was not specified."
+        execution_requirements["no-remote"] = "Not hermetic, since uid was not specified."
         # TODO(ccontavalli): an old comment claimed the following, is it
         # still true?
         # # We should also avoid remotely caching since:


### PR DESCRIPTION
Acting on late-arriving feedback from PR #775: this PR
only actives "no-remote" if a uid is not specified.

Tested: manually, using the command:

```
cd bazel/astore
blaze build :test_astore_download_file :test_astore_download_file_by_uid :test_astore_download_file_with_digest :test_astore_download_file_v1
```

