### PR TITLE
//proxy/ptunnel:go_default_test: tagged no-presubmit

### DIFF
--- a/proxy/ptunnel/BUILD.bazel
+++ b/proxy/ptunnel/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     # `http://127.0.0.1:44527/proxy?host=google.com&port=55`
     tags = [
         "no-cloudbuild",
+        "no-presubmit",
     ],
     deps = [
         "//lib/errdiff:go_default_library",


### PR DESCRIPTION
This presubmit-gating test appears broken in top of tree.  It fails both using
local-cache and buildbarn profiles, when run on build-04.sea.

Error message:

```
--- FAIL: TestTunnelTypeForHost (0.00s)
    --- FAIL: TestTunnelTypeForHost/error_for_non-existent_URL (0.00s)
        tunnel_test.go:223: got no error; want error containing "no such host"
FAIL
```

Tested: presubmit tests now pass with this tag set.

