### PR TITLE
remote: Use "target" config instead of "host" for remote_run rule

### DIFF
--- a/bazel/utils/remote.bzl
+++ b/bazel/utils/remote.bzl
@@ -420,7 +420,7 @@ export_and_run_rule = rule(
     executable = True,
     attrs = dict(_common_attrs(), **{
         "target": attr.label(
-            cfg = "host",
+            cfg = "target",
             doc = "Target to execute on the remote machine",
         ),
         "inputs": attr.label(


### PR DESCRIPTION
The reference below gets into more details, but the dependencies of a remote_run rule are really runtime dependencies that need to be compiled for the target architecture. We want the dependencies to be built as if they were built as a top-level target on the remote machine. While tools might follow the "exec" config, that does not apply here either.

Ref: https://bazel.build/extending/rules#configurations
Jira: SF-478

Signed-off-by: Raghu Raja <raghu@enfabrica.net>