### PR TITLE
gee bazelgc: handle very long lists of files to delete

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4585,6 +4585,7 @@ function gee__bazelgc() {
 
   if [[ -d ~/.cache/bazel-disk-cache ]]; then
     local -a OLD=()
+    local i
     mapfile -d '' OLD < \
       <(find ~/.cache/bazel-disk-cache \( -type f -o -type l \) -atime +3 -print0)
     if [[ "${#OLD[@]}" == 0 ]]; then
@@ -4594,7 +4595,13 @@ function gee__bazelgc() {
       if _confirm_default_no "Proceed? (y/N)  "; then
         local USED1
         USED1="$(df -k --output=used ~/.cache | tail -1)"
-        rm -f "${OLD[@]}"
+        # Unfortunately the OLD list might be longer than ARG_MAX, so we break
+        # this list up to delete files in batches of 100.
+        for i in $(seq 0 100 ${#OLD[@]}); do
+          local -a OLD_SLICE
+          OLD_SLICE=( "${OLD[@]:${i}:100}" )
+          rm -f "${OLD_SLICE[@]}"
+        done
         USED2="$(df -k --output=used ~/.cache | tail -1)"
         MBFREED="$(( (USED1 - USED2) / 1024 ))"
         _info "Approximately ${MBFREED}MiB freed."

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.38"
+readonly VERSION="0.2.39"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,11 @@
 
 ## Releases
 
+### 0.2.39
+
+* gee bazelgc: also prune old files from ~/.cache/bazel-disk-cache (#813)
+* gee grep: new command, easily search a git branch using grep or ripgrep (#811)
+
 ### 0.2.38
 
 Cosmetic improvements:

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.38
+gee version: 0.2.39
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
Unfortunately, in the real world:

```
$ gee bazelgc
No ~/.cache/bazel directories to delete.
About to delete 21053 old entries from ~/.cache/bazel-disk-cache
Proceed? (y/N)  y
/home/jonathan/bin/gee: line 4597: /usr/bin/rm: Argument list too long
Approximately 0MiB freed.
```

Looks like we ran into the ARG_MAX limit of the bash command line.  To work
around this issue, I've modified gee to delete files in batches of 100 files
per rm invocation.

Tested: Installed and re-ran in the same directory:

```
$ gee bazelgc
No ~/.cache/bazel directories to delete.
About to delete 21053 old entries from ~/.cache/bazel-disk-cache
Proceed? (y/N)  y
Approximately 6190MiB freed.
```

