### PR TITLE
third_party: Add Python proto rules

### DIFF
--- a/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
+++ b/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 # TODO: Make these definitions compatible with what gazelle wants to emit.
@@ -38,5 +38,17 @@ go_proto_library(
     ],
     deps = [
         "//third_party/bazel/src/main/protobuf:proto",
+    ],
+)
+
+py_proto_library(
+    name = "build_event_stream_py_proto",
+    srcs = ["build_event_stream.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/bazel/src/main/protobuf:command_line_py_proto",
+        "//third_party/bazel/src/main/protobuf:failure_details_py_proto",
+        "//third_party/bazel/src/main/protobuf:invocation_policy_py_proto",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/third_party/bazel/src/main/protobuf/BUILD.bazel
+++ b/third_party/bazel/src/main/protobuf/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 # TODO: Make these definitions compatible with what gazelle wants to emit.
@@ -46,4 +46,30 @@ go_proto_library(
         ":invocation_policy_proto",
         ":option_filters_proto",
     ],
+)
+
+py_proto_library(
+    name = "command_line_py_proto",
+    srcs = ["command_line.proto"],
+    deps = [
+        ":option_filters_py_proto",
+    ],
+)
+
+py_proto_library(
+    name = "option_filters_py_proto",
+    srcs = ["option_filters.proto"],
+)
+
+py_proto_library(
+    name = "failure_details_py_proto",
+    srcs = ["failure_details.proto"],
+    deps = [
+        "@com_google_protobuf//:protobuf_python",
+    ],
+)
+
+py_proto_library(
+    name = "invocation_policy_py_proto",
+    srcs = ["invocation_policy.proto"],
 )


### PR DESCRIPTION
This change adds `py_proto_library` rules for the Bazel BES proto, so that code in internal can depend on it.

Since internal only wants to use the top-level BES proto, only that rule needs to have public visibility; the dependencies can stick with restricted visibility.

Tested: Code in internal that requires the proto builds with this change when `--override_repository` is set appropriately