### PR TITLE
astore server: Update to go 1.19

### DIFF
--- a/astore/server/BUILD.bazel
+++ b/astore/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_go//extras:embed_data.bzl", "go_embed_data")
 load("//bazel/appengine:defs.bzl", "go_appengine_deploy")
 
@@ -40,15 +40,6 @@ go_binary(
     name = "server",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
-)
-
-# This target exists to ensure that the server binary builds with the version of
-# the Go SDK that supports AppEngine, which guards against e.g. third-party
-# dependencies that have newer Go SDK requirements.
-go_cross_binary(
-    name = "server_appengine",
-    sdk_version = "1.16",
-    target = ":server",
 )
 
 # Generate a .go file containing all the credentials supplied during the build.

--- a/astore/server/deploy/app.yaml
+++ b/astore/server/deploy/app.yaml
@@ -1,5 +1,5 @@
 env: standard
-runtime: go116
+runtime: go119
 instance_class: F1
 automatic_scaling:
   max_instances: 1


### PR DESCRIPTION
AppEngine now supports go 1.19! This change updates the runtime in app.yaml, and removes the target that enforces a build for go 1.16.

Tested: no

Jira: INFRA-3479