### PR TITLE
enkit: Always build cgo-enabled enkit for Linux

### DIFF
--- a/enkit/BUILD.bazel
+++ b/enkit/BUILD.bazel
@@ -60,7 +60,7 @@ astore_upload(
     name = "deploy",
     file = "tools/enkit",
     targets = [
-        ":enkit-linux-amd64",
+        ":enkit-linux-cgo-amd64",
         ":enkit-darwin-amd64",
         ":enkit-win-amd64",
     ],


### PR DESCRIPTION
Cadence chamber machines require a cgo-enabled version of `enkit` in order to properly resolve DNS names via e.g. NIS. This change swaps out the default build of enkit Linux binaries from pure-Go to cgo to build this cgo version by default, which should also be compatible with all other current environments.

Tested: `bazel run //enkit:enkit-linux-cgo-amd64 -- astore ls` still works locally

Jira: INFRA-5312