### PR TITLE
gee: improve error reporting

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1888,7 +1888,8 @@ function _log_command_failure() {
   local lineno="$1"
   local cmd="$2"
   local rc="$3"
-  local msg="$(printf "gee:%s: command %q failed with rc=%d" "${lineno}" "${cmd}" "${rc}")"
+  local msg
+  msg="$(printf "gee:%s: command %q failed with rc=%d" "${lineno}" "${cmd}" "${rc}")"
   printf >&2 "${_COLOR_WARN}WARNING: %s${_COLOR_RST}\n" "$msg"
   printf "  warn: %s\n" "$msg" | _to_gee_log
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -125,6 +125,7 @@ then :; fi
 # TODO(jonathan): "git push -u" option is going to change soon.
 
 set -e
+trap 'printf "WARN:gee:%s: command %q failed with rc=%d\n" "${BASH_SOURCE}" "${LINENO}" "${BASH_COMMAND}" "$?"' ERR
 
 if [[ -n "${DEBUG}" ]]; then
   set -x

--- a/scripts/gee
+++ b/scripts/gee
@@ -124,8 +124,8 @@ then :; fi
 # TODO(jonathan): Bash implementation is a prototype.  rewrite in golang?
 # TODO(jonathan): "git push -u" option is going to change soon.
 
-set -e
-trap 'printf "WARN:gee:%s: command %q failed with rc=%d\n" "${BASH_SOURCE}" "${LINENO}" "${BASH_COMMAND}" "$?"' ERR
+set -E  # enables errtrace (allows ERR traps to be inherited by functions and subshells)
+set -e  # terminate script on any simple command failure.
 
 if [[ -n "${DEBUG}" ]]; then
   set -x
@@ -1875,22 +1875,26 @@ function _write_parents_file() {
 
 ABNORMAL=1
 function _cleanup() {
-  local lineno="$1"
+  set +e
+  trap - ERR
+  if (( ABNORMAL == 1 )); then
+    _warn "Abnormal termination: gee unexpectedly exited."
+  fi
   # Ensure we always save the PARENTS file, even if we die:
   _write_parents_file
   # Warn the user if we terminated abnormally (for example, if set -e fired).
-  if (( ABNORMAL == 1 )); then
-    _warn "Abnormal termination at line ${lineno}"
-  fi
 }
+function _log_command_failure() {
+  local lineno="$1"
+  local cmd="$2"
+  local rc="$3"
+  local msg="$(printf "gee:%s: command %q failed with rc=%d" "${LINENO}" "${BASH_COMMAND}" "$?")"
+  printf >&2 "${_COLOR_WARN}WARNING: %s${_COLOR_RST}\n" "$msg"
+  printf "  warn: %s\n" "$msg" | _to_gee_log
+}
+
+trap '_log_command_failure "${LINENO}" "${BASH_COMMAND}" "$?"' ERR
 trap '_cleanup "${LINENO}"' EXIT
-# This doesn't quite work right, which is why gee needs to be rewritten
-# in golang:
-# function _error_report() {
-#   local lineno="$1"
-#   _warn "ERR signal raised on line ${lineno}"
-# }
-# trap '_error_report "${LINENO}"' ERR
 
 function _join() {
   # Usage:  _join <delimiter> <elements...>
@@ -4445,6 +4449,11 @@ function gee__hello() {
   if [[ -z "${_QUIET}" ]]; then
     _info "Hello, ${GHUSER}.  Connectivity to github is AOK."
   fi
+}
+
+function gee__debug_error_reporting() {
+  echo "About the run /bin/false, which should report an error:"
+  /bin/false
 }
 
 ##########################################################################

--- a/scripts/gee
+++ b/scripts/gee
@@ -1888,7 +1888,7 @@ function _log_command_failure() {
   local lineno="$1"
   local cmd="$2"
   local rc="$3"
-  local msg="$(printf "gee:%s: command %q failed with rc=%d" "${LINENO}" "${BASH_COMMAND}" "$?")"
+  local msg="$(printf "gee:%s: command %q failed with rc=%d" "${lineno}" "${cmd}" "${rc}")"
   printf >&2 "${_COLOR_WARN}WARNING: %s${_COLOR_RST}\n" "$msg"
   printf "  warn: %s\n" "$msg" | _to_gee_log
 }
@@ -4452,7 +4452,7 @@ function gee__hello() {
 }
 
 function gee__debug_error_reporting() {
-  echo "About the run /bin/false, which should report an error:"
+  echo "About to run /bin/false, which should report an error:"
   /bin/false
 }
 


### PR DESCRIPTION
While working on an unrelated problem, I finally figured out why
gee's error reporting (trap ERR) wasn't working correctly.  I learned:

* `set -E` is required to enable "errtrace" mode, allowing the ERR trap
  to be inherited by functions and subprocesses.

* in bash 4.0, the EXIT trap behavior changed so that the LINENO environment
  variable is always reset to 1 inside EXIT handlers.  (This feels like a
  misfeature to me.)

Now that I can get ERR traps to work correctly, I can get gee to correctly
report the line number, command, and exit code of any failing command that
is causing the gee script to fail.  This should be make debugging user issues
a little easier in the future.

Tested: added a hidden "debug_error_reporting" subcommand to gee that
emulates an error condition.  Running this command results in the
expected error report.

