### PR TITLE
astore/server: auto-close "Good job" pages after 30 seconds (LOW PRIO)

### DIFF
--- a/astore/server/README.md
+++ b/astore/server/README.md
@@ -1,6 +1,6 @@
 # How to test before deploying
 
-TODO(ahungrynacho, ccontavalli): please tell me how to test this.
+TODO(ccontavalli): add instructions for testing.
 
 # How to deploy and use the astore server
 

--- a/astore/server/README.md
+++ b/astore/server/README.md
@@ -1,6 +1,7 @@
 # How to test before deploying
 
-TODO(ccontavalli): add instructions for testing.
+TODO(ahungrynacho, ccontavalli): please tell me how to test this.  Is there a
+way to test without deploying?
 
 # How to deploy and use the astore server
 

--- a/astore/server/README.md
+++ b/astore/server/README.md
@@ -1,3 +1,7 @@
+# How to test before deploying
+
+TODO(ahungrynacho, ccontavalli): please tell me how to test this.
+
 # How to deploy and use the astore server
 
 1. Read the [README.md file in the credentials directory](credentials/),

--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -51,16 +51,16 @@ var messageNotFound = `Well, what you're looking for ain't here.<br />Go find a 
 
 func ShowResult(w http.ResponseWriter, r *http.Request, image, title, message string, status int) {
 	w.WriteHeader(status)
-	ok := "error"
+	sstring := "error"
 	if status == http.StatusOK {
-		ok = "ok"
+		sstring = "ok"
 	}
 	templates.WritePageTemplate(w, &templates.MessagePage{
 		PageTitle: title,
 		Highlight: title,
 		Text:      message,
 		ImageCSS:  image,
-		Ok:        ok,
+		Status:    sstring,
 	})
 }
 

--- a/astore/server/main.go
+++ b/astore/server/main.go
@@ -28,12 +28,12 @@ import (
 	"github.com/enfabrica/enkit/lib/kflags"
 	"github.com/enfabrica/enkit/lib/kflags/kcobra"
 	"github.com/enfabrica/enkit/lib/kflags/kconfig"
+	"github.com/enfabrica/enkit/lib/khttp/kassets"
 	"github.com/enfabrica/enkit/lib/khttp/kcookie"
 	"github.com/enfabrica/enkit/lib/logger"
 	"github.com/enfabrica/enkit/lib/oauth"
 	"github.com/enfabrica/enkit/lib/oauth/providers"
 	"github.com/enfabrica/enkit/lib/server"
-	"github.com/enfabrica/enkit/lib/khttp/kassets"
 	"github.com/enfabrica/enkit/lib/srand"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -51,11 +51,16 @@ var messageNotFound = `Well, what you're looking for ain't here.<br />Go find a 
 
 func ShowResult(w http.ResponseWriter, r *http.Request, image, title, message string, status int) {
 	w.WriteHeader(status)
+	ok := "error"
+	if status == http.StatusOK {
+		ok = "ok"
+	}
 	templates.WritePageTemplate(w, &templates.MessagePage{
 		PageTitle: title,
 		Highlight: title,
 		Text:      message,
 		ImageCSS:  image,
+		Ok:        ok,
 	})
 }
 

--- a/astore/server/templates/message.qtpl
+++ b/astore/server/templates/message.qtpl
@@ -5,7 +5,7 @@ type MessagePage struct {
 	ImageCSS string
 	Highlight string
 	Text string
-	Ok string
+	Status string
 }
 %}
 {% func (m *MessagePage) Title() %}{%s m.PageTitle %}{% endfunc %}
@@ -21,14 +21,16 @@ type MessagePage struct {
                 <div class="mdl-card__title-text">
                   <h2>{%s m.Highlight %}</h2>
                 </div>
-                <div class="mdl-card__supporting-text">{%s= m.Text %}</div>
+                <div class="mdl-card__supporting-text">
+                  {%s= m.Text %}
+                </div>
               </div>
           </div>
       </div>
 
       <div class="mdl-cell mdl-cell--2-col"></div>
 
-      {% if m.Ok == "ok" %}
+      {% if m.Status == "ok" %}
         <script>
           setTimeout(function() {window.close()}, 30000);
         </script>

--- a/astore/server/templates/message.qtpl
+++ b/astore/server/templates/message.qtpl
@@ -5,6 +5,7 @@ type MessagePage struct {
 	ImageCSS string
 	Highlight string
 	Text string
+	Ok string
 }
 %}
 {% func (m *MessagePage) Title() %}{%s m.PageTitle %}{% endfunc %}
@@ -14,10 +15,10 @@ type MessagePage struct {
       <div class="mdl-card mdl-shadow--2dp mdl-cell mdl-cell--8-col">
           <div class="mdl-card__title mdl-grid--no-spacing mdl-card--expand">
               <div class="mdl-cell mdl-cell--3-col-tablet mdl-cell--12-col-phone">
-    	        <div class="avatar" id="{%s m.ImageCSS %}"></div>
+             <div class="avatar" id="{%s m.ImageCSS %}"></div>
               </div>
               <div class="mdl-cell mdl-cell--9-col-desktop mdl-cell--12-col-phone">
-                <div class="mdl-card__title-text"> 
+                <div class="mdl-card__title-text">
                   <h2>{%s m.Highlight %}</h2>
                 </div>
                 <div class="mdl-card__supporting-text">{%s= m.Text %}</div>
@@ -26,4 +27,10 @@ type MessagePage struct {
       </div>
 
       <div class="mdl-cell mdl-cell--2-col"></div>
+
+      {% if m.Ok == "ok" %}
+        <script>
+          setTimeout(function() {window.close()}, 30000);
+        </script>
+      {% endif %}
 {% endfunc %}


### PR DESCRIPTION
This is a low-priority PR that addresses a personal preference, not a bug or a
problem.

I have to run enkit auth 2-4 times a day, and over the course of a week I end
up with lots of "Good jobs!" tabs that I keep forgetting to close.  This PR
adds a little bit of javascript to the Good Job page that auto-closes the
page after 30 seconds.

Unfortunately, I don't know how to test my change.  I can build the server, but
I don't know how to run it in a way that allows me to validate this
functionality.  It would be great if someone could share "how to test" steps in
the astore/server/README.md file.

This PR will remain a draft until someone has time to help me.

DRAFT

Tested: untested.

