### PR TITLE
gee update: use safer rebase flow when integrating changes from origin

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2759,8 +2759,8 @@ function gee__update() {
         _info "Pulling in changes from origin/${CURRENT_BRANCH}"
         HEAD="$("${GIT}" rev-parse HEAD)"
         _info "Old head commit before rebase: ${HEAD}"
-        _git rebase --autostash "origin/${CURRENT_BRANCH}"
-        _check_diff_for_merge_conflict_markers
+        _checkout_or_die "${CURRENT_BRANCH}"
+        _safer_rebase "${CURRENT_BRANCH}" "origin/${CURRENT_BRANCH}"
       else
         _info "You may need to \"git push -u origin --force\" to fix your origin remote."
       fi


### PR DESCRIPTION
Customer report says: they ran `gee update` to pull in commits that
other users had pushed onto their PR.  The commits caused merge
conflicts, leaving their branch in a bad state.

Root cause: When pull updated from origin, gee was assuming those
updates were safe and was using a naked `git rebase` invocation
instead of the safer rebase flow.

Fix: use the safer rebase flow with interactive conflict resolution
when merging commits from origin.

Tested:  testing in progress.  I won't submit until I've manually tested this flow,
but there's a few steps to get there.

