### PR TITLE
lib/bazel: implement an included_tags, to limit to a subset of targets.

### DIFF
--- a/enkit/proto/presubmit.proto
+++ b/enkit/proto/presubmit.proto
@@ -15,4 +15,10 @@ message PresubmitConfig {
 
   // Exclude targets that have at least one of these tags from build and test.
   repeated string exclude_tags = 3;
+
+  // Only include targets that have at least one of those tags.
+  //
+  // If both exclude_tags and include_tags are specified, a target will only
+  // be run if it both has an include_tags, and does NOT have an exclude_tags.
+  repeated string include_tags = 4;
 }

--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -64,6 +64,7 @@ func GetAffectedTargets(config *ppb.PresubmitConfig, mode GetMode, opts GetModeO
 		return nil, nil, err
 	}
 	excludeTags := config.GetExcludeTags()
+        includeTags := config.GetIncludeTags()
 
 	// Open the bazel workspaces, using a temporary output_base. Since the
 	// temporary worktrees created above will have a different path on every
@@ -149,6 +150,21 @@ skipTarget:
 				continue skipTarget
 			}
 		}
+
+		if len(includeTags) > 0 {
+			isIncluded := false
+			for _, t := range includeTags {
+				if target.containsTag(t) {
+					isIncluded = true
+					break
+				}
+			}
+			if !isIncluded {
+				log.Debugf("Filtering taget that does not include any of the included tags %q: %q", includeTags, targetName)
+				continue skipTarget
+			}
+		}
+
 		changedRules = append(changedRules, target)
 		if strings.HasSuffix(target.ruleType(), "_test") {
 			changedTests = append(changedTests, target)


### PR DESCRIPTION
In this PR:
- add support to only execute tests *including* at least one of the
  specified tags.
