### PR TITLE
bb_reporter: Parse to BigQuery struct

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -245,6 +245,7 @@ def go_repositories():
         # This is a copy of this patch: https://raw.githubusercontent.com/buildbarn/bb-storage/master/patches/com_github_bazelbuild_remote_apis/golang.diff
         # with modifications:
         # - s/:longrunning_/:longrunningpb_/g
+        build_naming_convention = "import",
         patches = ["@enkit//bazel/dependencies:remote_apis_fix_target_names.patch"],
         sum = "h1:jVU/1F77AdTYfbUUBYDjRpyBQ+eRhniSeeY7i7rFaOs=",
         version = "v0.0.0-20230315170832-8f539af4b407",

--- a/bb_reporter/main.go
+++ b/bb_reporter/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	cpb "github.com/buildbarn/bb-remote-execution/pkg/proto/completedactionlogger"
 	"github.com/golang/glog"
@@ -17,12 +18,17 @@ import (
 	"github.com/enfabrica/enkit/lib/server"
 )
 
+var (
+	batchSize           = flag.Int("batch_size", 100, "Number of messages that should be batched to each insert to BigQuery")
+	batchTimeoutSeconds = flag.Int("batch_timeout_seconds", 2, "Max number of seconds between each insert flush")
+)
+
 func main() {
 	flag.Parse()
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	srv, err := reporter.NewService(ctx)
+	srv, err := reporter.NewService(ctx, *batchSize, time.Duration(*batchTimeoutSeconds)*time.Second)
 	exitIf(err)
 
 	grpcs := grpc.NewServer()

--- a/bb_reporter/reporter/BUILD.bazel
+++ b/bb_reporter/reporter/BUILD.bazel
@@ -6,11 +6,13 @@ go_library(
     importpath = "github.com/enfabrica/enkit/bb_reporter/reporter",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:execution",
         "@com_github_buildbarn_bb_remote_execution//pkg/proto/completedactionlogger",
+        "@com_github_buildbarn_bb_remote_execution//pkg/proto/resourceusage",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
-        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )

--- a/bb_reporter/reporter/service.go
+++ b/bb_reporter/reporter/service.go
@@ -2,15 +2,19 @@ package reporter
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
 
+	repb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	cpb "github.com/buildbarn/bb-remote-execution/pkg/proto/completedactionlogger"
+	rupb "github.com/buildbarn/bb-remote-execution/pkg/proto/resourceusage"
 	"github.com/golang/glog"
+	"github.com/kylelemons/godebug/pretty"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -27,12 +31,17 @@ var (
 	},
 		[]string{
 			"reason",
-		})
-	metricCompletedActionCount = promauto.NewCounter(prometheus.CounterOpts{
+		},
+	)
+	metricCompletedActionCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bb_reporter",
 		Name:      "completed_action_recv_count",
 		Help:      "Number of CompletedAction messages received across all streams",
-	})
+	},
+		[]string{
+			"parse_outcome",
+		},
+	)
 	metricBatchCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bb_reporter",
 		Name:      "completed_action_batch_count",
@@ -44,20 +53,193 @@ var (
 	)
 )
 
