### PR TITLE
gee: add `recover_stashes` command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4897,8 +4897,7 @@ function gee__recover_stashes() {
   i=0
   while (( i < ${#COMMITS[@]} )); do
     commit="${COMMITS[$i]}"
-    # echo "Trying commit $((i+1))/${#COMMITS[@]}: ${commit}"
-    if grep -q "${SEARCH_FOR}" < <(git show "${commit}" || /bin/true); then
+    if git show "${commit}" | grep -q "${SEARCH_FOR}"; then
       MATCHES+=("${commit}")
     fi
     i=$(( i + 1 ))

--- a/scripts/gee
+++ b/scripts/gee
@@ -1153,7 +1153,13 @@ function _read_cmd() {
       printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" "${ESCAPED_CMD}"
     fi
     set +e
-    mapfile -t "${VAR}" < <("$@"; printf "%d\n" "$?")
+    mapfile -t "${VAR}" < <(
+      # use "if" statement to avoid ERR trap.
+      if ! "$@"; then
+        printf "%d\n" "$?";
+      else
+        printf "%d\n" "$?";
+      fi)
     local TMP
     TMP="${VAR}[-1]"
     RC="${!TMP}"  # indirect
@@ -4905,7 +4911,7 @@ function gee__recover_stashes() {
 
   echo "Found ${#MATCHES[@]} matches."
   for t in "${MATCHES[@]}"; do
-    echo $(git show --format="format:%at %H %ad" -s "${t}")
+    git show --format=$'format:%at %H %ad\n' -s "${t}"
   done | sort -n | awk '{$1=" "; print $0}'
   _info "Remove ${FSCKFILE} if you no longer need it."
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -4844,10 +4844,34 @@ _register_help "recover_stashes" "Recover identifiers for old, dropped stashes."
 <<'EOT'
 Usage: recover_stashes <"optional string to search for">
 
-The `recover_stashes` command searches your git repo for commits associated
-with old stashed changes that may have been already dropped (ie. are no
-longer listed in `git stash list`).  It reports them as a list, sorted by
-date.
+The `recover_stashes` command is useful if you accidentally dropped some
+stashed changes that you wanted to hold onto.  Even dropped stashes
+can be recovered if you know the right hash for the stash, and this
+command helps you discover them.
+
+By default, `recover_stashes` will print the hash ids for all stashes
+in your repo, sorted by author-date.  Any additional options are used
+to filter the commits (ie. by filename or file contents).
+
+Results are reported as a list of commits and their author-dates.
+
+For example:
+
+    $ gee recover_stashes enkit
+    Created temporary FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Searching your repo for discarded stash commits...
+    Checking object directories: 100% (256/256), done.
+    Checking objects: 100% (8266/8266), done.
+    Cached search results to FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Found 58 commits.
+    Filtering candidate commits...
+    Found 4 matches.
+      914c9f7f2a43e34c8b1f8ac26f478d4a3ae66c46 Sat Sep 24 12:56:57 2022 -0700
+      7b81aec0ed7806963e79bd2b236523aba57405a7 Tue Oct 4 07:33:03 2022 +0000
+      b957986e8044e8b3097591bae25dfee04e567469 Tue Oct 4 09:32:05 2022 -0700
+      184e791a27fe0f2dd3a7c87a7a9ea4c384d498e7 Thu Oct 6 06:01:44 2022 +0000
+    Remove /tmp/stashes-jonathan.0JTAXI if you no longer need it.
+
 EOT
 
 function gee__recover_stashes() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -4837,6 +4837,58 @@ function gee__restore_all_branches() {
 }
 
 ##########################################################################
+# recover_stashes
+##########################################################################
+
+_register_help "recover_stashes" "Recover identifiers for old, dropped stashes." \
+<<'EOT'
+Usage: recover_stashes <"optional string to search for">
+
+The `recover_stashes` command searches your git repo for commits associated
+with old stashed changes that may have been already dropped (ie. are no
+longer listed in `git stash list`).  It reports them as a list, sorted by
+date.
+EOT
+
+function gee__recover_stashes() {
+  local SEARCH_FOR="$*"
+
+  if [[ -z "${FSCKFILE}"  ]]; then
+    FSCKFILE="$(mktemp /tmp/stashes-"$USER".XXXXXX)"
+    _info "Created temporary FSCKFILE=${FSCKFILE}"
+  fi
+
+  if [[ ! -s "${FSCKFILE}" ]]; then
+    _info "Searching your repo for discarded stash commits..."
+    git fsck --no-reflog | awk '/dangling commit/ {print $3}' > "${FSCKFILE}"
+    _info "Cached search results to FSCKFILE=${FSCKFILE}"
+  fi
+
+  local -a COMMITS
+  mapfile -t COMMITS < "${FSCKFILE}"
+  echo "Found ${#COMMITS[*]} commits."
+
+  _info "Filtering candidate commits..."
+  local -a MATCHES=()
+  i=0
+  while (( i < ${#COMMITS[@]} )); do
+    commit="${COMMITS[$i]}"
+    # echo "Trying commit $((i+1))/${#COMMITS[@]}: ${commit}"
+    if grep -q "${SEARCH_FOR}" < <(git show "${commit}" || /bin/true); then
+      MATCHES+=("${commit}")
+    fi
+    i=$(( i + 1 ))
+  done
+
+  echo "Found ${#MATCHES[@]} matches."
+  for t in "${MATCHES[@]}"; do
+    echo $(git show --format="format:%at %H %ad" -s "${t}")
+  done | sort -n | awk '{$1=" "; print $0}'
+  _info "Remove ${FSCKFILE} if you no longer need it."
+}
+
+
+##########################################################################
 # bash_setup command
 ##########################################################################
 

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -7,6 +7,7 @@
 * Re-enable `--autostash` behavior when rebasing (#780)
 * Improve error reporting (#778)
 * `gee pr_checks`: report the buildbuddy URL on failure (#788)
+* `gee recover_stashes`: helps users recover dropped stashes (#791)
 
 ### 0.2.36
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -120,6 +120,7 @@ review.
 | <a href="#pr_rollback">`pr_rollback`</a> | Create a rollback PR for a specified PR. |
 | <a href="#pr_submit">`pr_submit`</a> | Merge the approved PR into the parent branch. |
 | <a href="#pr_view">`pr_view`</a> | View an existing pull request. |
+| <a href="#recover_stashes">`recover_stashes`</a> | Recover identifiers for old, dropped stashes. |
 | <a href="#remove_branch">`remove_branch`</a> | Remove a branch. |
 | <a href="#repair">`repair`</a> | Repair your gee workspace. |
 | <a href="#restore_all_branches">`restore_all_branches`</a> | Check out all remote branches. |
@@ -657,6 +658,38 @@ to restore those branches.
 
 Note that gee isn't able to restore parentage metadata in this way.  Be
 sure to invoke `gee set_parent` in branches that benefit from this.
+
+### recover_stashes
+
+Usage: `recover_stashes <"optional string to search for">`
+
+The `recover_stashes` command is useful if you accidentally dropped some
+stashed changes that you wanted to hold onto.  Even dropped stashes
+can be recovered if you know the right hash for the stash, and this
+command helps you discover them.
+
+By default, `recover_stashes` will print the hash ids for all stashes
+in your repo, sorted by author-date.  Any additional options are used
+to filter the commits (ie. by filename or file contents).
+
+Results are reported as a list of commits and their author-dates.
+
+For example:
+
+    $ gee recover_stashes enkit
+    Created temporary FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Searching your repo for discarded stash commits...
+    Checking object directories: 100% (256/256), done.
+    Checking objects: 100% (8266/8266), done.
+    Cached search results to FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Found 58 commits.
+    Filtering candidate commits...
+    Found 4 matches.
+      914c9f7f2a43e34c8b1f8ac26f478d4a3ae66c46 Sat Sep 24 12:56:57 2022 -0700
+      7b81aec0ed7806963e79bd2b236523aba57405a7 Tue Oct 4 07:33:03 2022 +0000
+      b957986e8044e8b3097591bae25dfee04e567469 Tue Oct 4 09:32:05 2022 -0700
+      184e791a27fe0f2dd3a7c87a7a9ea4c384d498e7 Thu Oct 6 06:01:44 2022 +0000
+    Remove /tmp/stashes-jonathan.0JTAXI if you no longer need it.
 
 ### bash_setup
 

--- a/scripts/git_recover_stash
+++ b/scripts/git_recover_stash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+SEARCH_FOR="$*"
+
+if [[ -z "${FSCKFILE}"  ]]; then
+  FSCKFILE="$(mktemp /tmp/stashes-"$USER".XXXXXX)"
+  echo "Creating temporary FSCKFILE=${FSCKFILE}"
+fi
+
+if [[ ! -s "${FSCKFILE}" ]]; then
+  git fsck --no-reflog | awk '/dangling commit/ {print $3}' > "${FSCKFILE}"
+  echo "Caching git fsck results to FSCKFILE=${FSCKFILE}"
+fi
+
+declare -a COMMITS
+mapfile -t COMMITS < "${FSCKFILE}"
+echo "Found ${#COMMITS[*]} commits."
+
+declare -a MATCHES=()
+i=0
+while (( i < ${#COMMITS[@]} )); do
+  commit="${COMMITS[$i]}"
+  # echo "Trying commit $((i+1))/${#COMMITS[@]}: ${commit}"
+  if grep -q "${SEARCH_FOR}" < <(git show "${commit}"); then
+    MATCHES+=("${commit}")
+  fi
+  i=$(( i + 1 ))
+done
+
+echo "Found ${#MATCHES[@]} matches."
+for t in "${MATCHES[@]}"; do
+  echo $(git show --format="format:%at %H %ad" -s "${t}")
+done | sort -n | awk '{$1=" "; print $0}'
+


### PR DESCRIPTION
A user recently had an issue where they had dropped some stashed
changed that they wanted to hold onto.  This PR automates the
process of discovering the identifiers necessary to recover
dropped stashed changes.

Tested: manually:

    $ ./gee recover_stashes enkit
    Created temporary FSCKFILE=/tmp/stashes-jonathan.0JTAXI
    Searching your repo for discarded stash commits...
    Checking object directories: 100% (256/256), done.
    Checking objects: 100% (8266/8266), done.
    Cached search results to FSCKFILE=/tmp/stashes-jonathan.0JTAXI
    Found 58 commits.
    Filtering candidate commits...
    Found 4 matches.
      914c9f7f2a43e34c8b1f8ac26f478d4a3ae66c46 Sat Sep 24 12:56:57 2022 -0700
      7b81aec0ed7806963e79bd2b236523aba57405a7 Tue Oct 4 07:33:03 2022 +0000
      b957986e8044e8b3097591bae25dfee04e567469 Tue Oct 4 09:32:05 2022 -0700
      184e791a27fe0f2dd3a7c87a7a9ea4c384d498e7 Thu Oct 6 06:01:44 2022 +0000
    Remove /tmp/stashes-jonathan.0JTAXI if you no longer need it.

I also:
  - created a stash
  - dropped a stash
  - observed the stash show up in the recover_stashes log.
