### PR TITLE
bazel/linux: fix breakages introduced by PR#878, variuos improvements

### DIFF
--- a/bazel/linux/bundles.bzl
+++ b/bazel/linux/bundles.bzl
@@ -1,6 +1,6 @@
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "RuntimeBundleInfo", "RuntimeInfo")
 load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible")
-load("//bazel/linux:runner.bzl", "expand_targets_and_bundles", "runtime_info_from_target")
+load("//bazel/linux:runner.bzl", "get_prepare_run_check", "runtime_info_from_target")
 load("//bazel/utils:messaging.bzl", "location", "package")
 load("//bazel/utils:files.bzl", "files_to_dir")
 load("@bazel_skylib//lib:shell.bzl", "shell")
@@ -25,7 +25,8 @@ def _add_attr_bundle(ctx, bundle, name, merge = [], distribute = []):
         fail(location(ctx) + "has {name}_bin pointing to a vm_bundle and also defines {name}_args - which is not allowed".format(name = name))
 
     rtis = []
-    # If abin has no arguments, it is allowed to be a bundle. Rely on expand_targets_and_bundles below.
+    # If abin has no arguments, it is allowed to be a bundle. Rely on expand_targets_and_bundles
+    # to compute the actual RuntimeInfo to use.
     if abin and not aargs:
         abins = [abin] + abins
         abin = None
@@ -33,14 +34,16 @@ def _add_attr_bundle(ctx, bundle, name, merge = [], distribute = []):
         rtis += [runtime_info_from_target(ctx, abin, commands = acmds, args = aargs)]
 
     if abins:
-        torun = expand_targets_and_bundles(ctx, abins)
-        rtis.append(RuntimeInfo(origin = True, commands = getattr(torun.commands, name), runfiles = getattr(torun.runfiles, name)))
+        # Why action=name? Naked binaries (not bundles!) listed in the specific attribute
+        # need to be assigned to that specific step. Eg, if we're processing the "prepare"
+        # actions, a binary outside a bundle should be considered a "prepare" command, not
+        # a run command. And those binaries are allowed to appear anywhere.
+        bundles = get_prepare_run_check(ctx, abins, action=name)
+        rtis.extend(getattr(bundles, name, []))
         for step in merge:
-            if getattr(torun.commands, step) or getattr(torun.runfiles, step):
-              rtis.append(RuntimeInfo(origin = True, commands = getattr(torun.commands, step), runfiles = getattr(torun.runfiles, step)))
+            rtis.extend(getattr(bundles, step, []))
         for step in distribute:
-            if getattr(torun.commands, step) or getattr(torun.runfiles, step):
-              bundle.setdefault(step, []).append(RuntimeInfo(origin = True, commands = getattr(torun.commands, step), runfiles = getattr(torun.runfiles, step)))
+            bundle.setdefault(step, []).extend(getattr(bundles, step))
 
     bundle.setdefault(name, []).extend(rtis)
 
@@ -267,8 +270,8 @@ def _kunit_bundle(ctx):
     return [
         DefaultInfo(files = depset([init, check]), runfiles = inside_runfiles.merge(outside_runfiles)),
         RuntimeBundleInfo(
-            run = [RuntimeInfo(binary = init, runfiles = inside_runfiles)],
-            check = [RuntimeInfo(binary = check, runfiles = outside_runfiles)],
+            run = [RuntimeInfo(origin = ctx.label, binary = init, runfiles = inside_runfiles)],
+            check = [RuntimeInfo(origin = ctx.label, binary = check, runfiles = outside_runfiles)],
         ),
     ]
 

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -58,7 +58,7 @@ and have basic tools available necessary for its users.
 RuntimeInfo = provider(
     doc = """Represents a binary to run""",
     fields = {
-        "origin": "bool, set to true if the commands print origin information for debug purposes",
+        "origin": "label, where this RuntimeInfo was first defined, used for debug info",
         "commands": "list of string, shell commands to embed in the script before running the binary",
         "binary": "File object, executable, binary to run",
         "runfiles": "runfiles() object, representing the files needed by the binary at run time",


### PR DESCRIPTION
This PR fixes issues introduced in PR#878, and uses a better and simpler
approach to handle expansion of parameters.

More details in the descriptions of individual commits.

Tested: run all tests that failed in PRESUBMIT for:
https://github.com/enfabrica/internal/pull/17184

- bazel/linux: propagate arguments correctly.
- bazel/linux: use a better approach to handle recursion, fix bugs.
