### PR TITLE
bazel: Runner template should be capable of running in non bash env

### DIFF
--- a/bazel/utils/remote/runner.template.sh
+++ b/bazel/utils/remote/runner.template.sh
@@ -130,7 +130,7 @@ done
 }
 
 # TODO(cccontavalli): better escaping, will fix it once we have more tests.
-command="cd $destrun; MACHINES='${DESTS[*]}' ./$executable ${TARGET_OPTS[*]}"
+command="cd $destrun; /bin/bash -c \"MACHINES='${DESTS[*]}' ./$executable ${TARGET_OPTS[*]}\""
 [ "$ONLY_COPY" != "true" ] || {
   echo "Copy only mode was requested - not running any command"
   echo "Would have run:"

--- a/bazel/utils/testdata/remote/simple.ssh.expected
+++ b/bazel/utils/testdata/remote/simple.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world 
+non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world "

--- a/bazel/utils/testdata/remote/with-all-basic.ssh.expected
+++ b/bazel/utils/testdata/remote/with-all-basic.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd ~/__bazel_utils_wrapper/enkit; MACHINES='non-existant-machine-1.corp' ./bazel/utils/wrapper 
+non-existant-machine-1.corp -- cd ~/__bazel_utils_wrapper/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp' ./bazel/utils/wrapper "

--- a/bazel/utils/testdata/remote/with-decorated-wrapper.ssh.expected
+++ b/bazel/utils/testdata/remote/with-decorated-wrapper.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd santa-coming/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/decorated-wrapper-wrapper --wrapper_opt1=foo --wrapper-opt2 -- bazel/utils/hello-world --target_opt1=foo --wrapper-opt3
+non-existant-machine-1.corp -- cd santa-coming/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/decorated-wrapper-wrapper --wrapper_opt1=foo --wrapper-opt2 -- bazel/utils/hello-world --target_opt1=foo --wrapper-opt3"

--- a/bazel/utils/testdata/remote/with-destdir.ssh.expected
+++ b/bazel/utils/testdata/remote/with-destdir.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world 
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world "

--- a/bazel/utils/testdata/remote/with-local-dir.ssh.expected
+++ b/bazel/utils/testdata/remote/with-local-dir.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp /tmp/testdir/' ./bazel/utils/hello-world --target_opt1=foo
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp /tmp/testdir/' ./bazel/utils/hello-world --target_opt1=foo"

--- a/bazel/utils/testdata/remote/with-noop-inputs.ssh.expected
+++ b/bazel/utils/testdata/remote/with-noop-inputs.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp' ./bazel/utils/hello-world 
+non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp' ./bazel/utils/hello-world "

--- a/bazel/utils/testdata/remote/with-opts.ssh.expected
+++ b/bazel/utils/testdata/remote/with-opts.ssh.expected
@@ -1,1 +1,1 @@
--ssh1=foo -ssh2 non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world -taget1=foo -target2
+-ssh1=foo -ssh2 non-existant-machine-1.corp -- cd ~/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/hello-world -taget1=foo -target2"

--- a/bazel/utils/testdata/remote/with-remote-dir-inverted.ssh.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir-inverted.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-2.corp:my-specific-dir/test/ -- cd non-existant-machine-2.corp:my-specific-dir/test//enkit; MACHINES='non-existant-machine-2.corp:my-specific-dir/test/ non-existant-machine-1.corp' ./bazel/utils/hello-world --target_opt1=foo
+non-existant-machine-2.corp:my-specific-dir/test/ -- cd non-existant-machine-2.corp:my-specific-dir/test//enkit; /bin/bash -c "MACHINES='non-existant-machine-2.corp:my-specific-dir/test/ non-existant-machine-1.corp' ./bazel/utils/hello-world --target_opt1=foo"

--- a/bazel/utils/testdata/remote/with-remote-dir.ssh.expected
+++ b/bazel/utils/testdata/remote/with-remote-dir.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp:my-specific-dir/test/' ./bazel/utils/hello-world --target_opt1=foo
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp:my-specific-dir/test/' ./bazel/utils/hello-world --target_opt1=foo"

--- a/bazel/utils/testdata/remote/with-wrapper.ssh.expected
+++ b/bazel/utils/testdata/remote/with-wrapper.ssh.expected
@@ -1,1 +1,1 @@
-non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/wrapper --wrapper_opt1=foo -- bazel/utils/hello-world --target_opt1=foo
+non-existant-machine-1.corp -- cd hw-dev-$USER/home/$USER/__bazel_utils_hello-world/enkit; /bin/bash -c "MACHINES='non-existant-machine-1.corp non-existant-machine-2.corp' ./bazel/utils/wrapper --wrapper_opt1=foo -- bazel/utils/hello-world --target_opt1=foo"


### PR DESCRIPTION
The runner template syntax does not correctly work in the case of csh, this change fixes the failure by running the command in a bash env.