### PR TITLE
bestie: add invocation id to logs

### DIFF
--- a/bestie/server/test_result.go
+++ b/bestie/server/test_result.go
@@ -160,9 +160,9 @@ func handleTestResultEvent(bazelBuildEvent bes.BuildEvent, streamId *build.Strea
 		sbuf.WriteString(fmt.Sprintf("\tinvocationId: %s\n", stream.invocationId))
 		sbuf.WriteString(fmt.Sprintf("\tinvocationSha: %s\n", stream.invocationSha))
 		glog.Info(sbuf.String())
-  } else {
-    glog.Info(fmt.Sprintf("Processing invocationId: %s\n", stream.invocationId));
-  }
+	} else {
+		glog.Info(fmt.Sprintf("Processing invocationId: %s\n", stream.invocationId))
+	}
 
 	var errs []error
 	var fileName, fileUri string

--- a/bestie/server/test_result.go
+++ b/bestie/server/test_result.go
@@ -160,7 +160,9 @@ func handleTestResultEvent(bazelBuildEvent bes.BuildEvent, streamId *build.Strea
 		sbuf.WriteString(fmt.Sprintf("\tinvocationId: %s\n", stream.invocationId))
 		sbuf.WriteString(fmt.Sprintf("\tinvocationSha: %s\n", stream.invocationSha))
 		glog.Info(sbuf.String())
-	}
+  } else {
+    glog.Info(fmt.Sprintf("Processing invocationId: %s\n", stream.invocationId));
+  }
 
 	var errs []error
 	var fileName, fileUri string


### PR DESCRIPTION
Today, bestie log looks like this:

```
I1108 19:51:06.937045       1 test_result.go:110] Opened output file "test.xml" for processing
E1108 19:51:06.937236       1 test_result.go:201] Error extracting XML metrics: Unstructured XML test results not supported (use junitxml)
I1108 19:51:06.941944       1 test_result.go:110] Opened output file "test.xml" for processing
E1108 19:51:06.942796       1 test_result.go:201] Error extracting XML metrics: Unstructured XML test results not supported (use junitxml)
I1108 19:51:06.975101       1 test_result.go:110] Opened output file "test.xml" for processing
E1108 19:51:06.976956       1 test_result.go:201] Error extracting XML metrics: Unstructured XML test results not supported (use junitxml)
```

There's no way to tell which failure is associated with which invocation ID.  This
PR corrects this by logging the invocation ID at the beginning of each processing
iteration.

Tested:

bestie compiles.
bestie doesn't seem to have any tests, so I have no idea how to test this trivial change.

