### PR TITLE
bes_publisher: Publish to pubsub topic

### DIFF
--- a/bes_publisher/BUILD.bazel
+++ b/bes_publisher/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//lib/server:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@com_google_cloud_go_pubsub//:go_default_library",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/bes_publisher/buildevent/BUILD.bazel
+++ b/bes_publisher/buildevent/BUILD.bazel
@@ -2,16 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["service.go"],
+    srcs = [
+        "errslice.go",
+        "pubsub.go",
+        "service.go",
+    ],
     importpath = "github.com/enfabrica/enkit/bes_publisher/buildevent",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/multierror:go_default_library",
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_google_cloud_go_pubsub//:go_default_library",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
@@ -20,14 +27,22 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "mockpubsub_test.go",
         "mockstream_test.go",
         "service_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//lib/errdiff:go_default_library",
+        "//lib/testutil:go_default_library",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_stretchr_testify//mock:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@com_google_cloud_go_pubsub//:go_default_library",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
         "@org_golang_google_grpc//metadata:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
     ],
 )

--- a/bes_publisher/buildevent/errslice.go
+++ b/bes_publisher/buildevent/errslice.go
@@ -1,0 +1,45 @@
+package buildevent
+
+import (
+	"github.com/enfabrica/enkit/lib/multierror"
+)
+
+// errslice accumulates errors into a slice in a threadsafe manner.
+type errslice struct {
+	errs    []error
+	errChan chan error
+	done    chan struct{}
+}
+
+// newErrslice returns a started errslice.
+func newErrslice() *errslice {
+	s := &errslice{
+		errs:    []error{},
+		errChan: make(chan error),
+		done:    make(chan struct{}),
+	}
+	go s.collect()
+	return s
+}
+
+// Append records an error. Append() can't be called after Close().
+func (s *errslice) Append(err error) {
+	s.errChan <- err
+}
+
+func (s *errslice) collect() {
+	defer close(s.done)
+	for err := range s.errChan {
+		if err != nil {
+			s.errs = append(s.errs, err)
+		}
+	}
+}
+
+// Close stops new errors from being added, and returns an error if this
+// errslice contains any errors.
+func (s *errslice) Close() error {
+	close(s.errChan)
+	<-s.done
+	return multierror.New(s.errs)
+}

--- a/bes_publisher/buildevent/mockpubsub_test.go
+++ b/bes_publisher/buildevent/mockpubsub_test.go
@@ -1,0 +1,35 @@
+package buildevent
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockTopic struct {
+	mock.Mock
+}
+
+func (m *mockTopic) Publish(ctx context.Context, msg *pubsub.Message) fetcher {
+	args := m.Called(ctx, msg)
+	return args.Get(0).(fetcher)
+}
+
+// newMockPublishResult returns a mockPublishResult with expectations pre-set:
+// * Get() returns a specified error after a specified amount of time `delay`
+func newMockPublishResult(delay time.Duration, err error) *mockPublishResult {
+	m := &mockPublishResult{}
+	m.On("Get", mock.Anything).After(delay).Return("", err).Once()
+	return m
+}
+
+type mockPublishResult struct {
+	mock.Mock
+}
+
+func (m *mockPublishResult) Get(ctx context.Context) (string, error) {
+	args := m.Called(ctx)
+	return args.String(0), args.Error(1)
+}

--- a/bes_publisher/buildevent/pubsub.go
+++ b/bes_publisher/buildevent/pubsub.go
@@ -1,0 +1,33 @@
+package buildevent
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+)
+
+// fetcher wraps the interface exposed by pubsub.MessageResult.
+type fetcher interface {
+	Get(context.Context) (string, error)
+}
+
+// sender wraps the interface exposed by pubsub.Topic.
+type sender interface {
+	Publish(context.Context, *pubsub.Message) fetcher
+}
+
+// Topic wraps a pubsub.Topic so that it can expose the proper return type for
+// Publish().
+type Topic struct {
+	*pubsub.Topic
+}
+
+// NewTopic wraps a pubsub.Topic with a *Topic so it can be used as a `sender`.
+func NewTopic(t *pubsub.Topic) *Topic {
+	return &Topic{t}
+}
+
+// Publish effectively casts a pubsub.MessageResult into a fetcher.
+func (t *Topic) Publish(ctx context.Context, msg *pubsub.Message) fetcher {
+	return t.Topic.Publish(ctx, msg)
+}

