### PR TITLE
gee: fix an ERR trap

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3580,7 +3580,7 @@ function gee__pr_make() {
 
   local STATE NUMBER TITLE
   read -r STATE NUMBER TITLE < \
-    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED) \
+    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED || :) \
     || /bin/true  # don't fail if empty
   if [[ "${STATE}" == "OPEN" ]]; then
     _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \


### PR DESCRIPTION
Now that gee has proper ERR trap notification, I'm discovering a few unhandled
ERR traps (ie. places in the code where a command returns a non-zero exit code
that isn't explicitly checked / handled).

This single-line PR fixes one such unhandled return code.

Tested: manual testing confirms that the err trap is squashed.