-type Service struct {
-	ctx      context.Context
-	recvChan chan *cpb.CompletedAction
-	bufChan  chan []*cpb.CompletedAction
+type ActionRecord struct {
+	ActionId        string
+	ActionDigest    string
+	ActionSizeBytes int64
+	OutputFiles     []FileRecord
+
+	WorkerCluster      string
+	WorkerVirtualNode  string
+	WorkerPhysicalNode string
+	WorkerThread       uint32
+
+	QueuedTime                time.Time
+	WorkerStartTime           time.Time
+	WorkerCompletedTime       time.Time
+	InputFetchStartTime       time.Time
+	InputFetchCompletedTime   time.Time
+	ExecutionStartTime        time.Time
+	ExecutionCompletedTime    time.Time
+	OutputUploadStartTime     time.Time
+	OutputUploadCompletedTime time.Time
+	VirtualExecutionDuration  time.Duration
+
+	BazelVersion            string
+	BazelInvocationId       string
+	CorrelatedInvocationsId string
+	Mnemonic                string
+	Target                  string
+	Configuration           string
+
+	UserTime                   time.Duration
+	SystemTime                 time.Duration
+	MaximumResidentSetSize     int64
+	PageReclaims               int64
+	PageFaults                 int64
+	Swaps                      int64
+	BlockInputOperations       int64
+	BlockOutputOperations      int64
+	VoluntaryContextSwitches   int64
+	InvoluntaryContextSwitches int64
+
+	Expenses []Expense
 }
 
-func NewService(ctx context.Context) (*Service, error) {
-	s := &Service{
-		ctx:      ctx,
-		recvChan: make(chan *cpb.CompletedAction),
-		bufChan:  make(chan []*cpb.CompletedAction),
+type FileRecord struct {
+	Filename  string
+	SizeBytes int64
+}
+
+type Expense struct {
+	Name      string
+	AmountUSD float64
+}
+
+func ActionRecordFromCompletedAction(c *cpb.CompletedAction) (*ActionRecord, error) {
+	em := c.GetHistoricalExecuteResponse().GetExecuteResponse().GetResult().GetExecutionMetadata()
+
+	var (
+		workerCluster      string
+		workerVirtualNode  string
+		workerPhysicalNode string
+		workerThread       uint32
+	)
+	workerMeta := map[string]any{}
+	if err := json.Unmarshal([]byte(em.GetWorker()), &workerMeta); err != nil {
+		glog.Errorf("Failed to unmarshal worker metadata dict on action %q: %v", c.GetUuid(), err)
+		return nil, errors.New("worker_metadata_unmarshal_failure")
+	}
+	if v, ok := workerMeta["nomad_alloc_id"]; ok {
+		workerVirtualNode, _ = v.(string)
+	}
+	if v, ok := workerMeta["nomad_datacenter"]; ok {
+		workerCluster, _ = v.(string)
+	}
+	if v, ok := workerMeta["nomad_node_id"]; ok {
+		workerPhysicalNode, _ = v.(string)
+	}
+	if v, ok := workerMeta["thread"]; ok {
+		v, _ := v.(int)
+		workerThread = uint32(v)
 	}
 
-	go s.batchRequestLoop(10, 2*time.Second)
+	var rm *repb.RequestMetadata
+	var ru *rupb.POSIXResourceUsage
+	var mu *rupb.MonetaryResourceUsage
+
+	for _, any := range em.GetAuxiliaryMetadata() {
+		m, err := any.UnmarshalNew()
+		if err != nil {
+			glog.Errorf("Failed to unmarshal auxiliary_metadata message on action %q: %v", c.GetUuid(), err)
+			continue
+		}
+
+		switch m := m.(type) {
+		case *repb.RequestMetadata:
+			rm = m
+		case *rupb.POSIXResourceUsage:
+			ru = m
+		case *rupb.MonetaryResourceUsage:
+			mu = m
+		case *rupb.FilePoolResourceUsage:
+			// No useful info here currently
+		default:
+			glog.Warningf("Unknown auxiliary_metadata message on action %q: %T", c.GetUuid(), m)
+		}
+	}
+
+	if rm == nil {
+		return nil, errors.New("missing_request_metadata")
+	}
+	if ru == nil {
+		return nil, errors.New("missing_posix_resource_usage")
+	}
+	if mu == nil {
+		return nil, errors.New("missing_cost_info")
+	}
+
+	of := c.GetHistoricalExecuteResponse().GetExecuteResponse().GetResult().GetOutputFiles()
+	files := make([]FileRecord, 0, len(of))
+	for _, file := range of {
+		files = append(files, FileRecord{Filename: file.GetPath(), SizeBytes: file.GetDigest().GetSizeBytes()})
+	}
+
+	costs := make([]Expense, 0, len(mu.GetExpenses()))
+	for name, cost := range mu.GetExpenses() {
+		costs = append(costs, Expense{Name: name, AmountUSD: cost.GetCost()})
+	}
+
+	a := &ActionRecord{
+		ActionId:        c.GetUuid(),
+		ActionDigest:    c.GetHistoricalExecuteResponse().GetActionDigest().GetHash(),
+		ActionSizeBytes: c.GetHistoricalExecuteResponse().GetActionDigest().GetSizeBytes(),
+		OutputFiles:     files,
+
+		WorkerCluster:      workerCluster,
+		WorkerVirtualNode:  workerVirtualNode,
+		WorkerPhysicalNode: workerPhysicalNode,
+		WorkerThread:       workerThread,
+
+		QueuedTime:                em.GetQueuedTimestamp().AsTime(),
+		WorkerStartTime:           em.GetWorkerStartTimestamp().AsTime(),
+		WorkerCompletedTime:       em.GetWorkerCompletedTimestamp().AsTime(),
+		InputFetchStartTime:       em.GetInputFetchStartTimestamp().AsTime(),
+		InputFetchCompletedTime:   em.GetInputFetchCompletedTimestamp().AsTime(),
+		ExecutionStartTime:        em.GetExecutionStartTimestamp().AsTime(),
+		ExecutionCompletedTime:    em.GetExecutionCompletedTimestamp().AsTime(),
+		VirtualExecutionDuration:  em.GetVirtualExecutionDuration().AsDuration(),
+		OutputUploadStartTime:     em.GetOutputUploadStartTimestamp().AsTime(),
+		OutputUploadCompletedTime: em.GetOutputUploadCompletedTimestamp().AsTime(),
+
+		BazelVersion:            rm.GetToolDetails().GetToolVersion(),
+		BazelInvocationId:       rm.GetToolInvocationId(),
+		CorrelatedInvocationsId: rm.GetCorrelatedInvocationsId(),
+		Mnemonic:                rm.GetActionMnemonic(),
+		Target:                  rm.GetTargetId(),
+		Configuration:           rm.GetConfigurationId(),
+
+		UserTime:                   ru.GetUserTime().AsDuration(),
+		SystemTime:                 ru.GetSystemTime().AsDuration(),
+		MaximumResidentSetSize:     ru.GetMaximumResidentSetSize(),
+		PageReclaims:               ru.GetPageReclaims(),
+		PageFaults:                 ru.GetPageFaults(),
+		Swaps:                      ru.GetSwaps(),
+		BlockInputOperations:       ru.GetBlockInputOperations(),
+		BlockOutputOperations:      ru.GetBlockOutputOperations(),
+		VoluntaryContextSwitches:   ru.GetVoluntaryContextSwitches(),
+		InvoluntaryContextSwitches: ru.GetInvoluntaryContextSwitches(),
+
+		Expenses: costs,
+	}
+
+	return a, nil
+}
+
+type Service struct {
+	ctx      context.Context
+	recvChan chan *ActionRecord
+	bufChan  chan []*ActionRecord
+}
+
+func NewService(ctx context.Context, batchSize int, batchTimeout time.Duration) (*Service, error) {
+	s := &Service{
+		ctx:      ctx,
+		recvChan: make(chan *ActionRecord),
+		bufChan:  make(chan []*ActionRecord),
+	}
+
+	go s.batchRequestLoop(batchSize, batchTimeout)
 	go s.bigqueryInsertLoop()
 
 	return s, nil
@@ -69,7 +251,7 @@ func (s *Service) batchRequestLoop(maxBatch int, maxDelay time.Duration) {
 
 	for {
 
-		buf := make([]*cpb.CompletedAction, 0, maxBatch)
+		buf := make([]*ActionRecord, 0, maxBatch)
 
 	batchLoop:
 		for {
@@ -114,7 +296,7 @@ func (s *Service) bigqueryInsertLoop() {
 			if i%100 == 0 {
 				i = 0
 				fmt.Println("--------------------------------------------------------------------------------")
-				fmt.Println(prototext.Format(reqs[0]))
+				pretty.Print(reqs[0])
 			}
 		}
 	}
@@ -135,8 +317,13 @@ func (s *Service) LogCompletedActions(stream cpb.CompletedActionLogger_LogComple
 			return err
 		}
 
-		s.recvChan <- req
-		metricCompletedActionCount.Inc()
+		a, err := ActionRecordFromCompletedAction(req)
+		if err != nil {
+			metricCompletedActionCount.WithLabelValues(err.Error()).Inc()
+		} else {
+			s.recvChan <- a
+			metricCompletedActionCount.WithLabelValues("ok").Inc()
+		}
 
 		empty := &emptypb.Empty{}
 		if err := stream.Send(empty); err != nil {


### PR DESCRIPTION
This change parses the `CompletedAction` message into a struct which will represent a BigQuery table entry. The proto message is not used directly in case it has too much nesting to be a useable BigQuery schema.

Pushing to BigQuery is still not implemented, but the parsed struct is printed periodically on stdout instead of the received message.

This change also modifies the batch size parameter, boosting that and the batch timeout params to flags in the process.

Tested: Deployed; successfully showing entries and no log errors/warnings

Jira: INFRA-5726