### PR TITLE
bazel: Add enkit_credential_helper

### DIFF
--- a/bazel/enkit_credential_helper/BUILD.bazel
+++ b/bazel/enkit_credential_helper/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "enkit_credential_helper",
+    embed = [":go_default_library"],
+    visibility = [
+        "//:__subpackages__",
+        "@com_github_enfabrica_enkit//:__subpackages__",
+        "@enkit//:__subpackages__",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/bazel/enkit_credential_helper",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib/config/defcon:go_default_library",
+        "//lib/config/identity:go_default_library",
+        "//lib/khttp/kcookie:go_default_library",
+    ],
+)

--- a/bazel/enkit_credential_helper/main.go
+++ b/bazel/enkit_credential_helper/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/enfabrica/enkit/lib/config/defcon"
+	"github.com/enfabrica/enkit/lib/config/identity"
+	"github.com/enfabrica/enkit/lib/khttp/kcookie"
+)
+
+type Credentials struct {
+	Headers map[string][]string `json:"headers"`
+}
+
+func exitIf(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	if len(os.Args) <= 1 {
+		exitIf(fmt.Errorf("no command given"))
+	}
+	switch os.Args[1] {
+	case "get":
+	default:
+		exitIf(fmt.Errorf("bad command %q", os.Args[1]))
+	}
+
+	store, err := identity.NewStore("enkit", defcon.Open)
+	exitIf(err)
+
+	_, token, err := store.Load("")
+	exitIf(err)
+
+	cookie := kcookie.New("Creds", token)
+
+	creds := &Credentials{
+		Headers: map[string][]string{
+			"cookie": []string{cookie.String()},
+		},
+	}
+	out, err := json.Marshal(creds)
+	exitIf(err)
+
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
This change adds a binary that can act as a credential helper to bazel
as specified in
https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md.

If successful, this will allow us to drop the tunnel requirement for
buildbarn.

Tested:
* Credential helper can successfully get through enproxy

Not tested (future PR):
* Helpful errors thrown when credentials don't exist