### PR TITLE
bes_publisher: Add new BEP handler server

### DIFF
--- a/bes_publisher/BUILD.bazel
+++ b/bes_publisher/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/bes_publisher",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bes_publisher/buildevent:go_default_library",
+        "//lib/server:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "bes_publisher",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/bes_publisher/buildevent/BUILD.bazel
+++ b/bes_publisher/buildevent/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["service.go"],
+    importpath = "github.com/enfabrica/enkit/bes_publisher/buildevent",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "mockstream_test.go",
+        "service_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//lib/errdiff:go_default_library",
+        "@com_github_stretchr_testify//mock:go_default_library",
+        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_grpc//metadata:go_default_library",
+    ],
+)

--- a/bes_publisher/buildevent/mockstream_test.go
+++ b/bes_publisher/buildevent/mockstream_test.go
@@ -1,0 +1,56 @@
+package buildevent
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+type mockStream struct {
+	mock.Mock
+}
+
+func (m *mockStream) Send(res *bpb.PublishBuildToolEventStreamResponse) error {
+	args := m.Called(res)
+	return args.Error(0)
+}
+
+func (m *mockStream) Recv() (*bpb.PublishBuildToolEventStreamRequest, error) {
+	args := m.Called()
+	err := args.Error(1)
+	if err != nil {
+		return nil, err
+	}
+	return args.Get(0).(*bpb.PublishBuildToolEventStreamRequest), nil
+}
+
+func (m *mockStream) SetHeader(meta metadata.MD) error {
+	args := m.Called(meta)
+	return args.Error(0)
+}
+
+func (m *mockStream) SendHeader(meta metadata.MD) error {
+	args := m.Called(meta)
+	return args.Error(0)
+}
+
+func (m *mockStream) SetTrailer(meta metadata.MD) {
+	_ = m.Called(meta)
+}
+
+func (m *mockStream) Context() context.Context {
+	args := m.Called()
+	return args.Get(0).(context.Context)
+}
+
+func (m *mockStream) SendMsg(msg interface{}) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockStream) RecvMsg(msg interface{}) error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/bes_publisher/buildevent/service.go
+++ b/bes_publisher/buildevent/service.go
@@ -1,0 +1,154 @@
+package buildevent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	bes "github.com/enfabrica/enkit/third_party/bazel/buildeventstream" // Allows prototext to automatically decode embedded messages
+)
+
+var (
+	metricLifecycleEventCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bes_publisher",
+		Name:      "lifecycle_event_count",
+		Help:      "Number of BEP lifecycle events, grouped by how they were handled",
+	},
+		[]string{
+			"event_type",
+			"outcome",
+		},
+	)
+	metricBuildEventProtocolEventCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bes_publisher",
+		Name:      "bep_event_count",
+		Help:      "Number of BEP events, grouped by how they were handled",
+	},
+		[]string{
+			"event_type",
+			"outcome",
+		},
+	)
+	metricBuildEventServiceEventCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bes_publisher",
+		Name:      "bes_event_count",
+		Help:      "Number of BES events, grouped by how they were handled",
+	},
+		[]string{
+			"event_type",
+			"outcome",
+		},
+	)
+)
+
+// oneofType returns a friendly string for a protobuf oneof type to use in
+// logging/metrics.
+//
+// Converts a string like `*proto.BuildEvent_BuildMetadata` to `BuildMetadata`.
+func oneofType(msg any) string {
+	ret := "<unknown>"
+	elems := strings.Split(fmt.Sprintf("%T", msg), "_")
+	if len(elems) < 2 {
+		return ret
+	}
+	return elems[1]
+}
+
+// bazelEventFrom returns a bazel BES BuildEvent from the given event stream
+// message, or an error if the message is of a different type.
+func bazelEventFrom(req *bpb.PublishBuildToolEventStreamRequest) (*bes.BuildEvent, error) {
+	switch event := req.GetOrderedBuildEvent().GetEvent().Event.(type) {
+	default:
+		metricBuildEventProtocolEventCount.WithLabelValues(oneofType(event), "dropped").Inc()
+		return nil, fmt.Errorf("not handling unknown BEP event type: %T", event)
+	case *bpb.BuildEvent_BazelEvent:
+		buildEvent := &bes.BuildEvent{}
+		if err := ptypes.UnmarshalAny(event.BazelEvent, buildEvent); err != nil {
+			metricBuildEventProtocolEventCount.WithLabelValues(oneofType(event), "parse_fail").Inc()
+			return nil, fmt.Errorf("failed to unmarshal embedded BazelEvent: %w", err)
+		}
+		metricBuildEventProtocolEventCount.WithLabelValues(oneofType(event), "ok").Inc()
+		return buildEvent, nil
+	}
+}
+
+// Service implements the Build Event Protocol service.
+type Service struct {
+}
+
+// PublishLifecycleEvent records the BEP lifecycle events seen in a metric, and
+// not much else.
+func (s *Service) PublishLifecycleEvent(ctx context.Context, req *bpb.PublishLifecycleEventRequest) (*emptypb.Empty, error) {
+	glog.V(2).Infof("# BEP LifecycleEvent message:\n%s", prototext.Format(req))
+	metricLifecycleEventCount.WithLabelValues(oneofType(req.GetBuildEvent().GetEvent().GetEvent()), "dropped").Inc()
+	return &emptypb.Empty{}, nil
+}
+
+// PublishBuildToolEventStream handles all the Bazel BES messages seen.
+func (s *Service) PublishBuildToolEventStream(stream bpb.PublishBuildEvent_PublishBuildToolEventStreamServer) (retErr error) {
+	bs := &buildStream{
+		stream: stream,
+	}
+	return bs.handleMessages()
+}
+
+// buildStream wraps a single stream (for a single build) so that it can
+// aggregate state seen across the entire stream, such as invocation ID and
+// build type.
+type buildStream struct {
+	stream bpb.PublishBuildEvent_PublishBuildToolEventStreamServer
+}
+
+// handleMessages handles all the messages on the stream, and then returns an
+// error if it encounters a non-EOF error while exhausting the stream.
+func (b *buildStream) handleMessages() error {
+	for {
+		req, err := b.stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := b.handleEvent(req); err != nil {
+			continue
+		}
+	}
+}
+
+// handleEvent handles a single event, making sure to ack the event even in the
+// case of an error. It returns an error if this event was not handled.
+func (b *buildStream) handleEvent(req *bpb.PublishBuildToolEventStreamRequest) error {
+	// The upstream sender is expecting an ack to be sent, regardless of whether
+	// this message was handled or not.
+	defer func() {
+		res := &bpb.PublishBuildToolEventStreamResponse{
+			StreamId:       req.GetOrderedBuildEvent().StreamId,
+			SequenceNumber: req.GetOrderedBuildEvent().SequenceNumber,
+		}
+		if err := b.stream.Send(res); err != nil {
+			glog.Error("failed to send event ack: %v", err)
+		}
+	}()
+
+	event, err := bazelEventFrom(req)
+	if err != nil {
+		return err
+	}
+
+	// TODO(scott): insert this message into PubSub
+	glog.V(2).Infof("# Bazel event:\n%s", prototext.Format(event))
+	metricBuildEventServiceEventCount.WithLabelValues(oneofType(event.Payload), "ok").Inc()
+
+	return nil
+}

