### PR TITLE
proxy/ptunnel: fix handling of timeouts on upload heavy flows.

### DIFF
--- a/proxy/ptunnel/tunnel.go
+++ b/proxy/ptunnel/tunnel.go
@@ -519,6 +519,8 @@ outer:
 			if len(buffer) == 0 {
 				break
 			}
+
+			conn.SetWriteDeadline(t.timeouts.Now().Add(t.timeouts.BrowserWriteTimeout))
 		}
 
 		if err := writer.Close(); err != nil {


### PR DESCRIPTION
See INFRA-3039 for details on the problem. Tl;Dr: observing connections
dropping continuously and not resuming with upload heavy flows from
some locations.

Problem:
- golang APIs express timeouts in absolute values, by setting a "deadline".
  If writes do not complete by the deadline, writes in progress or
  subsequent writes will fail.
- The code is structured so that it reads data from a file descriptor
  on one side, and writes it to the server on the other.
- This writing loop is structured in two parts: "wait for data to be
  ready", "flush it all to the remote server". "flush it all" loops
  over the input buffer, and keeps sending until empty. But if the
  reading thread keeps filling it, the loop may never complete, and
  it is guaranteed to time out.

Bug:
The intended deadline behavior was to timeout individual writes, not
to time out the overall loop, albheit slow.

In this PR:
Reset the timeout after every successful write, similar to what we do
in other snippets of code around the tunnel and the proxy.
