### PR TITLE
enproxy: Define config changes for conditionally adding headers

### DIFF
--- a/proxy/httpp/interface.go
+++ b/proxy/httpp/interface.go
@@ -20,6 +20,23 @@ type Regex struct {
 	match      *regexp.Regexp
 }
 
+type HeaderGroupMapping struct {
+	// Header which should get a value
+	Header string
+	// List of groups that should be tested. The header gets the value of the
+	// first group that matches the current request. If no match occurs, the
+	// request is rejected.
+	GroupMapping []ValueByGroup
+}
+
+type ValueByGroup struct {
+	// Name of the group this value should apply to. If set to the empty string,
+	// should match all requests (as a sort of "default case").
+	Group string
+	// If the group specifier matches, this value is used.
+	Value string
+}
+
 func (t *Regex) Compile() error {
 	var err error
 	t.match, err = regexp.Compile(t.Match)
@@ -80,6 +97,14 @@ type Transform struct {
 	// For example, by setting MapRequestHeaders to "Sec-Websocket-Key" to "Sec-WebSocket-Key"
 	// the case for WebSocket will be changed.
 	MapRequestHeaders map[string]string
+
+	// Add additional headers based on the groups the user is part of.
+	// This is useful to conditionally set headers based on the user's identity -
+	// for instance, to add an "X-Webauth-Role" to Grafana requests to indicate
+	// the user's role in Grafana.
+	//
+	// TODO(INFRA-4919): Implement this feature
+	MapRequestHeadersByGroup []HeaderGroupMapping
 
 	stripCookie     []*regexp.Regexp
 	noSlashFromPath string


### PR DESCRIPTION
This change defines the new types and additions to the enproxy config struct that enable mapping headers to request based on the user's groups.

The proposal enables a config spelled like:

```yaml
- from:
    host: 'monitoring.corp.enfabrica.net'
  to: http://127.0.0.1:3000/
  transform:
    xwebauth: "set"
    mapRequestHeadersByGroup:
    - header: X-Webauth-Role
      groupMapping:
      - group: foo
        value: Admin
      - group: bar
        value: Editor
      - group: ""
        value: Viewer
```

To translate to: "Add `X-Webauth-Role: Admin` to users in the `foo`
group; add `X-Webauth-Role: Editor` to users in the `bar` group; add
`X-Webauth-Role: Viewer` to everyone else".

Tested: N/A

Jira: INFRA-4919