### PR TITLE
gee: add find and vimdiff commands

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2382,6 +2382,36 @@ function gee__diff() {
 }
 
 ##########################################################################
+# find command
+##########################################################################
+
+_register_help "find" "Finds a file by name in the current branch." <<'EOT'
+Usage: gee find [options] <expression>
+
+Searches the current branch for the specified expression.  Equivalent
+to running:
+
+    find "${BROOT}" -name .git -prune -or -name "${expression}" -print
+
+Example of use:
+
+    gee find WORKSPACE
+
+EOT
+function gee__find() {
+  # The GEE_NO_RIPGREP environment variable is available for testing, to force
+  # the use of find without requiring that ripfind be uninstalled.
+  _startup_checks "find"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  NOFAIL=1 _cmd find ${BROOT} -name .git -prune -or -name "${1}" -print
+}
+
+##########################################################################
 # grep command
 ##########################################################################
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -2318,7 +2318,21 @@ function gee__make_branch() {
 
 _register_help "log" \
   "Log of commits since parent branch." <<'EOT'
-Usage: gee log
+Usage: gee log [<args...>]
+
+Invokes `git logp` with the supplied arguments.
+
+If the supplied arguments do not contain a commit range, then gee will show the
+log messages for commits between the parent branch and the the current branch.
+
+For example:
+
+    gee log                # show all commits since HEAD of parent branch.
+
+    gee log ./scripts/gee  # show commits since parent for a single file.
+
+    gee log master...mybr  # show all commits in a specific range
+
 EOT
 
 function gee__log() {
@@ -2327,13 +2341,13 @@ function gee__log() {
   _check_cwd
   local -a ARGS=( "$@" )
   local -a RANGE=()
-  _egrep_array RANGE '^\w*\.\.\.\w*$' "$@"
+  _egrep_array RANGE '^\w*\.\.\.\w*$' "${ARGS[@]}"
   if (( ${#RANGE[@]} == 0 )); then
     local PARENT_BRANCH CURRENT_BRANCH
     _read_parents_file
     PARENT_BRANCH="$(_get_parent_branch)"
     CURRENT_BRANCH="$(_get_current_branch)"
-    ARGS+=("${PARENT_BRANCH}...${CURRENT_BRANCH}")
+    ARGS=("${PARENT_BRANCH}...${CURRENT_BRANCH}" "${ARGS[@]}")
   fi
   local -a PRETTYLOG=(
       log

--- a/scripts/gee
+++ b/scripts/gee
@@ -5197,7 +5197,7 @@ function _gee_completion() {
     2)
       prev="\${COMP_WORDS[COMP_CWORD-1]}"
       case "\${prev}" in
-        diff|unpack|revert)
+        diff|log|unpack|vimdiff|revert)
           COMPREPLY=(\$(compgen -f -- "\${cur}"))
           ;;
         set_parent|gcd|rmbr|remove_branch)

--- a/scripts/gee
+++ b/scripts/gee
@@ -2455,6 +2455,65 @@ function gee__grep() {
 }
 
 ##########################################################################
+# vimdiff command
+##########################################################################
+
+_register_help "vimdiff" "Runs vimdiff to compare changes in a file." <<'EOT'
+Usage: gee vimdiff <filename>
+
+Invokes vimdiff to show and edit the changes to a specific file in the current
+branch, versus the version in the parent branch.  This can be useful to clean
+up local changes, especially after resolving merge conflicts.
+
+If installed, neovim will be used.  Otherwise, gee will fallback to vim.
+
+When working in a branch created with `pr_checkout`, the parent branch isn't
+a local worktree, and so vimdiff will produce an error and fail.
+
+Example of use:
+
+    gee vimdiff BUILD.bazel
+
+EOT
+function gee__vimdiff() {
+  _startup_checks "vimdiff"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  local FILENAME="$1"
+  if [[ -z "${FILENAME}" ]]; then
+    _fatal "vimdiff requires a filename argument."
+  elif [[ ! -e "${FILENAME}" ]]; then
+    _fatal "File \"${FILENAME}\" does not exist."
+  fi
+  local RELPATH
+  RELPATH="$(realpath --relative-to "${BRANCH_ROOT_DIR}" "${FILENAME}")"
+  if [[ "${RELPATH}" == ".."* ]]; then
+    _fatal "File \"${FILENAME}\" is not beneath branch root directory "${BRANCH_ROOT_DIR}"."
+  fi
+
+  local PARENT_BRANCH PARENT_ROOT_DIR
+  _read_parents_file
+  PARENT_BRANCH="$(_get_parent_branch)"
+  # branches created with "gee pr_checkout" need special handling:
+  if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
+    _fatal "gee vimdiff doesn't support pr_checkout-created branches yet."
+  fi
+  PARENT_ROOT_DIR="$(_get_branch_rootdir "${PARENT_BRANCH}")"
+
+  if command -v nvim >/dev/null; then
+    _cmd nvim -d "${PARENT_ROOT_DIR}/${RELPATH}" "${BRANCH_ROOT_DIR}/${RELPATH}"
+  elif command -v vimdiff >/dev/null; then
+    _cmd vimdiff "${PARENT_ROOT_DIR}/${RELPATH}" "${BRANCH_ROOT_DIR}/${RELPATH}"
+  else
+    _fatal "Neither nvim nor vimdiff seem to be installed."
+  fi
+}
+
+##########################################################################
 # pack command
 ##########################################################################
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -2408,7 +2408,7 @@ function gee__find() {
   CURRENT_BRANCH="$(_get_current_branch)"
   BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
 
-  NOFAIL=1 _cmd find ${BROOT} -name .git -prune -or -name "${1}" -print
+  NOFAIL=1 _cmd find "${BRANCH_ROOT_DIR}" -name .git -prune -or -name "${1}" -print
 }
 
 ##########################################################################
@@ -2492,7 +2492,7 @@ function gee__vimdiff() {
   local RELPATH
   RELPATH="$(realpath --relative-to "${BRANCH_ROOT_DIR}" "${FILENAME}")"
   if [[ "${RELPATH}" == ".."* ]]; then
-    _fatal "File \"${FILENAME}\" is not beneath branch root directory "${BRANCH_ROOT_DIR}"."
+    _fatal "File \"${FILENAME}\" is not beneath branch root directory ${BRANCH_ROOT_DIR}."
   fi
 
   local PARENT_BRANCH PARENT_ROOT_DIR

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -5,8 +5,8 @@
 
 ### 0.2.39 (unreleased)
 
-* gee find: new command, quickly find named files.
-* gee vimdiff: new command, view local changes in a file.
+* gee find: new command, quickly find named files. (#839)
+* gee vimdiff: new command, view local changes in a file. (#839)
 * gee bazelgc: fix, correctly handle deletion of too many files. (#817)
 * gee bazelgc: also prune old files from ~/.cache/bazel-disk-cache (#813)
 * gee grep: new command, easily search a git branch using grep or ripgrep (#811)

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -3,7 +3,7 @@
 ## Releases
 
 
-### 0.2.39 (unreleased)
+### 0.2.39
 
 * gee find: new command, quickly find named files. (#839)
 * gee vimdiff: new command, view local changes in a file. (#839)

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,8 +2,12 @@
 
 ## Releases
 
-### 0.2.39
 
+### 0.2.39 (unreleased)
+
+* gee find: new command, quickly find named files.
+* gee vimdiff: new command, view local changes in a file.
+* gee bazelgc: fix, correctly handle deletion of too many files. (#817)
 * gee bazelgc: also prune old files from ~/.cache/bazel-disk-cache (#813)
 * gee grep: new command, easily search a git branch using grep or ripgrep (#811)
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -181,7 +181,20 @@ revision.
 
 ### log
 
-Usage: `gee log`
+Usage: `gee log [<args...>]`
+
+Invokes `git logp` with the supplied arguments.
+
+If the supplied arguments do not contain a commit range, then gee will show the
+log messages for commits between the parent branch and the the current branch.
+
+For example:
+
+    gee log                # show all commits since HEAD of parent branch.
+
+    gee log ./scripts/gee  # show commits since parent for a single file.
+
+    gee log master...mybr  # show all commits in a specific range
 
 ### diff
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -100,6 +100,7 @@ review.
 | <a href="#create_ssh_key">`create_ssh_key`</a> | Create and enroll an ssh key. |
 | <a href="#diagnose">`diagnose`</a> | Capture diagnostics about your repository. |
 | <a href="#diff">`diff`</a> | Differences in this branch. |
+| <a href="#find">`find`</a> | Finds a file by name in the current branch. |
 | <a href="#fix">`fix`</a> | Run automatic code formatters over changed files only. |
 | <a href="#gcd">`gcd`</a> | Change directory to another branch. |
 | <a href="#get_parent">`get_parent`</a> | Which branch is this branch branched from? |
@@ -134,6 +135,7 @@ review.
 | <a href="#update">`update`</a> | integrate changes from parent into this branch. |
 | <a href="#upgrade">`upgrade`</a> | Upgrade the gee tool. |
 | <a href="#version">`version`</a> | Print tool version information. |
+| <a href="#vimdiff">`vimdiff`</a> | Runs vimdiff to compare changes in a file. |
 | <a href="#whatsout">`whatsout`</a> | List locally changed files in this branch. |
 
 ## Commands
@@ -189,6 +191,19 @@ Shows all local changes this since branch diverged from its parent branch.
 
 If <files...> are omited, shows changes to all files.
 
+### find
+
+Usage: `gee find [options] <expression>`
+
+Searches the current branch for the specified expression.  Equivalent
+to running:
+
+    find "${BROOT}" -name .git -prune -or -name "${expression}" -print
+
+Example of use:
+
+    gee find WORKSPACE
+
 ### grep
 
 Usage: `gee grep [options] <expression>`
@@ -210,6 +225,23 @@ command.
 Example of use:
 
     grg -l fdst
+
+### vimdiff
+
+Usage: `gee vimdiff <filename>`
+
+Invokes vimdiff to show and edit the changes to a specific file in the current
+branch, versus the version in the parent branch.  This can be useful to clean
+up local changes, especially after resolving merge conflicts.
+
+If installed, neovim will be used.  Otherwise, gee will fallback to vim.
+
+When working in a branch created with `pr_checkout`, the parent branch isn't
+a local worktree, and so vimdiff will produce an error and fail.
+
+Example of use:
+
+    gee vimdiff BUILD.bazel
 
 ### pack
 


### PR DESCRIPTION
This adds two useful convenience commands to gee.

   find: for quickly finding a named file in a branch.
   vimdiff: vimdiff a file against the parent branch version.

Tested: manually ran each command.

