### PR TITLE
bazel: Make all patches repo-absolute

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -245,7 +245,7 @@ def go_repositories():
         # This is a copy of this patch: https://raw.githubusercontent.com/buildbarn/bb-storage/master/patches/com_github_bazelbuild_remote_apis/golang.diff
         # with modifications:
         # - s/:longrunning_/:longrunningpb_/g
-        patches = ["//bazel/dependencies:remote_apis_fix_target_names.patch"],
+        patches = ["@enkit//bazel/dependencies:remote_apis_fix_target_names.patch"],
         sum = "h1:jVU/1F77AdTYfbUUBYDjRpyBQ+eRhniSeeY7i7rFaOs=",
         version = "v0.0.0-20230315170832-8f539af4b407",
     )
@@ -2129,7 +2129,7 @@ def go_repositories():
         patch_args = ["-p1"],
         patch_tool = "patch",
         patches = [
-            "//bazel/dependencies:datastore_query_toproto_exported.patch",
+            "@enkit//bazel/dependencies:datastore_query_toproto_exported.patch",
         ],
         sum = "h1:iF6I/HaLs3Ado8uRKMvZRvF/ZLkWaWE9i8AiHzbC774=",
         version = "v1.11.0",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -263,14 +263,14 @@ def stage_1():
             # To generate this patch:
             # * clone the source repo
             # * run `find . -name BUILD.bazel -delete`
-            "//bazel/dependencies:googleapis/delete_build_files.patch",
+            "@enkit//bazel/dependencies:googleapis/delete_build_files.patch",
             # set gazelle directives; change workspace name
-            "//bazel/dependencies:googleapis/add_directives.patch",
+            "@enkit//bazel/dependencies:googleapis/add_directives.patch",
             # Add new BUILD files
             # To generate this patch:
             # * clone the source repo
             # * run `gazelle -repo_root .`
-            "//bazel/dependencies:googleapis/generate_build_files.patch",
+            "@enkit//bazel/dependencies:googleapis/generate_build_files.patch",
         ],
         patch_args = ["-E", "-p1"],
     )


### PR DESCRIPTION
Currently, patch labels are specified starting with `//` (omitting `@enkit`) which makes them "repo-relative": when another repo calls a macro that has a repository rule that references a patch with this format, it looks for the patch within itself instead of enkit.

To avoid having to duplicate these patches in other repos, this change makes the patch paths absolute, so other repos will look for them within enkit itself.

Tested:
* Built internal targets via `--override_repository`; confirmed this fixes build in internal