### PR TITLE
gee: add grep command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2404,7 +2404,7 @@ command.
 
 Example of use:
 
-    grg -t bazel unit_test
+    grg -l fdst
 
 EOT
 function gee__grep() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -2408,6 +2408,8 @@ Example of use:
 
 EOT
 function gee__grep() {
+  # The GEE_NO_RIPGREP environment variable is available for testing, to force
+  # the use of grep without requiring that ripgrep be uninstalled.
   _startup_checks "grep"
   _check_cwd
 
@@ -2415,7 +2417,7 @@ function gee__grep() {
   CURRENT_BRANCH="$(_get_current_branch)"
   BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
 
-  if command -v rg > /dev/null; then
+  if [[ "${GEE_NO_RIPGREP}" == "" ]] && command -v rg > /dev/null; then
     NOFAIL=1 _cmd rg "$@" "${BRANCH_ROOT_DIR}"
   else
     NOFAIL=1 _cmd grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -2382,6 +2382,47 @@ function gee__diff() {
 }
 
 ##########################################################################
+# grep command
+##########################################################################
+
+_register_help "grep" "Greps the current branch." <<'EOT'
+Usage: gee grep [options] <expression>
+
+Searches the current branch for the specified expression.
+
+If the ripgrep tool is installed, then this command invokes:
+
+    rg "$@" "${BRANCH_ROOT_DIR}"
+
+If ripgrep is not installed, this command falls back on the grep utility,
+invoked to be similar in operation to ripgrep, like this:
+
+    grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"
+
+If the `gee bash_setup` environment is loaded, `grg` is an alias for this
+command.
+
+Example of use:
+
+    grg -t bazel unit_test
+
+EOT
+function gee__grep() {
+  _startup_checks "grep"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  if command -v rg > /dev/null; then
+    NOFAIL=1 _cmd rg "$@" "${BRANCH_ROOT_DIR}"
+  else
+    NOFAIL=1 _cmd grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"
+  fi
+}
+
+##########################################################################
 # pack command
 ##########################################################################
 
@@ -3195,7 +3236,7 @@ function gee__revert() {
   _startup_checks "revert"
 
   _check_cwd
-  local CURRENT_BRANCH
+  local CURRENT_BRANCH CURRENT_ROOT
   CURRENT_BRANCH="$(_get_current_branch)"
   CURRENT_ROOT="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
   local PARENT_BRANCH
@@ -5004,6 +5045,10 @@ function gcd() {
   fi
   export BROOT="$(git rev-parse --show-toplevel)"
   export BRBIN="${BROOT}/bazel-bin"
+}
+
+function grg() {
+  gee grep "$@"
 }
 
 function _gee_completion_branches() {

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -103,6 +103,7 @@ review.
 | <a href="#fix">`fix`</a> | Run automatic code formatters over changed files only. |
 | <a href="#gcd">`gcd`</a> | Change directory to another branch. |
 | <a href="#get_parent">`get_parent`</a> | Which branch is this branch branched from? |
+| <a href="#grep">`grep`</a> | Greps the current branch. |
 | <a href="#hello">`hello`</a> | Check connectivity to github. |
 | <a href="#help">`help`</a> | Print more help about a command. |
 | <a href="#init">`init`</a> | initialize a new git workspace |
@@ -187,6 +188,28 @@ Usage: `gee diff [<files...>]`
 Shows all local changes this since branch diverged from its parent branch.
 
 If <files...> are omited, shows changes to all files.
+
+### grep
+
+Usage: `gee grep [options] <expression>`
+
+Searches the current branch for the specified expression.
+
+If the ripgrep tool is installed, then this command invokes:
+
+    rg "$@" "${BRANCH_ROOT_DIR}"
+
+If ripgrep is not installed, this command falls back on the grep utility,
+invoked to be similar in operation to ripgrep, like this:
+
+    grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"
+
+If the `gee bash_setup` environment is loaded, `grg` is an alias for this
+command.
+
+Example of use:
+
+    grg -l fdst
 
 ### pack
 


### PR DESCRIPTION
This is a shortcut for invoking ripgrep over the entire current branch.
If ripgrep is not installed, this command falls back on the grep utility.

I guess I've been doing this operation several times a day, so it felt
useful (to me) to include as a shortcut in gee.

Tested: Installed locally and tested manually.  The hidden `GEE_NO_RIPGREP`
environment variable is used to demonstrate the "fallback on grep"
functionality.

```
$ grg fdst
CMD: rg fdst /home/jonathan/gee/enkit/gee_grep
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go
23:     fdst, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, 0660)
27:     defer fdst.Close()
29:     _, err = io.Copy(fdst, fsrc)
34:     if err := fdst.Sync(); err != nil {
38:     return fdst.Close()

$ GEE_NO_RIPGREP=1 grg fdst
CMD: grep -r --exclude-dir=.git fdst /home/jonathan/gee/enkit/gee_grep
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go:       fdst, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, 0660)
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go:       defer fdst.Close()
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go:       _, err = io.Copy(fdst, fsrc)
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go:       if err := fdst.Sync(); err != nil {
/home/jonathan/gee/enkit/gee_grep/bazel/appengine/deploy/main.go:       return fdst.Close()

```

