### PR TITLE
enkit outputs: Support persistent tunnels

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -1371,6 +1371,12 @@ def go_repositories():
         sum = "h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=",
         version = "v0.0.0-20200827194710-b269163b24ab",
     )
+    go_repository(
+        name = "com_github_jackpal_gateway",
+        importpath = "github.com/jackpal/gateway",
+        sum = "h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=",
+        version = "v1.0.7",
+    )
 
     go_repository(
         name = "com_github_jbenet_go_context",

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,7 @@ require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05
 	cloud.google.com/go/asset v1.1.0 // indirect
 	cloud.google.com/go/bigquery v1.28.0 // indirect
-	cloud.google.com/go/compute v1.3.0 // indirect
 	cloud.google.com/go/datastore v1.1.0
-	cloud.google.com/go/iam v0.2.0 // indirect
 	cloud.google.com/go/security v1.2.0 // indirect
 	cloud.google.com/go/storage v1.26.0
 	github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter v0.4.6 // indirect
@@ -51,6 +49,7 @@ require (
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/improbable-eng/grpc-web v0.13.0
+	github.com/jackpal/gateway v1.0.7 // indirect
 	github.com/kataras/muxie v1.1.1
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/klauspost/compress v1.15.1 // indirect
@@ -91,7 +90,7 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/tools v0.1.9 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/api v0.68.0
+	google.golang.org/api v0.94.0
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -707,6 +707,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
+github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/proxy/ptunnel/BUILD.bazel
+++ b/proxy/ptunnel/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//lib/retry:go_default_library",
         "//proxy/nasshp:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_jackpal_gateway//:go_default_library",
     ],
 )
 

--- a/proxy/ptunnel/tunnel_test.go
+++ b/proxy/ptunnel/tunnel_test.go
@@ -194,22 +194,22 @@ func TestHostLookup(t *testing.T) {
 	})
 }
 
-func TestShouldTunnel(t *testing.T) {
+func TestTunnelTypeForHost(t *testing.T) {
 	testCases := []struct {
-		desc         string
-		host         string
-		shouldTunnel bool
-		wantErr      string
+		desc    string
+		host    string
+		want    TunnelType
+		wantErr string
 	}{
 		{
-			desc:         "false for external URL",
-			host:         "www.enfabrica.net",
-			shouldTunnel: false,
+			desc: "no tunnel required for external URL",
+			host: "www.enfabrica.net",
+			want: TunnelTypeNone,
 		},
 		{
-			desc:         "true for internal URL",
-			host:         "anything.local.enfabrica.net",
-			shouldTunnel: true,
+			desc: "local tunnel for localhost URL",
+			host: "anything.local.enfabrica.net",
+			want: TunnelTypeLocal,
 		},
 		{
 			desc:    "error for non-existent URL",
@@ -219,12 +219,12 @@ func TestShouldTunnel(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, gotErr := ShouldTunnel(tc.host)
+			got, gotErr := TunnelTypeForHost(tc.host)
 			errdiff.Check(t, gotErr, tc.wantErr)
 			if gotErr != nil {
 				return
 			}
-			assert.Equal(t, got, tc.shouldTunnel)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
When doing `enkit outputs mount`, the destination host resolves to an IP in the network due to DNS spoofing to redirect traffic to a persistent tunnel. The logic correctly recognizes that it does not need to create an additional tunnel, but then attempts to connect to the remote port (traefik on 8080, in this case) rather than the persistent tunnel port (8001).

This change expands the tunnel decision logic to accommmodate the "persistent tunnel on the gateway" case. When this scenario is detected, no tunnel will be created, but the port will be replaced with `tunnelPort` in the returned value. By setting the `--tunnel-listen-port` flag, the target port can be changed to the port the tunnel on the gateway is listening on.

Tested:
* `bazel build //guidelines/...`
* `enkit outputs mount -i 07dc68b2-56b6-4f9f-bb93-a88bb7bb5003 --loglevel-console=debug --tunnel-listen-port=8001`
  * Saw correct debug log message
* Confirm all files are readable: `find ~/outputs/07dc68b2-56b6-4f9f-bb93-a88bb7bb5003/ -type f | xargs md5sum`

Jira: INFRA-2343