### PR TITLE
gee pr_checks: capture URL for buildbuddy

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3854,7 +3854,7 @@ function gee__pr_check() {
       local BUILD
       for BUILD in "${FAILED_BUILDS[@]}"; do
         _warn "Failed build: ${BUILD}"
-        gcloud builds log "${BUILD}" | grep -i FAILED
+        gcloud builds log "${BUILD}" | grep -i -E "(failed:|error:|streaming build results to:)"
       done
     fi
   fi


### PR DESCRIPTION
This change saves the user a little time when debugging presubmit failures.
`gee pr_checks` now reports a summary of the error messages from the
presubmit job, including the line that contains a URL that points to
the specific buildbuddy page that contains the information the user
probably needs to fix the issue.

Tested: Ran the updated pr_checks command in a branch with a build failure.

