### PR TITLE
gee check: wait for checks to start

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4007,10 +4007,17 @@ function gee__pr_check() {
   while [[ "${PENDING}" -ne 0 ]]; do
     if VERBOSE=0 DONT_WARN=1 _read_cmd CHECKS "${GH}" pr checks; then
       printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
-      # no failures, nothing pending.
-      _info "All checks successful."
-      CHECKS_FAILED=0
-      PENDING=0
+      # Sometimes github takes a long time to start presubmit tasks, and "gh pr checks"
+      # will incorrectly return "success" when the checks simply haven't started yet.
+      # We check for that condition by making sure the CHECKS list isn't empty.
+      if [[ "${#CHECKS[@]}" == 0 ]]; then
+        _info "Waiting for checks to start."
+      else
+        # no failures, nothing pending.
+        _info "All checks successful."
+        CHECKS_FAILED=0
+        PENDING=0
+      fi
     else
       # something went wrong.  Is a test pending, or did we get a failure?
       _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -4009,8 +4009,10 @@ function gee__pr_check() {
       printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
       # Sometimes github takes a long time to start presubmit tasks, and "gh pr checks"
       # will incorrectly return "success" when the checks simply haven't started yet.
-      # We check for that condition by making sure the CHECKS list isn't empty.
-      if [[ "${#CHECKS[@]}" == 0 ]]; then
+      # We check for that condition by making sure the CHECKS list isn't empty, and
+      # doesn't contain a string like:
+      #    "no checks reported on the 'gee_no_empty_checks' branch"
+      if [[ "${#CHECKS[@]}" == 0 ]] || [[ "${CHECKS[0]}" == "no checks reported "* ]]; then
         _info "Waiting for checks to start."
       else
         # no failures, nothing pending.


### PR DESCRIPTION
Previously, we had this bug:

`gee rerun; gee pr_submit --wait`

Would incorrectly submit a PR even though the checks hadn't started yet.  The
issue is that github is slow, and so after requesting presubmits, there is
a period of time where `gh pr check` tells us that there are no presubmits
and returns a "success" return code.

We don't want that -- so now gee will verify that at least one presubmit check
is being reprorted by `gh pr check` before confirming that checks have passed.
There's still a risk of fast presubmit checks completing before slow presubmit
checks have even started, but I don't know quite what the right solution is
(yet), and this fix will correct the problem >99% of the time.

Tested: `gee rerun && gee check --wait`