--- a/bes_publisher/buildevent/service_test.go
+++ b/bes_publisher/buildevent/service_test.go
@@ -1,0 +1,72 @@
+package buildevent
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+
+	"github.com/enfabrica/enkit/lib/errdiff"
+)
+
+func TestServicePublishLifecycleEvent(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		req     *bpb.PublishLifecycleEventRequest
+		wantErr string
+	}{
+		{
+			desc: "no error on any call",
+			req:  &bpb.PublishLifecycleEventRequest{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			service := &Service{}
+
+			_, gotErr := service.PublishLifecycleEvent(ctx, tc.req)
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+		})
+	}
+}
+
+func TestPublishBuildToolEventStream(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		events        []*bpb.PublishBuildToolEventStreamRequest
+		streamSendErr error
+		streamRecvErr error
+
+		wantErr string
+	}{
+		{
+			desc:    "no events",
+			events:  []*bpb.PublishBuildToolEventStreamRequest{},
+			wantErr: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			service := &Service{}
+
+			stream := &mockStream{}
+			stream.On("Send", mock.Anything).Return(tc.streamSendErr)
+			for _, event := range tc.events {
+				stream.On("Recv").Return(event, nil).Once()
+			}
+			if tc.streamRecvErr != nil {
+				stream.On("Recv").Return(nil, tc.streamRecvErr).Once()
+			} else {
+				stream.On("Recv").Return(nil, io.EOF).Once()
+			}
+
+			gotErr := service.PublishBuildToolEventStream(stream)
+
+			errdiff.Check(t, gotErr, tc.wantErr)
+		})
+	}
+}

--- a/bes_publisher/main.go
+++ b/bes_publisher/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+	"google.golang.org/grpc"
+
+	"github.com/enfabrica/enkit/bes_publisher/buildevent"
+	"github.com/enfabrica/enkit/lib/server"
+)
+
+var (
+	// BES can send large messages; if the default message size isn't raised,
+	// these large messages will be dropped.
+	maxMessageSize = flag.Int(
+		"grpc_max_message_size_bytes",
+		50*1024*1024,
+		"Maximum receive message size in bytes accepted by gRPC methods",
+	)
+)
+
+func main() {
+	flag.Parse()
+
+	grpcs := grpc.NewServer(
+		grpc.MaxRecvMsgSize(*maxMessageSize),
+	)
+	bpb.RegisterPublishBuildEventServer(grpcs, &buildevent.Service{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	glog.Exit(server.Run(mux, grpcs, nil))
+}

--- a/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
+++ b/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
@@ -30,6 +30,7 @@ go_proto_library(
         ":build_event_stream_proto",
     ],
     visibility = [
+        "//bes_publisher:__subpackages__",
         "//bestie:__subpackages__",
         "//lib/bes:__subpackages__",
         "//lib/kbuildbarn:__subpackages__",


### PR DESCRIPTION
This change adds a BEP handler server that will eventually publish important messages it sees onto PubSub.

In this iteration, the server simply increments metrics for messages seen, and optionally logs if the logging level is set high enough.

Tested:
* Unit tests
* Manually (see steps below)

To run manually:
* `bazel run //:gazelle && bazel run //bes_publisher -- --alsologtostderr --v=2`
* Run a bazel build: `bazel test //bes_publisher/... --bes_backend=grpc://localhost:6433`
* View metrics: `curl localhost:6433/metrics`