### PR TITLE
tools/codegen: add support for 'as_filter'.

### DIFF
--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -80,6 +80,22 @@ def re_replace_function(text, match, sub):
     return re.sub(match, sub, text)
 
 
+@jinja2.pass_context
+def as_filter_function(context, text, macro, *args, **kwargs):
+    """Allows to use a macro as a filter.
+
+    For example:
+        {% macro UpperPrefix(text, prefix = "prefix_") -%}
+        {{prefix}}{{text|upper}}
+        {%- endmacro %}
+
+        {{"toast"|as_filter("UpperPrefix", prefix = "prefix_")}}
+
+    Will invoke the macro UpperPrefix as a filter, returning
+    "prefix_TOAST".
+    """
+    return context.vars[macro](text, *args, **kwargs)
+
 def _merge(a, b, path=None):
     """Merges structure b into structure a."""
     if path is None:
@@ -122,6 +138,7 @@ class Template(data_loader.DataLoader):
         self.env.filters.update(
             {
                 "re_replace": re_replace_function,
+                "as_filter": as_filter_function,
             }
         )
         self.context = {"_DATA": [], "_TEMPLATE": ""}

--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -76,6 +76,10 @@ def re_split_function(regex, text):
     return re.split(regex, text)
 
 
+def re_replace_function(text, match, sub):
+    return re.sub(match, sub, text)
+
+
 def _merge(a, b, path=None):
     """Merges structure b into structure a."""
     if path is None:
@@ -112,6 +116,12 @@ class Template(data_loader.DataLoader):
                 "bitwise_xor": bitwise_xor_function,
                 "bitwise_not": bitwise_not_function,
                 "re_split": re_split_function,
+                "re_replace": re_replace_function,
+            }
+        )
+        self.env.filters.update(
+            {
+                "re_replace": re_replace_function,
             }
         )
         self.context = {"_DATA": [], "_TEMPLATE": ""}

--- a/tools/codegen/tests/d2-test.expected
+++ b/tools/codegen/tests/d2-test.expected
@@ -4,6 +4,7 @@ foo=bar
 camel=BAR
 tooth=taath
 tooth=faa
+filtered=myp_TEST STRING
   bum: x
   bum: y
   bum: z

--- a/tools/codegen/tests/d2-test.expected
+++ b/tools/codegen/tests/d2-test.expected
@@ -2,6 +2,8 @@ over=rides
 zoo=zebra
 foo=bar
 camel=BAR
+tooth=taath
+tooth=faa
   bum: x
   bum: y
   bum: z

--- a/tools/codegen/tests/gen-test.expected
+++ b/tools/codegen/tests/gen-test.expected
@@ -2,6 +2,8 @@ over=rides
 zoo=zebra
 foo=bar
 camel=BAR
+tooth=taath
+tooth=faa
   bum: a
   bum: b
   bum: c

--- a/tools/codegen/tests/gen-test.expected
+++ b/tools/codegen/tests/gen-test.expected
@@ -4,6 +4,7 @@ foo=bar
 camel=BAR
 tooth=taath
 tooth=faa
+filtered=myp_TEST STRING
   bum: a
   bum: b
   bum: c

--- a/tools/codegen/tests/test.template
+++ b/tools/codegen/tests/test.template
@@ -1,9 +1,13 @@
+{%- macro ImAFilter(text, prefix) -%}
+{{prefix}}{{text|upper}}
+{%- endmacro -%}
 over={{over}}
 zoo={{zoo}}
 foo={{foo}}
 camel={{foo|to_screaming_snake}}
 tooth={{"tooth"|re_replace("o", "a")}}
 tooth={{re_replace("foo", "o", "a")}}
+filtered={{"test string"|as_filter("ImAFilter", "myp_")}}
 {%- for t in bum %}
   bum: {{ t }}
 {%- endfor %}

--- a/tools/codegen/tests/test.template
+++ b/tools/codegen/tests/test.template
@@ -2,6 +2,8 @@ over={{over}}
 zoo={{zoo}}
 foo={{foo}}
 camel={{foo|to_screaming_snake}}
+tooth={{"tooth"|re_replace("o", "a")}}
+tooth={{re_replace("foo", "o", "a")}}
 {%- for t in bum %}
   bum: {{ t }}
 {%- endfor %}


### PR DESCRIPTION
This commit adds support for a tiny extension, as_filter, that allows
to use macros defined in templates as filters. This is extremely convenient
to apply repetitive set of filters to - for example - mangle names in
systemic ways.

Examples provided in the code.
