### PR TITLE
bazel/astore: fix integration errors

### DIFF
--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -1,64 +1,13 @@
-load("@//bazel/astore:defs.bzl", "astore_upload", "astore_download")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "defs_bzl",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+)
 
 exports_files([
     "astore_upload_file.sh",
     "astore_upload_dir.sh",
 ])
 
-# This target can be used to validate the "uidfile" functionality
-# of the astore_upload rule.  Running this rule will cause the
-# UID_ASTORE_UPLOAD_FILE_SH variable, below, to be updated.
-astore_upload(
-    name = "test_astore_upload_file",
-    file = "tmp/astore_upload_file_testdata",
-    targets = [
-        ":astore_upload_file.sh",
-    ],
-    visibility = [
-        "//developer:__subpackages__",
-    ],
-    uidfile = "BUILD.bazel",
-)
-
-UID_ASTORE_UPLOAD_FILE_SH = "skh2ux3sdyijzxdny33g32sst7bw42od"
-SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
-V1_UID_ASTORE_UPLOAD_FILE_SH = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
-V1_SHA_ASTORE_UPLOAD_FILE_SH = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
-
-# downloads whatever the latest version is:
-astore_download(
-  name = "test_astore_download_file",
-  download_src = "tmp/astore_upload_file_testdata",
-  tags = ["manual", "no-presubmit"],
-)
-
-# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH
-astore_download(
-  name = "test_astore_download_file_by_uid",
-  download_src = "tmp/astore_upload_file_testdata",
-  output= "by_uid.txt",
-  uid = UID_ASTORE_UPLOAD_FILE_SH,
-  tags = ["manual", "no-presubmit"],
-)
-
-
-# downloads the version specified by UID_ASTORE_UPLOAD_FILE_SH
-# and verifies it using SHA_ASTORE_UPLOAD_FILE_SH
-astore_download(
-  name = "test_astore_download_file_with_digest",
-  download_src = "tmp/astore_upload_file_testdata",
-  output = "with_digest.txt",  # must be specified to avoid output collision with previous rule.
-  uid = UID_ASTORE_UPLOAD_FILE_SH,
-  digest = SHA_ASTORE_UPLOAD_FILE_SH,
-  tags = ["manual", "no-presubmit"],
-)
-
-# downloads a "frozen" V1 version of the uploaded file.  This UID is manually updated only.
-astore_download(
-  name = "test_astore_download_file_v1",
-  download_src = "tmp/astore_upload_file_testdata",
-  output = "v1_with_digest.txt",  # must be specified to avoid output collision with previous rule.
-  uid = V1_UID_ASTORE_UPLOAD_FILE_SH,
-  digest = V1_SHA_ASTORE_UPLOAD_FILE_SH,
-  tags = ["manual", "no-presubmit"],
-)

--- a/bazel/astore/tests/BUILD.bazel
+++ b/bazel/astore/tests/BUILD.bazel
@@ -1,0 +1,59 @@
+load("@//bazel/astore:defs.bzl", "astore_upload", "astore_download")
+
+# This target can be used to validate the "uidfile" functionality
+# of the astore_upload rule.  Running this rule will cause the
+# UID_TESTDATA_TXT variable, below, to be updated.
+astore_upload(
+    name = "test_astore_upload_file",
+    file = "tmp/astore_upload_file_testdata",
+    targets = [
+        "testdata.txt",
+    ],
+    visibility = [
+        "//developer:__subpackages__",
+    ],
+    uidfile = "BUILD.bazel",
+)
+
+UID_TESTDATA_TXT = "wg36keugs3w6eexzg8azrnuspoqcrbnn"
+SHA_TESTDATA_TXT = "20f565a43697b7804d6a9d7ad4929118a1ed660183dda18229a92fc71c449725"
+V1_UID_TESTDATA_TXT = "k6xcd26ipqk6o6axnxwmxa8gf8bpjhnc"
+V1_SHA_TESTDATA_TXT = "d47d169097d16b57a2f8899c6c0b553c61f6a52cffe8d6264432324db1d80421"
+
+# downloads whatever the latest version is:
+astore_download(
+  name = "test_astore_download_file",
+  download_src = "tmp/astore_upload_file_testdata",
+  tags = ["manual", "no-presubmit"],
+)
+
+# downloads the version specified by UID_TESTDATA_TXT
+astore_download(
+  name = "test_astore_download_file_by_uid",
+  download_src = "tmp/astore_upload_file_testdata",
+  output= "by_uid.txt",
+  uid = UID_TESTDATA_TXT,
+  tags = ["manual", "no-presubmit"],
+)
+
+
+# downloads the version specified by UID_TESTDATA_TXT
+# and verifies it using SHA_TESTDATA_TXT
+astore_download(
+  name = "test_astore_download_file_with_digest",
+  download_src = "tmp/astore_upload_file_testdata",
+  output = "with_digest.txt",  # must be specified to avoid output collision with previous rule.
+  uid = UID_TESTDATA_TXT,
+  digest = SHA_TESTDATA_TXT,
+  tags = ["manual", "no-presubmit"],
+)
+
+# downloads a "frozen" V1 version of the uploaded file.  This UID is manually updated only.
+astore_download(
+  name = "test_astore_download_file_v1",
+  download_src = "tmp/astore_upload_file_testdata",
+  output = "v1_with_digest.txt",  # must be specified to avoid output collision with previous rule.
+  uid = V1_UID_TESTDATA_TXT,
+  digest = V1_SHA_TESTDATA_TXT,
+  tags = ["manual", "no-presubmit"],
+)