--- a/bes_publisher/buildevent/service_test.go
+++ b/bes_publisher/buildevent/service_test.go
@@ -5,10 +5,17 @@ import (
 	"io"
 	"testing"
 
+	"cloud.google.com/go/pubsub"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	bpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/enfabrica/enkit/lib/errdiff"
+	"github.com/enfabrica/enkit/lib/testutil"
+	bes "github.com/enfabrica/enkit/third_party/bazel/buildeventstream"
 )
 
 func TestServicePublishLifecycleEvent(t *testing.T) {
@@ -34,28 +41,81 @@ func TestServicePublishLifecycleEvent(t *testing.T) {
 	}
 }
 
+func anypbOrDie(msg proto.Message) *anypb.Any {
+	a, err := anypb.New(msg)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func wrapBesMessages(msgs []*bes.BuildEvent) []*bpb.PublishBuildToolEventStreamRequest {
+	var wrapped []*bpb.PublishBuildToolEventStreamRequest
+	for i, msg := range msgs {
+		wrapped = append(wrapped, &bpb.PublishBuildToolEventStreamRequest{
+			OrderedBuildEvent: &bpb.OrderedBuildEvent{
+				SequenceNumber: int64(i),
+				Event: &bpb.BuildEvent{
+					Event: &bpb.BuildEvent_BazelEvent{
+						BazelEvent: anypbOrDie(msg),
+					},
+				},
+			},
+		})
+	}
+	return wrapped
+}
+
 func TestPublishBuildToolEventStream(t *testing.T) {
 	testCases := []struct {
 		desc          string
-		events        []*bpb.PublishBuildToolEventStreamRequest
+		events        []*bes.BuildEvent
 		streamSendErr error
 		streamRecvErr error
 
-		wantErr string
+		wantMessages []*pubsub.Message
+		wantErr      string
 	}{
 		{
 			desc:    "no events",
-			events:  []*bpb.PublishBuildToolEventStreamRequest{},
+			events:  []*bes.BuildEvent{},
+			wantErr: "",
+		},
+		{
+			desc: "build started",
+			events: []*bes.BuildEvent{
+				&bes.BuildEvent{
+					Payload: &bes.BuildEvent_Started{
+						Started: &bes.BuildStarted{
+							Uuid: "d9b5cec0-c1e6-428c-8674-a74194b27447",
+						},
+					},
+				},
+			},
+			wantMessages: []*pubsub.Message{
+				&pubsub.Message{
+					Data: []byte(`{"started":{"uuid":"d9b5cec0-c1e6-428c-8674-a74194b27447"}}`),
+					Attributes: map[string]string{
+						"inv_id": "d9b5cec0-c1e6-428c-8674-a74194b27447",
+					},
+				},
+			},
 			wantErr: "",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			service := &Service{}
+			ctx := context.Background()
+			bepEvents := wrapBesMessages(tc.events)
+
+			topic := &mockTopic{}
+			service, err := NewService(topic)
+			require.NoError(t, err)
 
 			stream := &mockStream{}
+			stream.On("Context").Return(ctx)
 			stream.On("Send", mock.Anything).Return(tc.streamSendErr)
-			for _, event := range tc.events {
+			for _, event := range bepEvents {
 				stream.On("Recv").Return(event, nil).Once()
 			}
 			if tc.streamRecvErr != nil {
@@ -64,9 +124,16 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 				stream.On("Recv").Return(nil, io.EOF).Once()
 			}
 
+			var sentMessages []*pubsub.Message
+			topic.On("Publish", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				sent := args.Get(1).(*pubsub.Message)
+				sentMessages = append(sentMessages, sent)
+			}).Return(newMockPublishResult(randomMs(10, 100), nil))
+
 			gotErr := service.PublishBuildToolEventStream(stream)
 
 			errdiff.Check(t, gotErr, tc.wantErr)
+			testutil.AssertCmp(t, sentMessages, tc.wantMessages, cmpopts.IgnoreUnexported(pubsub.Message{}))
 		})
 	}
 }


### PR DESCRIPTION
This change adds logic to propagate `BuildStarted` events into a pubsub topic, with the attributes specified in
https://docs.google.com/document/d/1kA17-zwUxFDHrcpogQv5fMa9MLJpTkhwEAMAqzYCBr0/edit#heading=h.kbi1exowvrim.

Unit tests are added to ensure:
* the expected messages are published
* the messages have the correct attributes
* PublishResults received from Publish calls are handled properly

Tested: unit tests