### PR TITLE
astore/server/auth: create ssh certificates with user and user@domain.

### DIFF
--- a/astore/server/auth/auth.go
+++ b/astore/server/auth/auth.go
@@ -139,7 +139,9 @@ func (s *Server) Token(ctx context.Context, req *auth.TokenRequest) (*auth.Token
 			return nil, status.Errorf(codes.InvalidArgument, "PublicKey cannot be parsed as an ssh authorized key - %s", err)
 		}
 		var certMods []kcerts.CertMod
-		effectivePrincipals := append(s.principals, authData.Creds.Identity.Username)
+		effectivePrincipals := append([]string{}, s.principals...)
+		effectivePrincipals = append(effectivePrincipals, authData.Creds.Identity.Username)
+		effectivePrincipals = append(effectivePrincipals, authData.Creds.Identity.GlobalName())
 		for _, i := range authData.Identities {
 			effectivePrincipals = append(effectivePrincipals, i.GlobalName())
 			certMods = append(certMods, i.CertMod())

--- a/lib/kcerts/ssh_test.go
+++ b/lib/kcerts/ssh_test.go
@@ -97,7 +97,7 @@ func TestSSHAgent_Principals(t *testing.T) {
 	toBeSigned, toBeSignedPrivateKey, err := GenerateED25519()
 	assert.NoError(t, err)
 	// code of your test
-	principalList := []string{"foo", "bar", "baz"}
+	principalList := []string{"foo", "bar", "foo@enfabrica.net", "foo@ext.enfabrica.net", "baz"}
 	cert, err := SignPublicKey(sourcePrivKey, 1, principalList, 5*time.Hour, toBeSigned)
 	localCache := &cache.Local{
 		Root: tmpDir,


### PR DESCRIPTION
The goal is to allow using the domain name as part of the
policy handling.
