### PR TITLE
bes_publisher: Publish more messages

### DIFF
--- a/bes_publisher/buildevent/BUILD.bazel
+++ b/bes_publisher/buildevent/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/enfabrica/enkit/bes_publisher/buildevent",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/gmap:go_default_library",
         "//lib/multierror:go_default_library",
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "@com_github_golang_glog//:go_default_library",

--- a/bes_publisher/main.go
+++ b/bes_publisher/main.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"net/http"
-	"os"
-	"os/signal"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/golang/glog"
@@ -45,8 +43,7 @@ func exitIf(err error) {
 
 func main() {
 	flag.Parse()
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
-	defer cancel()
+	ctx := context.Background()
 
 	pubsubClient, err := pubsub.NewClient(ctx, *gcpProjectID)
 	exitIf(err)

--- a/lib/gmap/BUILD.bazel
+++ b/lib/gmap/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gmap.go"],
+    importpath = "github.com/enfabrica/enkit/lib/gmap",
+    visibility = ["//visibility:public"],
+)

--- a/lib/gmap/gmap.go
+++ b/lib/gmap/gmap.go
@@ -1,0 +1,20 @@
+// Package gmap provides generic functions over maps.
+package gmap
+
+// Copy returns a deep copy of m.
+func Copy[T map[K]V, K comparable, V any](m T) T {
+	copy := T{}
+	for k, v := range m {
+		copy[k] = v
+	}
+	return copy
+}
+
+// Keys returns the keys of m.
+func Keys[T map[K]V, K comparable, V any](m T) []K {
+	var keys []K
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
This change adds more messages to the list published by `bes_publisher`,
along with a test that ensures the attributes are aggregated correctly.

This change also adds a generic map library, with convenience functions
for maps so that these simple functions no longer need to be duplicated
in the codebase.

Tested: unit tests