### PR TITLE
tools/codegen: add case handling extension in jinja2.

### DIFF
--- a/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
@@ -63,6 +63,8 @@ enkit/../python_dependencies_jinja2/jinja2/sandbox.py
 enkit/../python_dependencies_jinja2/jinja2/tests.py
 enkit/../python_dependencies_jinja2/jinja2/utils.py
 enkit/../python_dependencies_jinja2/jinja2/visitor.py
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase/__init__.py
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase/jinja2_strcase.py
 enkit/../python_dependencies_jsonschema/jsonschema/__init__.py
 enkit/../python_dependencies_jsonschema/jsonschema/__main__.py
 enkit/../python_dependencies_jsonschema/jsonschema/_format.py
@@ -261,6 +263,10 @@ enkit/../python_dependencies_markupsafe/markupsafe/_speedups.c
 enkit/../python_dependencies_markupsafe/markupsafe/_speedups.cpython-38-x86_64-linux-gnu.so
 enkit/../python_dependencies_markupsafe/markupsafe/_speedups.pyi
 enkit/../python_dependencies_markupsafe/markupsafe/py.typed
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase-0.0.2.dist-info/LICENSE
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase-0.0.2.dist-info/METADATA
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase-0.0.2.dist-info/WHEEL
+enkit/../python_dependencies_jinja2_strcase/jinja2_strcase-0.0.2.dist-info/top_level.txt
 enkit/tools/codegen/tests/data.yaml
 enkit/tools/codegen/tests/test.template
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-actions.h

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs==21.4.0
 importlib-metadata==4.11.3
 importlib-resources==5.7.1
 jinja2==3.1.1
+jinja2-strcase==0.0.2
 jsonschema==4.4.0
 linkify-it-py==1.0.3
 markdown-it-py==2.1.0

--- a/tools/codegen/BUILD.bazel
+++ b/tools/codegen/BUILD.bazel
@@ -49,6 +49,7 @@ py_binary(
         ":data_loader",
         requirement("absl-py"),
         requirement("jinja2"),
+        requirement("jinja2-strcase"),
         requirement("jsonschema"),
         requirement("markupsafe"),
         requirement("pyyaml"),

--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -100,7 +100,7 @@ class Template(data_loader.DataLoader):
         super(Template, self).__init__()
         search_paths = ["."] + FLAGS.incdir
         self.env = jinja2.Environment(
-            extensions=["jinja2.ext.do", "jinja2.ext.loopcontrols", "jinja2.ext.debug", RaiseExtension],
+            extensions=["jinja2.ext.do", "jinja2.ext.loopcontrols", "jinja2.ext.debug", "jinja2_strcase.StrcaseExtension", RaiseExtension],
             loader=jinja2.FileSystemLoader(search_paths),
             keep_trailing_newline=True,
             autoescape=False,

--- a/tools/codegen/tests/d2-test.expected
+++ b/tools/codegen/tests/d2-test.expected
@@ -1,6 +1,7 @@
 over=rides
 zoo=zebra
 foo=bar
+camel=BAR
   bum: x
   bum: y
   bum: z

--- a/tools/codegen/tests/gen-test.expected
+++ b/tools/codegen/tests/gen-test.expected
@@ -1,6 +1,7 @@
 over=rides
 zoo=zebra
 foo=bar
+camel=BAR
   bum: a
   bum: b
   bum: c

--- a/tools/codegen/tests/test.template
+++ b/tools/codegen/tests/test.template
@@ -1,6 +1,7 @@
 over={{over}}
 zoo={{zoo}}
 foo={{foo}}
+camel={{foo|to_screaming_snake}}
 {%- for t in bum %}
   bum: {{ t }}
 {%- endfor %}


### PR DESCRIPTION
We are adding support for capnp generation of C kernel code.
This requires a lot of turning CamelCase to snake case, or
screaming snake case. Rather than implementing all this in
jinja templates, this PR brings in:
   https://pypi.org/project/jinja2-strcase/#description

That provides simple python implementations for the needed
conversion functions.