--- a/bazel/astore/tests/manual_test.sh
+++ b/bazel/astore/tests/manual_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This script captures the steps to manually test the special functionality
+# in the //bazel/astore:defs.bzl rules.
+
+set -e
+trap 'printf "%s:%s: command %q failed with rc=%d\n" "${BASH_SOURCE}" "${LINENO}" "${BASH_COMMAND}" "$?"' ERR
+
+echo "## Uploading to astore."
+bazel run //bazel/astore/tests:test_astore_upload_file
+
+echo "## Validate that BUILD file changes look right:"
+git diff BUILD.bazel
+
+echo "## These builds should all pass:"
+bazel build \
+  //bazel/astore/tests:test_astore_download_file \
+  //bazel/astore/tests:test_astore_download_file_by_uid \
+  //bazel/astore/tests:test_astore_download_file_with_digest \
+  //bazel/astore/tests:test_astore_download_file_v1
+
+echo "## Testing completed successfully."
+trap - ERR

--- a/bazel/astore/tests/testdata.txt
+++ b/bazel/astore/tests/testdata.txt
@@ -1,0 +1,20 @@
+Good Bones
+Maggie Smith
+
+Life is short, though I keep this from my children.
+Life is short, and I’ve shortened mine
+in a thousand delicious, ill-advised ways,
+a thousand deliciously ill-advised ways
+I’ll keep from my children. The world is at least
+fifty percent terrible, and that’s a conservative
+estimate, though I keep this from my children.
+For every bird there is a stone thrown at a bird.
+For every loved child, a child broken, bagged,
+sunk in a lake. Life is short and the world
+is at least half terrible, and for every kind
+stranger, there is one who would break you,
+though I keep this from my children. I am trying
+to sell them the world. Any decent realtor,
+walking you through a real shithole, chirps on
+about good bones: This place could be beautiful,
+right? You could make this place beautiful.


### PR DESCRIPTION
presubmits for the integration PR uncovered a surprising error:

* https://github.com/enfabrica/internal/pull/9321
* https://console.cloud.google.com/cloud-build/builds/7ed83bd9-dae0-4482-bc2a-2d36a5653dd2;step=6?project=cloud-build-290921

An example error message:

```
ERROR: /tmp/git_temp_worktree_2097900939/hw/projects/mlm/design/chip/macro_gen/BUILD:10940:14:
every rule of type astore_upload implicitly depends upon the target
'@enkit//bazel/astore:astore_upload_file.sh', but this target could not be
found because of: error loading package '@enkit//bazel/astore': Label
'//bazel/astore:defs.bzl' is invalid because 'bazel/astore' is not a package;
perhaps you meant to put the colon here: '//bazel:astore/defs.bzl'?`
```

The issue is resolved by adding a bzl_library rule to bazel/astore/BUILD.bazel, verified by running

```
bazel query --override_repository=enkit=/home/jonathan/gee/enkit/bazel_astore_cleanup  'deps (//bazel/dependencies/...)'
```

I'm a little confused as to why this error didn't exist before my PR as well,
but -- shrug!  At least this PR fixes it.

While I was debugging this, I moved the test rules to a test subdirectory, and
replaced the boring test data file with a poem.

Tested: See above.  I also re-ran my manual tests:

```
cd bazel/astore/tests
blaze run :test_astore_upload_file  # upload a new version and update UID
blaze build $(blaze query :all)  # run the various astore_download rules
```

