### PR TITLE
python3 hermetic toolchain bug fix: Fix missing pyyaml requirement in bazel target

### DIFF
--- a/bazel/appengine/configtools/BUILD.bazel
+++ b/bazel/appengine/configtools/BUILD.bazel
@@ -1,9 +1,14 @@
+load("@enkit_pip_deps//:requirements.bzl", "requirement")
+
 py_binary(
     name = "merge",
     srcs = [
         "merge.py",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        requirement("PyYAML"),
+    ],
 )
 
 py_binary(


### PR DESCRIPTION
This change explicitly declares pyyaml as a package dependency requirement to the `merge` py_binary target. This will fix the `//specs:specs-web-config` target in internal which is broken right now on master.

Tested: 
- `BAZEL_PROFILE=buildbarn bazel build --override_repository=enkit=$HOME/enkit //specs:specs-web-config`
- http://buddy.gcp01.corp.enfabrica.net/invocation/3b5b0d5c-061e-472d-8b41-f2457547ed1e
- `BAZEL_PROFILE=buildbarn bazel test $(bazel query "kind(py_*, //...)")`
```
INFO: Analyzed 23 targets (0 packages loaded, 0 targets configured).
INFO: Found 20 targets and 3 test targets...
INFO: Elapsed time: 13.588s, Critical Path: 13.47s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//bazel/linux/kunit:kunit_test                                  (cached) PASSED in 0.2s
//tools/codegen:data_loader_test                                (cached) PASSED in 0.2s
//tools/codegen:data_loader_benchmark                                    PASSED in 13.3s

Executed 1 out of 3 tests: 3 tests pass.
```

JIRA: INFRA-4606