### PR TITLE
enkit outputs: Change default tunnel port

### DIFF
--- a/enkit/outputs/commands.go
+++ b/enkit/outputs/commands.go
@@ -75,7 +75,7 @@ func NewRoot(base *client.BaseFlags) (*Root, error) {
 	rc.PersistentFlags().StringVar(&rc.BuildBuddyUrl, "buildbuddy-url", "", "build buddy url instance")
 	rc.PersistentFlags().StringVar(&rc.BuildbarnHost, "buildbarn-host", "", "host:port of BuildBarn instance")
 	rc.PersistentFlags().StringVar(&rc.BuildbarnTunnelTarget, "buildbarn-tunnel-target", "", "If a tunnel is required, this is the endpoint that should be tunnelled to")
-	rc.PersistentFlags().IntVar(&rc.TunnelListenPort, "tunnel-listen-port", 8822, "If a tunnel is required, this is the local port the tunnel listens on for connections")
+	rc.PersistentFlags().IntVar(&rc.TunnelListenPort, "tunnel-listen-port", 8001, "If a tunnel is required, this is the local port the tunnel listens on for connections")
 	rc.PersistentFlags().StringVar(&rc.GatewayProxy, "gateway-proxy", "", "If a tunnel is used, gateway proxy to tunnel through")
 	return rc, nil
 }


### PR DESCRIPTION
This change modifies the default tunnel port to match that of the one used for tunneling to buildbarn. This does not cause conflicts, as both the bazel profile script and this code starts a persistent background tunnel, and continues gracefully if the tunnel already exists.

Jira: INFRA-2122