### PR TITLE
bazel/linux: various feature additions in preparation for next PR

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -1,5 +1,6 @@
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "RuntimeBundleInfo", "RuntimeInfo")
 load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible")
+load("//bazel/linux:runner.bzl", "expand_targets_and_bundles")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("@bazel_skylib//lib:shell.bzl", "shell")
@@ -19,7 +20,7 @@ def _add_attr_bundle(ctx, bundle, name):
         info["binary"] = di.files_to_run.executable
         info["runfiles"] = di.default_runfiles
 
-    bundle[name] = RuntimeInfo(**info)
+    bundle[name] = [RuntimeInfo(**info)]
 
 def _vm_bundle(ctx):
     bundle = {}
@@ -220,8 +221,8 @@ def _kunit_bundle(ctx):
     return [
         DefaultInfo(files = depset([init, check]), runfiles = inside_runfiles.merge(outside_runfiles)),
         RuntimeBundleInfo(
-            run = RuntimeInfo(binary = init, runfiles = inside_runfiles),
-            check = RuntimeInfo(binary = check, runfiles = outside_runfiles),
+            run = [RuntimeInfo(binary = init, runfiles = inside_runfiles)],
+            check = [RuntimeInfo(binary = check, runfiles = outside_runfiles)],
         ),
     ]
 

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -377,42 +377,6 @@ def kernel_module(*args, **kwargs):
 
     return _kernel_module_targets(*args, **kwargs)
 
