### PR TITLE
enproxy: Implement mapRequestHeadersByGroup

### DIFF
--- a/lib/oauth/ogoogle/BUILD.bazel
+++ b/lib/oauth/ogoogle/BUILD.bazel
@@ -24,7 +24,7 @@ go_test(
     deps = [
         "//lib/logger:go_default_library",
         "//lib/oauth:go_default_library",
-        "//lib/oauth/providers:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )

--- a/lib/slice/BUILD.bazel
+++ b/lib/slice/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["slice.go"],
+    importpath = "github.com/enfabrica/enkit/lib/slice",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["slice_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+)

--- a/lib/slice/slice.go
+++ b/lib/slice/slice.go
@@ -1,0 +1,10 @@
+package slice
+
+// ToSet returns a map that acts as a set from the contents of slice s.
+func ToSet[T comparable](s []T) map[T]struct{} {
+	m := map[T]struct{}{}
+	for _, elem := range s {
+		m[elem] = struct{}{}
+	}
+	return m
+}

--- a/lib/slice/slice_test.go
+++ b/lib/slice/slice_test.go
@@ -1,0 +1,43 @@
+package slice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToSet(t *testing.T) {
+	testCases := []struct {
+		desc string
+		s    []string
+		want map[string]struct{}
+	}{
+		{
+			desc: "nil slice",
+			s:    nil,
+			want: map[string]struct{}{},
+		},
+		{
+			desc: "empty slice",
+			s:    []string{},
+			want: map[string]struct{}{},
+		},
+		{
+			desc: "small slice",
+			s:    []string{"foo", "bar"},
+			want: map[string]struct{}{"foo": struct{}{}, "bar": struct{}{}},
+		},
+		{
+			desc: "deduplicates repeats",
+			s:    []string{"foo", "bar", "foo", "foo", "bar"},
+			want: map[string]struct{}{"foo": struct{}{}, "bar": struct{}{}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := ToSet(tc.s)
+
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/proxy/httpp/BUILD.bazel
+++ b/proxy/httpp/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//lib/logger:go_default_library",
         "//lib/multierror:go_default_library",
         "//lib/oauth:go_default_library",
+        "//lib/slice:go_default_library",
         "//proxy/amux:go_default_library",
     ],
 )


### PR DESCRIPTION
This change implements the "map request headers by group" functionality, which allows header values to be assigned to a given header conditionally based on group matching. #890 has context on how the feature works.

In order to simplify the logic a bit, a helper library is created to convert slices into maps, reducing the need for nested `for` loops within the feature implementation itself.

Tested: unit tests only

Jira: INFRA-4919