### PR TITLE
qemu-template: Add tmpfs mount for root directory and /var/log

### DIFF
--- a/bazel/linux/templates/init-qemu.template.sh
+++ b/bazel/linux/templates/init-qemu.template.sh
@@ -15,10 +15,6 @@ test "$dir" == "$path" || cd "$dir"
 
 set -e
 
-# Remount / with the nosuid flag. Otherwise the following mount fails with:
-# mount: only root can use "--options" option (effective UID is 65534)
-python -c 'import ctypes; exit(ctypes.cdll.LoadLibrary("libc.so.6").mount("", "/", "", 2|32, 0))'
-
 mount --types tmpfs tmpfs /tmp
 
 # Mount the output directory. This directory is shared with the host.
@@ -27,5 +23,11 @@ mkdir "$OUTPUT_DIR"
 mount --types 9p \
     --options trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl \
     /dev/output_dir "$OUTPUT_DIR"
+
+# setup skeleton for root access
+mount -t tmpfs none /var/log/
+mount -t tmpfs none /root/
+mkdir -p /root/.ssh
+chmod 700 /root /root/.ssh
 
 {commands}


### PR DESCRIPTION
Allow VMs to have root access via ssh by creating a tmpfs based home directory for root (needed because VMs run as non-root and root id is squashed from host perspective) and /var/log (access to btmp file).

Remove the nosuid remount of base path.