### PR TITLE
bb_reporter: Add no-op server

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -282,6 +282,7 @@ def go_repositories():
         importpath = "github.com/buildbarn/bb-remote-execution",
         sum = "h1:u1K0yklAdRXR4srfBPXGLXs3vS7uf7DcfJjVwdUn5vM=",
         version = "v0.0.0-20230414072355-c0df58fb74b5",
+        build_naming_convention = "import",
     )
     go_repository(
         name = "com_github_buildbarn_bb_storage",

--- a/bb_reporter/BUILD.bazel
+++ b/bb_reporter/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/bb_reporter",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//bb_reporter/reporter:go_default_library",
+        "//lib/server:go_default_library",
+        "@com_github_buildbarn_bb_remote_execution//pkg/proto/completedactionlogger",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "bb_reporter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "bb_reporter_tar",
+    srcs = [":bb_reporter"],
+    package_dir = "/enfabrica/bin",
+)
+
+container_image(
+    name = "bb_reporter_image",
+    base = "@golang_base//image",
+    cmd = [
+        "/enfabrica/bin/bb_reporter",
+    ],
+    tars = [
+        ":bb_reporter_tar",
+    ],
+)
+
+container_push(
+    name = "bb_reporter_image_push",
+    format = "Docker",
+    image = ":bb_reporter_image",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/services/bb_reporter",
+    tag = "testing",
+)

--- a/bb_reporter/main.go
+++ b/bb_reporter/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	cpb "github.com/buildbarn/bb-remote-execution/pkg/proto/completedactionlogger"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+
+	"github.com/enfabrica/enkit/bb_reporter/reporter"
+	"github.com/enfabrica/enkit/lib/server"
+)
+
+func main() {
+	flag.Parse()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	srv, err := reporter.NewService(ctx)
+	exitIf(err)
+
+	grpcs := grpc.NewServer()
+	cpb.RegisterCompletedActionLoggerServer(grpcs, srv)
+
+	go func() {
+		<-ctx.Done()
+		glog.Info("Got ctx.Done(); stopping gRPC server")
+		grpcs.Stop()
+	}()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	glog.Exit(server.Run(mux, grpcs, nil))
+}
+
+func exitIf(err error) {
+	if err != nil {
+		glog.Exit(err)
+	}
+}

--- a/bb_reporter/reporter/BUILD.bazel
+++ b/bb_reporter/reporter/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["service.go"],
+    importpath = "github.com/enfabrica/enkit/bb_reporter/reporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_buildbarn_bb_remote_execution//pkg/proto/completedactionlogger",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+    ],
+)

--- a/bb_reporter/reporter/service.go
+++ b/bb_reporter/reporter/service.go
@@ -1,0 +1,147 @@
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	cpb "github.com/buildbarn/bb-remote-execution/pkg/proto/completedactionlogger"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+var (
+	metricActiveStreams = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "bb_reporter",
+		Name:      "active_completed_action_stream_count",
+		Help:      "Number of currently active CompletedActionLogger streams",
+	})
+	metricStreamCloseCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bb_reporter",
+		Name:      "completed_action_stream_close_count",
+		Help:      "Number of CompletedActionLogger stream closes, by reason",
+	},
+		[]string{
+			"reason",
+		})
+	metricCompletedActionCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "bb_reporter",
+		Name:      "completed_action_recv_count",
+		Help:      "Number of CompletedAction messages received across all streams",
+	})
+	metricBatchCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bb_reporter",
+		Name:      "completed_action_batch_count",
+		Help:      "Number of batches of CompletedActions",
+	},
+		[]string{
+			"trigger",
+		},
+	)
+)
+
+type Service struct {
+	ctx      context.Context
+	recvChan chan *cpb.CompletedAction
+	bufChan  chan []*cpb.CompletedAction
+}
+
+func NewService(ctx context.Context) (*Service, error) {
+	s := &Service{
+		ctx:      ctx,
+		recvChan: make(chan *cpb.CompletedAction),
+		bufChan:  make(chan []*cpb.CompletedAction),
+	}
+
+	go s.batchRequestLoop(10, 2*time.Second)
+	go s.bigqueryInsertLoop()
+
+	return s, nil
+}
+
+func (s *Service) batchRequestLoop(maxBatch int, maxDelay time.Duration) {
+	t := time.NewTicker(maxDelay)
+	defer t.Stop()
+
+	for {
+
+		buf := make([]*cpb.CompletedAction, 0, maxBatch)
+
+	batchLoop:
+		for {
+			select {
+			case <-s.ctx.Done():
+				glog.Infof("batchRequests got ctx.Done(); exiting")
+				return
+
+			case req := <-s.recvChan:
+				buf = append(buf, req)
+				if len(buf) >= maxBatch {
+					metricBatchCount.WithLabelValues("batch_full").Inc()
+					break batchLoop
+				}
+
+			case <-t.C:
+				if len(buf) > 0 {
+					metricBatchCount.WithLabelValues("timer_tick").Inc()
+					break batchLoop
+				}
+			}
+		}
+
+		s.bufChan <- buf
+	}
+}
+
+func (s *Service) bigqueryInsertLoop() {
+	i := 0
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			glog.Infof("bigqueryInsertLoop got ctx.Done(); exiting")
+			return
+
+		case reqs := <-s.bufChan:
+			// TODO(scott): Insert into bigquery
+			// For now, to get some testdata, log a single message to stdout every 100
+			// batches
+			i++
+			if i%100 == 0 {
+				i = 0
+				fmt.Println("--------------------------------------------------------------------------------")
+				fmt.Println(prototext.Format(reqs[0]))
+			}
+		}
+	}
+}
+
+func (s *Service) LogCompletedActions(stream cpb.CompletedActionLogger_LogCompletedActionsServer) error {
+	metricActiveStreams.Inc()
+	defer metricActiveStreams.Dec()
+
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			metricStreamCloseCount.WithLabelValues("eof").Inc()
+			return nil
+		}
+		if err != nil {
+			metricStreamCloseCount.WithLabelValues("recv_error").Inc()
+			return err
+		}
+
+		s.recvChan <- req
+		metricCompletedActionCount.Inc()
+
+		empty := &emptypb.Empty{}
+		if err := stream.Send(empty); err != nil {
+			metricStreamCloseCount.WithLabelValues("send_error").Inc()
+			return err
+		}
+	}
+}


### PR DESCRIPTION
This change adds an implementation of a `CompletedActionLogger` server that basically drops all messages, while:
* logging a single message to stdout every once in a while, so we can see some actual test data
* collecting metrics, so we can get an idea of the scale of the data

Eventually this service should upload messages to some sort of database, but that will come in a future PR. This PR is sufficient to confirm that the implementation of the skeleton is sufficient to interoperate with Buildbarn.

Tested: Server builds and starts.

Jira: INFRA-5725