### PR TITLE
hw dev v2: Support using local path to enkit for astore_download

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -122,7 +122,7 @@ def _astore_download_impl(ctx):
     if ctx.executable.astore_client:
         command = ctx.executable.astore_client.path
     else:
-        command = "/opt/enfabrica/bin/enkit astore"
+        command = "%s astore" % ctx.attr.astore_path
     command += " download --no-progress --overwrite -o %s" % output.path
     execution_requirements = {
             # We can't run these remotely since remote workers won't have
@@ -201,6 +201,9 @@ _astore_download = rule(
             executable = True,
             cfg = "host",
         ),
+        "astore_path": attr.string(
+            doc = "Absolute path to the enkit binary that should only be set by the bazel macro.",
+        ),
     },
     doc = """Downloads artifacts from artifact store - astore.
 
@@ -211,6 +214,8 @@ files from an artifact store.""",
 def astore_download(*args, **kwargs):
     if "astore_client" not in kwargs:
         kwargs["astore_client"] = Label("//astore/client:astore")
+    else:
+        kwargs["astore_path"] = kwargs.pop("astore_client")
     return _astore_download(*args, **kwargs)
 
 def _astore_download_and_verify(rctx, dest, uid, digest, timeout):


### PR DESCRIPTION
This change adds a new field to the `astore_download()` rule to allow using the locally installed `/opt/enfabrica/bin/enkit astore` binary instead of building astore from source. This will decouple PD and DFT targets in the Sonora container from using gcc-10 to build protobuf dependencies required by `enkit astore`. If `HOME` is not set, then `enkit` will complain in the sandbox that it cannot find it. In the future, PD and DFT targets should either download dependencies via the workspace rule `astore_package()` or via an absolute path under `/edatools` automatically deployed via pubhook.

Tested in the Sonora container:
- `bazel build --action_env=HOME=$HOME --override_repository=enkit=/home/bbhuynh/enkit //hw/projects/mlm/imp/pd/fp_defs:swc_bm_4bank_128b_pd-fp_def` passes when `astore_client = "/opt/enfabrica/bin/enkit"` in the target as expected.
- `bazel build --action_env=HOME=$HOME --override_repository=enkit=/home/bbhuynh/enkit //hw/projects/mlm/imp/pd/fp_defs:swc_bm_4bank_128b_pd-fp_def` fails as expected when the `astore_client` attribute is omitted since bazel attempts to build `enkit astore` from source.

Expected passing case:
```
INFO: From Action hw/projects/mlm/imp/pd/fp_defs/swc_bm_4bank_128b_pd.fp.pg.def.gz:
Directly downloadable
 | Created                 Creator                        Arch           MD5                              UID                              Size    TAGs          
 | 2022-11-07 19:14:25.621 antarsingh@enfabrica.net       all            91d23c3f787250611a54964c4f2fbf83 86ux83xvetzu36rmehikzi33gi8bfio3 22 MB   [latest]
Target //hw/projects/mlm/imp/pd/fp_defs:swc_bm_4bank_128b_pd-fp_def up-to-date:
  bazel-bin/hw/projects/mlm/imp/pd/fp_defs/swc_bm_4bank_128b_pd.fp.pg.def.gz
INFO: Elapsed time: 2.571s, Critical Path: 1.40s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
```
Expected failing case:
```
Running: /home/bbhuynh/.cache/bazelisk/downloads/bazelbuild/bazel-6.0.0-linux-x86_64/bin/bazel --bazelrc=/tmp/bazelrc.vS8UtA build --action_env=HOME=/home/bbhuynh --override_repository=enkit=/home/bbhuynh/enkit :swc_bm_4bank_128b_pd-fp_def
INFO: Analyzed target //hw/projects/mlm/imp/pd/fp_defs:swc_bm_4bank_128b_pd-fp_def (388 packages loaded, 13020 targets configured).
INFO: Found 1 target...
ERROR: /home/bbhuynh/.cache/bazel/_bazel_bbhuynh/f5f4b4917f8f987ac1333504c41186dc/external/com_google_protobuf/BUILD:155:11: Compiling src/google/protobuf/arenastring.cc [for tool] failed: (Exit 1): gcc-10 failed: error executing command (from target @com_google_protobuf//:protobuf_lite) /usr/bin/gcc-10 -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 ... (remaining 33 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ERROR: This is a dummy gcc-10 used to bypass bazel toolchain checks
```

JIRA: INFRA-4783
