### PR TITLE
gee: fix pr_checks output format

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3816,7 +3816,7 @@ function gee__pr_check() {
   printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" " ${GH} pr checks"  # show user what we're doing
   while [[ "${PENDING}" -ne 0 ]]; do
     if VERBOSE=0 DONT_WARN=1 _read_cmd CHECKS "${GH}" pr checks; then
-      printf "%s\n" "${CHECKS[@]}" | column -t >&2
+      printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
       # no failures, nothing pending.
       _info "All checks successful."
       CHECKS_FAILED=0
@@ -3826,7 +3826,7 @@ function gee__pr_check() {
       _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
       # Only inform the user when a result changes:
       if [[ "${PREV_CHECKS}" != "${CHECKS[*]}"  ]]; then
-        printf "%s\n" "${CHECKS[@]}" | column -t >&2
+        printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
         PREV_CHECKS="${CHECKS[*]}"
         local REPORT="gh pr checks:"
         local KEY

--- a/scripts/gee
+++ b/scripts/gee
@@ -3748,7 +3748,7 @@ EndOfPrTemplate
 
 _register_help "pr_check" \
   "Checks the status of presubmit tests for a PR." \
-  "pr_checks" "check_pr" <<'EOT'
+  "pr_checks" "check_pr" "check" "checks" <<'EOT'
 Usage: gee pr_check [--wait]
 
 Returns the state of presubmit checks.  If the --wait option is provided,
@@ -3798,6 +3798,8 @@ function _parse_gh_pr_checks() {
 }
 
 function gee__check_pr() { gee__pr_check "$@"; }
+function gee__check() { gee__pr_check "$@"; }
+function gee__checks() { gee__pr_check "$@"; }
 function gee__pr_checks() { gee__pr_check "$@"; }
 function gee__pr_check() {
   _startup_checks "pr_check"
@@ -3957,7 +3959,7 @@ function gee__pr_submit() {
   fi
 
   # Presubmit check: Are presubmit checks passing?
-  if ! gee__pr_check; then
+  if ! gee__pr_check "$@"; then
     if ! _confirm_default_no \
       "Presubmit checks did not succeed.  Proceed anyway? (y/N)  "; then
       _fatal "PR submission aborted."

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -478,7 +478,7 @@ Uses the same options as "gh pr create".
 
 ### pr_check
 
-Aliases: pr_checks check_pr
+Aliases: pr_checks check_pr check checks
 
 Usage: `gee pr_check [--wait]`
 


### PR DESCRIPTION
`gh pr checks` reports data formatted like this:

```
triage  pass    4s      https://github.com/enfabrica/internal/actions/runs/3588585723/jobs/6040131746
Pushes-preview-version-of-web-pages (cloud-build-290921)        skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
external-dependencies (cloud-build-290921)      skipping        0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
experimental-bazel-presubmit (cloud-build-290921)       pass    7m48s   https://console.cloud.google.com/cloud-build/builds/da0cf69c-6612-431b-9ea2-8fec49ef800a?project=496137108493
linter-checks (cloud-build-290921)      pass    34s     https://console.cloud.google.com/cloud-build/builds/9c2662d4-08f2-450a-b3b9-fa659b5c5563?project=496137108493
```

`triage` is missing a parentehsis cloud-build job id.  The optional
`(cloud-build-NNNN)` token trips up tabular formatting implemented by the
`column -t` command, and doesn't add any useful information, so I've filtered
it out to produce more readable information.

Tested:

The old output of `gee pr_checks` looked like this:

```
$ gee pr_checks
CMD: /usr/bin/gh pr checks
triage                               pass                  4s        https://github.com/enfabrica/internal/actions/runs/3588585723/jobs/6040131746
Pushes-preview-version-of-web-pages  (cloud-build-290921)  skipping  0                                                                              https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
external-dependencies                (cloud-build-290921)  skipping  0                                                                              https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
experimental-bazel-presubmit         (cloud-build-290921)  pass      7m48s                                                                          https://console.cloud.google.com/cloud-build/builds/da0cf69c-6612-431b-9ea2-8fec49ef800a?project=496137108493
linter-checks                        (cloud-build-290921)  pass      34s                                                                            https://console.cloud.google.com/cloud-build/builds/9c2662d4-08f2-450a-b3b9-fa659b5c5563?project=496137108493
All checks successful.
```

The new output of `gee pr_checks` looks like this:

```
$ /home/jonathan/gee/enkit/gee_checks_formating/scripts/gee pr_checks --wait
CMD: /usr/bin/gh pr checks
triage                               pass      4s     https://github.com/enfabrica/internal/actions/runs/3588585723/jobs/6040131746
Pushes-preview-version-of-web-pages  skipping  0      https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
external-dependencies                skipping  0      https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
experimental-bazel-presubmit         pass      7m48s  https://console.cloud.google.com/cloud-build/builds/da0cf69c-6612-431b-9ea2-8fec49ef800a?project=496137108493
linter-checks                        pass      34s    https://console.cloud.google.com/cloud-build/builds/9c2662d4-08f2-450a-b3b9-fa659b5c5563?project=496137108493
All checks successful.

```

