### PR TITLE
bb_reporter: Write results to BigQuery

### DIFF
--- a/bb_reporter/reporter/BUILD.bazel
+++ b/bb_reporter/reporter/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["service.go"],
+    srcs = [
+        "bigquery.go",
+        "service.go",
+    ],
     importpath = "github.com/enfabrica/enkit/bb_reporter/reporter",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,6 +16,7 @@ go_library(
         "@com_github_kylelemons_godebug//pretty:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_google_cloud_go_bigquery//:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )

--- a/bb_reporter/reporter/bigquery.go
+++ b/bb_reporter/reporter/bigquery.go
@@ -1,0 +1,43 @@
+package reporter
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/bigquery"
+)
+
+// Inserter inserts a single row into a database.
+type Inserter[T any] interface {
+	Insert(context.Context, *T) error
+}
+
+// Inserter inserts multiple rows into a database.
+type BatchInserter[T any] interface {
+	BatchInsert(context.Context, []*T) error
+}
+
+// NewBigquery returns a BatchInserter that inserts into a specific table.
+func NewBigquery[T any](ctx context.Context, projectID string, dataset string, table string) (BatchInserter[T], error) {
+	client, err := bigquery.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("while creating BigQuery client for project %q: %w", projectID, err)
+	}
+	return &BigqueryTable[T]{
+		table: client.Dataset(dataset).Table(table).Inserter(),
+	}, nil
+}
+
+// BigqueryTable is an Inserter and BatchInserter that inserts into a specific
+// BigQuery table.
+type BigqueryTable[T any] struct {
+	table *bigquery.Inserter
+}
+
+func (b *BigqueryTable[T]) Insert(ctx context.Context, val *T) error {
+	return b.table.Put(ctx, val)
+}
+
+func (b *BigqueryTable[T]) BatchInsert(ctx context.Context, vals []*T) error {
+	return b.table.Put(ctx, vals)
+}


### PR DESCRIPTION
This change implements BigQuery writing for each batch of `ActionRecord` instances.

Each struct is taught to implement `bigquery.ValueSaver`, which is an interface whereby each is converted to a row. This is a bit extra for a few reasons:
* the bigquery library can infer a schema from a struct instance (though it is not clear how the field names are inferred)
* there is already a conversion from proto message to struct, and now a second conversion from struct to map - it's possible to do this in one conversion. This double-conversion approach is chosen because it makes the metrics/logging more explicit (rather than needing to parse the Bigquery client library errors).

The BigQuery insertion code implements an interface that looks like internal's `memo.Inserter`, in case the latter is ever backported to this repo. A second variation is introduced (`BatchInserter`) with similar semantics, but for a list of values instead.

Tested: builds

Jira: INFRA-5725