### PR TITLE
machinist: Flag off most machine configuration

### DIFF
--- a/machinist/config/machine.go
+++ b/machinist/config/machine.go
@@ -12,6 +12,12 @@ type Node struct {
 
 	RequireRoot bool
 
+	// BUG(INFRA-2550): Machinist can unpack files/scripts/config onto the host
+	// machine, but this is better managed out-of-band by another tool, such as
+	// Ansible or Puppet. If this bool is set, perform the legacy unpacking
+	// behavior.
+	ModifyMachineConfig bool
+
 	LibNssConfLocation string
 
 	// Pam Location configs

--- a/machinist/machine/commands.go
+++ b/machinist/machine/commands.go
@@ -43,6 +43,7 @@ func NewEnrollCommand(conf *config.Node) *cobra.Command {
 	}
 	// General Flags.
 	c.PersistentFlags().BoolVar(&conf.RequireRoot, "require-root", true, "should the enroll command require root for execution")
+	c.PersistentFlags().BoolVar(&conf.ModifyMachineConfig, "modify-machine-config", true, "perform additional setup (install libnss_autouser and config, PAM scripts, etc.)")
 
 	// NSS AutoUser flags.
 	c.PersistentFlags().StringVar(&conf.LibNssConfLocation, "nss-autouser-conf", "/etc/nss-autouser.conf", "the file location of libnss autouser configuration file")

--- a/machinist/machine/node.go
+++ b/machinist/machine/node.go
@@ -100,26 +100,30 @@ func (n *Machine) Enroll() error {
 		}
 	}
 
-	// Pam Installer Steps
-	n.Log.Infof("Executing Pam installation steps")
-	if err := InstallLibPam(n.Log); err != nil {
-		return err
-	}
-	if err := InstallPamSSHDFile(n.PamSSHDLocation, n.Log); err != nil {
-		return err
-	}
-	if err := InstallPamScript(n.PamSecurityLocation, n.Log); err != nil {
-		return err
-	}
+	if n.ModifyMachineConfig{
+		// Pam Installer Steps
+		n.Log.Infof("Executing Pam installation steps")
+		if err := InstallLibPam(n.Log); err != nil {
+			return err
+		}
+		if err := InstallPamSSHDFile(n.PamSSHDLocation, n.Log); err != nil {
+			return err
+		}
+		if err := InstallPamScript(n.PamSecurityLocation, n.Log); err != nil {
+			return err
+		}
 
-	//// Nss AutoUser Setup
-	if err := InstallNssAutoUserConf(n.LibNssConfLocation, &NssConf{
-		DefaultShell: "/bin/bash",
-	}); err != nil {
-		return err
-	}
-	if err := InstallNssAutoUser(n.Log); err != nil {
-		return err
+		//// Nss AutoUser Setup
+		if err := InstallNssAutoUserConf(n.LibNssConfLocation, &NssConf{
+			DefaultShell: "/bin/bash",
+		}); err != nil {
+			return err
+		}
+		if err := InstallNssAutoUser(n.Log); err != nil {
+			return err
+		}
+	} else {
+		n.Log.Infof("Skipping machine configuration steps, as ModifyMachineConfig was not set")
 	}
 
 	// SSHD installer steps


### PR DESCRIPTION
This change adds a new flag that disables much of the static machine configuration done, so that machinist does not fight with current/future puppet configuration on startup.

This flag defaults to true for backwards compatibility, and will have to be explicitly specified in Puppet.

Dynamic steps (writing out keys, certs, etc. received from the auth server at runtime) are not affected by this flag - only static configuration and installation steps are controlled.

Tested: `bazel build //machinist/cmd && bazel-bin/machinist/cmd/cmd_/cmd node enroll --require-root=false --loglevel-console=debug --modify-machine-config=false --auth-server=https://auth.corp.enfabrica.net --sshd-configuration-file=/tmp/machinist/sshd_config --ca-key-file=/tmp/machinist/ca.pub --host-key-file=/tmp/machinist/host_key`:

```
2022/11/03 20:00:01 [info] Skipping machine configuration steps, as ModifyMachineConfig was not set
2022/11/03 20:00:01 [info] Writing SSHD Configuration
2022/11/03 20:00:01 [info] Writing CA Public Key Configuration
2022/11/03 20:00:01 [info] Writing Host Cert
2022/11/03 20:00:01 [info] Writing Host Key
```

Jira: INFRA-2550