### PR TITLE
enkit machine-cert: Implement `install` subcommand

### DIFF
--- a/enkit/machinecert/BUILD.bazel
+++ b/enkit/machinecert/BUILD.bazel
@@ -2,11 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["commands.go"],
+    srcs = [
+        "commands.go",
+        "install.go",
+    ],
     importpath = "github.com/enfabrica/enkit/enkit/machinecert",
     visibility = ["//visibility:public"],
     deps = [
+        "//astore/rpc/auth:go_default_library",
         "//lib/client:go_default_library",
+        "//lib/kcerts:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_x_crypto//ssh:go_default_library",
     ],
 )

--- a/enkit/machinecert/commands.go
+++ b/enkit/machinecert/commands.go
@@ -13,10 +13,11 @@ type Root struct {
 	*cobra.Command
 	*client.BaseFlags
 
-	PublicKeyPath string
-	PrivateKeyPath string
-	SignedCertPath string
-	SshdConfigPath string
+	PublicKeyPath   string
+	PrivateKeyPath  string
+	PublicCaKeyPath string
+	SignedCertPath  string
+	SshdConfigPath  string
 }
 
 func New(base *client.BaseFlags) (*Root, error) {
@@ -45,24 +46,30 @@ func NewRoot(base *client.BaseFlags) (*Root, error) {
 		&rc.PublicKeyPath,
 		"public-key-path",
 		"/etc/ssh/machinist_host_key.pub",
-		"Path to location where unsigned public key should be read from or installed to",
+		"Path to location where unsigned public key should be installed to",
+	)
+	rc.PersistentFlags().StringVar(
+		&rc.PublicCaKeyPath,
+		"public-ca-key-path",
+		"/etc/ssh/machinist_host_ca.pub",
+		"Path to location where CA public key should be installed to",
 	)
 	rc.PersistentFlags().StringVar(
 		&rc.PrivateKeyPath,
 		"private-key-path",
 		"/etc/ssh/machinist_host_key",
-		"Path to location where private key should be read from or installed to",
+		"Path to location where private key should be installed to",
 	)
 	rc.PersistentFlags().StringVar(
 		&rc.SignedCertPath,
-		"private-key-path",
-		"/etc/ssh/machinist_host_key",
-		"Path to location where signed cert should be read from or installed to",
+		"signed-cert-path",
+		"/etc/ssh/machinist_host_cert",
+		"Path to location where signed cert should be installed to",
 	)
 	rc.PersistentFlags().StringVar(
 		&rc.SshdConfigPath,
 		"sshd-config-path",
-		"/etc/ssh/sshd_config",
+		"/etc/ssh/sshd_config.d/enkit.conf",
 		"Path to sshd configuration to read/modify",
 	)
 
@@ -96,11 +103,12 @@ type Install struct {
 	*cobra.Command
 	root *Root
 
-	ExistingPublicKeyPath string
+	ExistingPublicKeyPath  string
 	ExistingPrivateKeyPath string
-	Overwrite bool
-	ConfigureSshd bool
-	RestartSshd bool
+	SshPrincipals []string
+	Overwrite              bool
+	ConfigureSshd          bool
+	RestartSshd            bool
 }
 
 func NewInstall(root *Root) *Install {
@@ -140,14 +148,16 @@ func NewInstall(root *Root) *Install {
 		"If set, possibly modify sshd configuration to enable cert authentication",
 	)
 	command.Flags().BoolVar(
-		&command.ConfigureSshd,
+		&command.RestartSshd,
 		"restart-sshd",
 		true,
 		"If set, restart sshd when configuration is modified automatically",
 	)
+	command.Flags().StringSliceVar(
+		&command.SshPrincipals,
+		"ssh-principals",
+		nil,
+		"List of SSH principals to add to cert",
+	)
 	return command
-}
-
-func (i *Install) Run(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("enkit machine-cert install not yet implemented")
 }

--- a/enkit/machinecert/install.go
+++ b/enkit/machinecert/install.go
@@ -1,0 +1,177 @@
+package machinecert
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/enfabrica/enkit/astore/rpc/auth"
+	"github.com/enfabrica/enkit/lib/kcerts"
+	"golang.org/x/crypto/ssh"
+)
+
+func (i *Install) Run(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Get connection to auth server
+	conn, err := i.root.Connect()
+	if err != nil {
+		return fmt.Errorf("can't connect to auth server: %w", err)
+	}
+	authClient := auth.NewAuthClient(conn)
+
+	// Check file overwriting
+	created, overwritten, err := i.getAffectedFiles()
+	if err != nil {
+		return fmt.Errorf("while determining changed files: %w", err)
+	}
+	if len(overwritten) > 0 && !i.Overwrite {
+		return fmt.Errorf("--overwrite not specified, but command would change files: %v", overwritten)
+	}
+
+	if err := createDirs(created); err != nil {
+		return fmt.Errorf("ensuring directories exist for new files: %w", err)
+	}
+
+	privateKey, err := readFileOrEmpty(i.ExistingPrivateKeyPath)
+	if err != nil {
+		return fmt.Errorf("while loading private key: %w", err)
+	}
+	publicKey, err := readFileOrEmpty(i.ExistingPublicKeyPath)
+	if err != nil {
+		return fmt.Errorf("while loading public key: %w", err)
+	}
+
+	if (publicKey != nil && privateKey == nil) || (publicKey == nil && privateKey != nil) {
+		return fmt.Errorf("If one of [--existing-private-key, --existing-public-key] is supplied, both must be supplied")
+	}
+	if privateKey == nil || publicKey == nil {
+		// Create new keypair
+		pubKey, privKey, err := kcerts.GenerateED25519()
+		if err != nil {
+			return fmt.Errorf("failed to generate new keypair: %w", err)
+		}
+		publicKey = pubKey.Marshal()
+		publicKeyAuthLine := ssh.MarshalAuthorizedKey(pubKey)
+
+		// Write private key to disk
+		privateKey, err = privKey.SSHPemEncode()
+		if err != nil {
+			return fmt.Errorf("while encoding private key: %w", err)
+		}
+		if err := ioutil.WriteFile(i.root.PrivateKeyPath, privateKey, 0600); err != nil {
+			return fmt.Errorf("while writing private key: %w", err)
+		}
+		// Write public key to disk
+		if err := ioutil.WriteFile(i.root.PublicKeyPath, publicKeyAuthLine, 0640); err != nil {
+			return fmt.Errorf("while writing public key: %w", err)
+		}
+	}
+
+	// Sign host cert
+	principals := i.SshPrincipals
+	if principals == nil {
+		principals = append(principals, "localhost")
+		hostname, err := os.Hostname()
+		if err == nil {
+			principals = append(principals, hostname)
+		}
+	}
+
+	pubKey, err := ssh.ParsePublicKey(publicKey)
+	if err != nil {
+		return fmt.Errorf("can't parse public key content: %w", err)
+	}
+
+	req := &auth.HostCertificateRequest{
+		Hostcert: pem.EncodeToMemory(&pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: ssh.MarshalAuthorizedKey(pubKey),
+		}),
+		Hosts: principals,
+	}
+	res, err := authClient.HostCertificate(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to get cert signed by auth server: %w", err)
+	}
+
+	// Write host cert
+	if err := ioutil.WriteFile(i.root.SignedCertPath, res.Signedhostcert, 0640); err != nil {
+		return fmt.Errorf("while writing host cert key: %w", err)
+	}
+
+	// Write CA public key
+	if err := ioutil.WriteFile(i.root.PublicCaKeyPath, res.Capublickey, 0640); err != nil {
+		return fmt.Errorf("while writing CA public key: %w", err)
+	}
+
+	if i.ConfigureSshd {
+		contents := fmt.Sprintf(`
+HostKey %s
+TrustedUserCAKeys %s
+HostCertificate %s
+`, i.root.PrivateKeyPath, i.root.PublicCaKeyPath, i.root.SignedCertPath)
+		if err := ioutil.WriteFile(i.root.SshdConfigPath, []byte(strings.TrimSpace(contents)), 0600); err != nil {
+			return fmt.Errorf("while writing sshd config: %w", err)
+		}
+	}
+
+	if i.RestartSshd {
+		out, err := exec.Command("systemctl", "restart", "sshd").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("sshd restart failed: %v\nOutput:\n%s", err, string(out))
+		}
+	}
+
+	return nil
+}
+
+func (i *Install) getAffectedFiles() ([]string, []string, error) {
+	newFiles := []string{}
+	changedFiles := []string{}
+
+	for _, path := range []string{i.root.PrivateKeyPath, i.root.PublicCaKeyPath, i.root.PublicKeyPath} {
+		if _, err := os.Stat(path); err == nil {
+			changedFiles = append(changedFiles, path)
+		} else if errors.Is(err, os.ErrNotExist) {
+			newFiles = append(newFiles, path)
+		} else {
+			return nil, nil, err
+		}
+	}
+
+	return newFiles, changedFiles, nil
+}
+
+func createDirs(paths []string) error {
+	for _, path := range paths {
+		parent := filepath.Dir(path)
+		if _, err := os.Stat(parent); errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(parent, 0755); err != nil {
+				return fmt.Errorf("making parent dir %q: %w", parent, err)
+			}
+		}
+	}
+	return nil
+}
+
+func readFileOrEmpty(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("loading existing files not implemented")
+	} else {
+		return nil, fmt.Errorf("error reading file %q: %w", path, err)
+	}
+}


### PR DESCRIPTION
This change implements the install command.

Not a ton of thought is put into adding tests; this command is useful in
the short-term to quickly issue some certs for the Cadence chamber
machines so that people can SSH between them cleanly.

Tested:
* Run locally; is able to create a keypair and obtain a signed
  cert

Jira: INFRA-5652