### PR TITLE
gee: add pr_push note in gee commit

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.39"
+readonly VERSION="0.2.40"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3317,6 +3317,12 @@ function gee__commit() {
     # We always push upstream so that users have a backup in case they lose their
     # laptop:
     _push_to_origin "${CURRENT_BRANCH}"
+    _read_parents_file
+    if [[ "${PARENTS[${CURRENT_BRANCH}]}" == upstream/refs/pull/*/head ]]; then
+      _info "NOTE: This is a branch of another user's PR.  Your changes were pushed to *your* " \
+            "      github fork.  To push your changes back into the other user's PR, you need " \
+            "      to use the \"gee pr_push\" command."
+    fi
   fi
 }
 

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### 0.2.40
+
+* gee up: resolve conflicts when integrating commits from origin (#849)
+* gee find: also traverses symlinks by default. (#847)
 
 ### 0.2.39
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.39
+gee version: 0.2.40
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
One user was making the mistake of thinking that "gee commit" was pushing
changes back into another user's PR, instead of their local fork of that
PR.  "gee commit" now detects if a user is committing a change in a fork
of a PR, and emits a message letting the user know that commit != pr_push.

Tested: n/a

