### PR TITLE
enkit agent print: further diagnosis of os.Rename failure

### DIFF
--- a/lib/kcerts/certs.go
+++ b/lib/kcerts/certs.go
@@ -215,7 +215,7 @@ func checkValidCert(cert *ssh.Certificate) bool {
 }
 
 const (
-	MaxCertTimeDuration = time.Duration(1 << 63 - 1)
+	MaxCertTimeDuration     = time.Duration(1<<63 - 1)
 	InValidCertTimeDuration = time.Duration(0)
 )
 

--- a/lib/kcerts/certs_test.go
+++ b/lib/kcerts/certs_test.go
@@ -137,8 +137,8 @@ func TestCertTTL(t *testing.T) {
 	nowTime := time.Now().Unix()
 	badCerts := []ssh.Certificate{
 		{
-			ValidAfter: uint64(nowTime + 20),
-			ValidBefore:  50,
+			ValidAfter:  uint64(nowTime + 20),
+			ValidBefore: 50,
 		},
 		{
 			ValidAfter:  uint64(nowTime + 50),

--- a/lib/kcerts/ked25519/cert.go
+++ b/lib/kcerts/ked25519/cert.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"math/rand"
 )
+
 // Copied from https://github.com/mikesmitty/edkey/blob/master/edkey.go
 /* Writes ed25519 private keys into the new OpenSSH private key format.
 I have no idea why this isn't implemented anywhere yet, you can do seemingly

--- a/lib/kcerts/ssh_test.go
+++ b/lib/kcerts/ssh_test.go
@@ -12,6 +12,12 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func TestAnnotatedErrorf(t *testing.T) {
+	err := AnnotatedErrorf("foo %d %d", 2, 3)
+	expectedErrorMsg := "[lib/kcerts/ssh_test.go:16] foo 2 3"
+	assert.EqualErrorf(t, err, expectedErrorMsg, "AnnotatedErrorf mismatch.")
+}
+
 // TODO(adam): improve this test, including files writes and other edges cases
 func TestAddSSHCAToClient(t *testing.T) {
 	hdir, _ := os.UserHomeDir()


### PR DESCRIPTION
This PR adds an AnnotatedErrorf method which annotates an error
message with the source file and line number that originated the
error, addressing a pet peeve of mine.

Tested: ssh_test.go validates AnnotatedErrorf.  manual testing of enkit.