-def nv_driver(*args, **kwargs):
-    """Convenience wrapper around kernel_modules_rule.
-
-    Use this wrpaper for building the NVidia driver modules.
-
-    The parameters passed to nv_driver are just passed to nv_driver_rule, except for
-    what is listed below.
-
-    Args:
-      srcs: list of labels, specifying the source files that constitute the kernel module.
-            If not specified, nv_driver will provide a reasonable default including all
-            files that are typically part of a kernel module (i.e., the specified makefile
-            and all .c and .h files belonging to the package where the kernel_module rule
-            has been instantiated, see https://docs.bazel.build/versions/master/be/functions.html#glob).
-      modules: list of strings, naming the output modules. Mandatory. Also, it normalizes the
-            names ensuring they have a '.ko' suffix.
-      makefile: string, name of the makefile to build the driver. If not specified, nv_driver
-            assumes it is just called Makefile.
-      kernel: a label, indicating the kernel_tree to build the module against. nv_driver ensures
-            the label starts with an '@', as per bazel convention.
-      kernels: list of kernel (same as above). kernel_module will instantiate multiple
-            kernel_module_rule, one per kernel, and ensure they all build in parallel.
-    """
-
-    if "makefile" not in kwargs:
-        kwargs["makefile"] = "Makefile"
-
-    if "srcs" not in kwargs:
-        include = ["**/*.c", "**/*.h", "Kbuild", "**/*.Kbuild", "conftest.sh", "**/*.o_binary", kwargs["makefile"]]
-        kwargs["srcs"] = native.glob(include = include, exclude = BUILD_LEFTOVERS, allow_empty = False)
-
-    if "make_format_str" not in kwargs:
-        kwargs["make_format_str"] = "-C $PWD/{src_dir} SYSSRC=$PWD/{kernel_build_dir} SYSOUT=$PWD/{kernel_build_dir} -j modules"
-
-    return _kernel_module_targets(*args, **kwargs)
-
 def _kernel_tree(ctx):
     return [DefaultInfo(files = depset(ctx.files.files)), KernelTreeInfo(
         name = ctx.attr.name,

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -70,6 +70,7 @@ RuntimeBundleInfo = provider(
     doc = """Represents something to run in a VM environment.""",
     fields = {
         "prepare": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM BEFORE the RUN to prepare the environment",
+        "init": "RuntimeInfo, executable (and its runfiles) to run INSIDE the VM to prepare it",
         "run": "RuntimeInfo, executable (and its runfiles) to run INSIDE the VM",
         "cleanup": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN (in reverse order) to clean up the environment",
         "check": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN to check if the run was successful",

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -58,6 +58,7 @@ and have basic tools available necessary for its users.
 RuntimeInfo = provider(
     doc = """Represents a binary to run""",
     fields = {
+        "origin": "bool, set to true if the commands print origin information for debug purposes",
         "commands": "list of string, shell commands to embed in the script before running the binary",
         "binary": "File object, executable, binary to run",
         "runfiles": "runfiles() object, representing the files needed by the binary at run time",
@@ -69,10 +70,10 @@ RuntimeInfo = provider(
 RuntimeBundleInfo = provider(
     doc = """Represents something to run in a VM environment.""",
     fields = {
-        "prepare": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM BEFORE the RUN to prepare the environment",
-        "init": "RuntimeInfo, executable (and its runfiles) to run INSIDE the VM to prepare it",
-        "run": "RuntimeInfo, executable (and its runfiles) to run INSIDE the VM",
-        "cleanup": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN (in reverse order) to clean up the environment",
-        "check": "RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN to check if the run was successful",
+        "prepare": "list of RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM BEFORE the RUN to prepare the environment",
+        "init": "list of RuntimeInfo, executable (and its runfiles) to run INSIDE the VM to prepare it",
+        "run": "list of RuntimeInfo, executable (and its runfiles) to run INSIDE the VM",
+        "cleanup": "list of RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN (in reverse order) to clean up the environment",
+        "check": "list of RuntimeInfo, executable (and its runfiles) to run OUTSIDE the VM AFTER the RUN to check if the run was successful",
     },
 )

--- a/bazel/linux/runner.bzl
+++ b/bazel/linux/runner.bzl
@@ -5,6 +5,8 @@ load("//bazel/utils:files.bzl", "files_to_dir")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def create_runner_attrs(template_init_default):
+    """Returns a dict of attributes common to all runners.""" 
+
     return {
         "kernel_image": attr.label(
             mandatory = True,
@@ -47,51 +49,52 @@ emulator flags from those passed to the wrapper.
         ),
     }
 
-def commands_and_runtime(ctx, msg, runs, runfiles, verbose = True):
+def commands_and_runtime(ctx, msg, runs):
     """Computes commands and runfiles from a list of RuntimeInfo"""
     commands = []
-    runfiles = ctx.runfiles().merge(runfiles)
+    runfiles = ctx.runfiles()
     labels = []
-    for r, rbi in runs:
-        if not hasattr(rbi, "commands") and (not hasattr(rbi, "binary") or not rbi.binary):
-            fail(location(ctx) + (" the '{msg}' step in {target} must be executable, " +
-                                  "and have a binary defined, or provide commands to run").format(msg = msg, target = package(r.label)))
+    for r, rbl in runs:
+        for rbi in rbl:
+            if not hasattr(rbi, "commands") and (not hasattr(rbi, "binary") or not rbi.binary):
+                fail(location(ctx) + (" the '{msg}' step in {target} must be executable, " +
+                                      "and have a binary defined, or provide commands to run").format(msg = msg, target = package(r.label)))
 
-        if hasattr(rbi, "commands") and rbi.commands:
-            if verbose:
-                commands.append("echo '==== {msg}: {target} -- inline commands'".format(
-                    msg = msg,
-                    target = package(r.label),
-                ))
-                labels.append(str(r.label))
-            commands.extend(rbi.commands)
-            for command in rbi.commands:
-                labels.append("{label}:{cmd}".format(label = r.label, cmd = command))
+            if hasattr(rbi, "commands") and rbi.commands:
+                if not getattr(rbi, "origin", False):
+                    commands.append("echo '==== {msg}: {target} -- inline commands'".format(
+                        msg = msg,
+                        target = package(r.label),
+                    ))
+                    labels.append(str(r.label))
+                commands.extend(rbi.commands)
+                for command in rbi.commands:
+                    labels.append("{label}:{cmd}".format(label = r.label, cmd = command))
 
-        if hasattr(rbi, "binary") and rbi.binary:
-            binary = rbi.binary
-            args = ""
-            if hasattr(rbi, "args"):
-                args = rbi.args
+            if hasattr(rbi, "binary") and rbi.binary:
+                binary = rbi.binary
+                args = ""
+                if hasattr(rbi, "args"):
+                    args = rbi.args
 
-            if verbose:
-                commands.append("echo '==== {msg}: {target} as \"{path} {args}\"...'".format(
-                    msg = msg,
-                    target = package(r.label),
-                    path = rbi.binary.short_path,
+                if not getattr(rbi, "origin", False):
+                    commands.append("echo '==== {msg}: {target} as \"{path} {args}\"...'".format(
+                        msg = msg,
+                        target = package(r.label),
+                        path = rbi.binary.short_path,
+                        args = args,
+                    ))
+                    labels.append(str(r.label))
+                commands.append("{binary} {args}".format(
+                    binary = shell.quote(binary.short_path),
                     args = args,
                 ))
                 labels.append(str(r.label))
-            commands.append("{binary} {args}".format(
-                binary = shell.quote(binary.short_path),
-                args = args,
-            ))
-            labels.append(str(r.label))
 
-            runfiles = runfiles.merge(ctx.runfiles([binary]))
+                runfiles = runfiles.merge(ctx.runfiles([binary]))
 
-        if hasattr(rbi, "runfiles") and rbi.runfiles:
-            runfiles = runfiles.merge(rbi.runfiles)
+            if hasattr(rbi, "runfiles") and rbi.runfiles:
+                runfiles = runfiles.merge(rbi.runfiles)
 
     if len(labels) != len(commands):
         fail(location(ctx) +
@@ -103,6 +106,16 @@ def commands_and_runtime(ctx, msg, runs, runfiles, verbose = True):
     return commands, runfiles, labels
 
 def get_prepare_run_check(ctx, run):
+    """Returns a [(label, [RuntimeInfo]), ...] for each bundle or bin in run.
+
+    Args:
+      ctx: a bazel context, used for debug/error messages.
+      run: a list of executable targets or RuntimeBundleInfo objects.
+
+    Returns:
+      (prepares, inits, runs, checks, cleanups), where each of them is an array
+      of (label, [RuntimeInfo]) defining what to run in each of those steps. 
+    """
     prepares = []
     inits = []
     runs = []
@@ -130,12 +143,61 @@ def get_prepare_run_check(ctx, run):
                                       target = package(r.label),
                                   )))
 
-        runs.append((r, RuntimeInfo(
+        runs.append((r, [RuntimeInfo(
             binary = di.files_to_run.executable,
             runfiles = di.default_runfiles,
-        )))
+        )]))
     cleanups = list(reversed(cleanups))
     return prepares, inits, runs, cleanups, checks
+
+def expand_targets_and_bundles(ctx, attr, verbose = True):
+    """Returns the commands to run for the binaries or bundles supplied.
+
+    Args:
+      ctx: a bazel context, used for error message purposes.
+      attr: generally a label_list attribute, a list of targets that are either
+        executable, or represent a bundle, with the RuntimeBundleInfo provider.
+
+    Returns:
+      A struct representing the commands to run for each phase and the
+      required labels and runfiles.
+    """
+    prepares, inits, runs, cleanups, checks = get_prepare_run_check(ctx, attr)
+
+    cprepares, rprepares, lprepares = commands_and_runtime(ctx, "prepare", prepares)
+    cchecks, rchecks, lchecks = commands_and_runtime(ctx, "check", checks)
+    ccleanups, rcleanups, lcleanups  = commands_and_runtime(ctx, "cleanup", cleanups)
+    outside_runfiles = ctx.runfiles().merge_all([rprepares, rchecks, rcleanups])
+
+    cinits, rinits, linits = commands_and_runtime(ctx, "init", inits)
+    cruns, rruns, lruns = commands_and_runtime(ctx, "run", runs)
+    inside_runfiles = ctx.runfiles().merge_all([rinits, rruns])
+
+    return struct(
+        inside_runfiles = inside_runfiles,
+        outside_runfiles = outside_runfiles,
+        commands = struct(
+            prepare = cprepares,
+            check = cchecks,
+            cleanup = ccleanups,
+            init = cinits,
+            run = cruns,
+        ),
+        runfiles = struct(
+            prepare = rprepares,
+            check = rchecks,
+            cleanup = rcleanups,
+            init = rinits,
+            run = rruns,
+        ),
+        labels = struct(
+            prepare = lprepares,
+            check = lchecks,
+            cleanup = lcleanups,
+            init = linits,
+            run = lruns,
+        ),
+    )
 
 def create_runner(ctx, archs, code, runfiles = None, extra = {}):
     ki = ctx.attr.kernel_image[KernelImageInfo]
@@ -149,18 +211,7 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
             ),
         )
 
-    prepares, inits, runs, cleanups, checks = get_prepare_run_check(ctx, ctx.attr.run)
-
-    outside_runfiles = ctx.runfiles()
-    if runfiles:
-        outside_runfiles = outside_runfiles.merge(runfiles)
-    cprepares, outside_runfiles, _ = commands_and_runtime(ctx, "prepare", prepares, outside_runfiles)
-    cchecks, outside_runfiles, _ = commands_and_runtime(ctx, "check", checks, outside_runfiles)
-    ccleanups, outside_runfiles, _ = commands_and_runtime(ctx, "cleanup", cleanups, outside_runfiles)
-
-    inside_runfiles = ctx.runfiles()
-    cinits, inside_runfiles, _ = commands_and_runtime(ctx, "init", inits, inside_runfiles)
-    cruns, inside_runfiles, _ = commands_and_runtime(ctx, "run", runs, inside_runfiles)
+    torun = expand_targets_and_bundles(ctx, ctx.attr.run)
 
     init = ctx.actions.declare_file(ctx.attr.name + "-init.sh")
     ctx.actions.expand_template(
@@ -170,8 +221,8 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
             "{message}": "INIT STARTED",
             "{target}": package(ctx.label),
             "{relpath}": init.short_path,
-            "{inits}": "\n".join(cinits),
-            "{commands}": "\n".join(cruns),
+            "{inits}": "\n".join(torun.commands.init),
+            "{commands}": "\n".join(torun.commands.run),
         },
         is_executable = True,
     )
@@ -179,10 +230,12 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
     runtime_root = files_to_dir(
         ctx,
         ctx.attr.name + "-root",
-        inside_runfiles.files.to_list() + [init],
+        torun.inside_runfiles.files.to_list() + [init],
         post = "cd {dest}; cp -L %s ./init.sh" % (shell.quote(init.short_path)),
     )
-    outside_runfiles = outside_runfiles.merge(ctx.runfiles([runtime_root, ki.image]))
+    outside_runfiles = torun.outside_runfiles.merge(ctx.runfiles([runtime_root, ki.image]))
+    if runfiles:
+      outside_runfiles = outside_runfiles.merge(runfiles)
 
     rootfs = ""
     if ctx.attr.rootfs_image:
@@ -191,9 +244,9 @@ def create_runner(ctx, archs, code, runfiles = None, extra = {}):
 
     subs = dict({
         "target": package(ctx.label),
-        "prepares": "\n".join(cprepares),
-        "cleanups": "\n".join(ccleanups),
-        "checks": "\n".join(cchecks),
+        "prepares": "\n".join(torun.commands.prepare),
+        "cleanups": "\n".join(torun.commands.cleanup),
+        "checks": "\n".join(torun.commands.check),
         "kernel": ki.image.short_path,
         "rootfs": rootfs,
         "init": init.short_path,

--- a/bazel/linux/templates/init-qemu.template.sh
+++ b/bazel/linux/templates/init-qemu.template.sh
@@ -28,4 +28,6 @@ mount --types 9p \
     --options trans=virtio,version=9p2000.L,msize=5000000,cache=mmap,posixacl \
     /dev/output_dir "$OUTPUT_DIR"
 
+{inits}
+
 {commands}

--- a/bazel/linux/templates/init-uml.template.sh
+++ b/bazel/linux/templates/init-uml.template.sh
@@ -10,4 +10,5 @@ dir="${path%%$relpath}"
 test "$dir" == "$path" || cd "$dir"
 
 set -e
+{inits}
 {commands}


### PR DESCRIPTION
The next PR will add support for always being able to start an sshd
server within the test, and providing a cozier debugging environment.

A pre-requisite is to define the steps/commands necessary to run a
test, versus the steps/commands necessary to setup the environment.

This set of commits expands the capabilities of vm_bundle and friends
to support this.

- bazel/linux: remove nv_.* related rules, that are unused and obsolete.
- bazel/linux: add support for initialization steps in vm setup.
- bazel/linux: expand bundle capabilities to support list of binaries.
- bazel/linux: expand bundles to support recursive expansion.
- bazel/linux: improve qemu_test target to propagate init correctly.
