### PR TITLE
flextape: Update the flextape version

### DIFF
--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:4bd2e371a31b6735539a215ee7143609e64807408c33b7c579d65d326585dac1"
+  "gcr.io/devops-284019/infra/flextape@sha256:17b71d9260fddbaa1f730c66ef7242338815e2a234bec488932d29e48e0f6431"


### PR DESCRIPTION
Update the docker image hash for the deployed version of flextape on infra-04.sea

Tested:
- Deployed on infra-04.sea with correct license counts. However, the `jasper_fao` license feature just expired today after my pull request https://github.com/enfabrica/internal/pull/12931 was merged. Argh, I will create a silence and schedule another flextape update for `jasper_fao`.

License Alerting:
```
[FIRING:4, RESOLVED:5] (P1)
**Firing**

Value: B=2, C=1
Labels:
- alertname = flextape license count drift
- grafana_folder = infra_services
- license_type = cadence::jasper_fao
- priority = P1
```

JIRA: INFRA-3994