### PR TITLE
gee: re-enable autostash

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1490,7 +1490,7 @@ function _interactive_conflict_resolution() {
             _warn "\"Pick\" will abort and restart your rebase merge from the beginning."
             if _confirm_default_no "Are you sure you want to restart? (y/N)  "; then
               _git rebase --abort
-              local -a GITCMD=( rebase --no-autostash -i )
+              local -a GITCMD=( rebase --autostash -i )
               if [[ -n "${ONTO}" ]]; then
                 GITCMD+=( --onto "${ONTO}" )
               fi
@@ -1561,9 +1561,21 @@ function _interactive_conflict_resolution() {
     fi
   done  # while rebase is in progress
 
+  _check_diff_for_merge_conflict_markers
+
   if (( ABORT == 1 )); then
     _git rebase --abort
     return
+  fi
+}
+
+function _grep_for_merge_conflict_markers() {
+  grep -E "^((<{6,})|(={6,})|(>{6,}))"
+}
+
+function _check_diff_for_merge_conflict_markers() {
+  if "${GIT}" diff | _grep_for_merge_conflict_markers >/dev/null; then
+    _warn "Uncommited files contain conflict markers: please resolve."
   fi
 }
 
@@ -1612,7 +1624,6 @@ function _safer_rebase() {
   if (( "${#UNCOMMITTED[@]}" )); then
     _warn "Branch ${CHILD} contains ${#UNCOMMITTED[@]} uncommitted changes:" \
       "${UNCOMMITTED[@]}"
-    _fatal "Commit all changes and try again."
   fi
 
   _silent_cmd "${GIT}" tag -f "${CHILD}.REBASE_BACKUP"
@@ -1640,9 +1651,9 @@ function _safer_rebase() {
       # fatal: invalid upstream 'upstream/pull/1234/head'
       _die "git pull --rebase does not support --onto"
     fi
-    GITCMD+=( pull --rebase --no-autostash upstream "${PARENT#upstream/}" )
+    GITCMD+=( pull --rebase --autostash upstream "${PARENT#upstream/}" )
   else
-    GITCMD+=( rebase --no-autostash )
+    GITCMD+=( rebase --autostash )
     if [[ -n "${ONTO}" ]]; then
       GITCMD+=(--onto "${ONTO}")
     fi
@@ -1673,6 +1684,7 @@ function _safer_rebase() {
       return 1
     fi
   fi
+  _check_diff_for_merge_conflict_markers
 
   _info "To undo: git checkout ${CHILD}; git reset --hard ${CHILD}.REBASE_BACKUP"
   _push_to_origin "+${CHILD}"
@@ -1759,7 +1771,7 @@ function _update_from_upstream() {
   local LOCAL_BRANCH="$1"
   local UPSTREAM_BRANCH="$2"
   _checkout_or_die "${LOCAL_BRANCH}"
-  if ! _git pull --rebase --no-autostash upstream "${UPSTREAM_BRANCH}"; then
+  if ! _git pull --rebase --autostash upstream "${UPSTREAM_BRANCH}"; then
     _warn "Git pull operation failed."
     if ! _is_rebase_in_progress; then
       _fatal "Rebase not in progress, no idea what went wrong."
@@ -1781,6 +1793,7 @@ function _update_from_upstream() {
   if (( COUNTS[0] != 0 )); then
     _fatal "pull failed: upstream/${UPSTREAM_BRANCH} is ${COUNTS[1]} commits ahead of ${LOCAL_BRANCH}"
   fi
+  _check_diff_for_merge_conflict_markers
   _push_to_origin "+${MAIN}"
 }
 
@@ -2593,7 +2606,8 @@ function gee__update() {
         _info "Pulling in changes from origin/${CURRENT_BRANCH}"
         HEAD="$("${GIT}" rev-parse HEAD)"
         _info "Old head commit before rebase: ${HEAD}"
-        _git rebase --no-autostash "origin/${CURRENT_BRANCH}"
+        _git rebase --autostash "origin/${CURRENT_BRANCH}"
+        _check_diff_for_merge_conflict_markers
       else
         _info "You may need to \"git push -u origin --force\" to fix your origin remote."
       fi
@@ -3139,6 +3153,7 @@ function gee__commit() {
         _warn "You must integrate upstream changes before pushing."
         if _confirm_default_yes "Do you want to pull upstream changes now? (Y/n)  "; then
           _git rebase --autostash "origin/${CURRENT_BRANCH}"
+          _check_diff_for_merge_conflict_markers
         else
           _warn "Skipping backup of branch to origin/${CURRENT_BRANCH}"
           return 0

--- a/scripts/gee.bats
+++ b/scripts/gee.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!/usr/bin/env bats -x
 
 load "external/bats_support/load.bash"
 load "external/bats_assert/load.bash"
@@ -32,6 +32,16 @@ setup() {
   assert_equal 2    "${#ARGS_POSITIONAL[@]}"
   assert_equal bar  "${ARGS_POSITIONAL[0]}"
   assert_equal bum  "${ARGS_POSITIONAL[1]}"
+}
+
+@test "_grep_for_merge_conflict_markers" {
+  local testdata=$'fooo\nbar\n<<<<<<<<<\nabc\n===\nbar >>>>>>>> bum\n======\n>>>>>\n>>>>>>>>>>\n'
+  run _grep_for_merge_conflict_markers <<< "${testdata}"
+  assert_success
+  assert_output $'<<<<<<<<<\n======\n>>>>>>>>>>'  # bats run eats the final newline.
+  run _grep_for_merge_conflict_markers <<< $'foobar\ndeadbeef\n'
+  assert_failure
+  assert_output ""
 }
 
 @test "test_foo" {

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### Unreleased
+
+* Re-enable --autostash behavior when rebasing (#780)
+
 ### 0.2.36
 
 * Timeout ssh-add -l if the ssh-agent gets stuck (#768)


### PR DESCRIPTION
The users are right: the "autostash" behavior is the right choice for
the "just function" philosophy of gee.  This PR re-enables autostash,
but adds a few checks for post-rebase merge conflict markers, just
in case a merge conflict was introduced when the stashed changes
got re-applied.

Tested: Used modified gee to run `gee rupdate` in a branch with uncommitted changes.

