### PR TITLE
kbuildbarn: Fix buildbarn-browser URL generation

### DIFF
--- a/bestie/server/test_result.go
+++ b/bestie/server/test_result.go
@@ -121,7 +121,10 @@ func openBytestreamFile(fileName, bytestreamUri string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing bytestream url %q: %w", bytestreamUri, err)
 	}
-	fileUrl := kbuildbarn.Url(deploymentBaseUrl, hash, size, kbuildbarn.WithFileName(fileName))
+	// BUG(INFRA-5841): Buildbarn URLs include the hash function of the blob. If
+	// we ever change the hash function used, the hard-coded function in this call
+	// needs to change as well.
+	fileUrl := kbuildbarn.Url(deploymentBaseUrl, "sha256", hash, size, kbuildbarn.WithFileName(fileName))
 
 	client := http.DefaultClient
 	resp, err := client.Get(fileUrl)

--- a/bestie/server/test_result.go
+++ b/bestie/server/test_result.go
@@ -119,18 +119,18 @@ func openBytestreamFile(fileName, bytestreamUri string) (io.ReadCloser, error) {
 
 	hash, size, err := kbuildbarn.ParseByteStreamUrl(bytestreamUri)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing bytestream url %q: %w", bytestreamUri, err)
 	}
 	fileUrl := kbuildbarn.Url(deploymentBaseUrl, hash, size, kbuildbarn.WithFileName(fileName))
 
 	client := http.DefaultClient
 	resp, err := client.Get(fileUrl)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching URL %q: %w", fileUrl, err)
 	}
 	respStatus := resp.StatusCode
 	if respStatus != http.StatusOK {
-		return nil, fmt.Errorf("HTTP error status %d", respStatus)
+		return nil, fmt.Errorf("HTTP error status %d while fetching %q", respStatus, fileUrl)
 	}
 	return resp.Body, nil
 }

--- a/lib/kbuildbarn/options.go
+++ b/lib/kbuildbarn/options.go
@@ -10,11 +10,11 @@ type Option interface {
 	apply(*options)
 }
 
-func generateOptions(base, hash, size string, inOpts ...Option) options {
+func generateOptions(base, hashFn, hash, size string, inOpts ...Option) options {
 	do := options{
 		Scheme:       "http",
 		PathTemplate: "",
-		TemplateArgs: []interface{}{hash, size},
+		TemplateArgs: []interface{}{hashFn, hash, size},
 	}
 	for _, o := range inOpts {
 		o.apply(&do)
@@ -24,11 +24,11 @@ func generateOptions(base, hash, size string, inOpts ...Option) options {
 
 // the following default values are arbitrary, based on what current works with buildbarn
 const (
-	DefaultFileTemplate       = "/blobs/file/%s-%s/%s"
-	DefaultActionTemplate     = "/blobs/action/%s-%s"
-	DefaultCommandTemplate    = "/blobs/command/%s-%s"
-	DefaultDirectoryTemplate  = "/blobs/directory/%s-%s"
-	DefaultByteStreamTemplate = "/blobs/%s/%s"
+	DefaultFileTemplate       = "/blobs/%s/file/%s-%s/%s"
+	DefaultActionTemplate     = "/blobs/%s/action/%s-%s"
+	DefaultCommandTemplate    = "/blobs/%s/command/%s-%s"
+	DefaultDirectoryTemplate  = "/blobs/%s/directory/%s-%s"
+	DefaultByteStreamTemplate = "/blobs/%s/%s/%s"
 )
 
 type multipleOption []Option

--- a/lib/kbuildbarn/protoparse.go
+++ b/lib/kbuildbarn/protoparse.go
@@ -85,10 +85,10 @@ func GenerateLinksForFiles(filesPb []*bespb.File, baseName, destPrefix, invocati
 		if destPrefix == "" {
 			destPrefix = "."
 		}
-		simSource := File(baseName, digest, size,
+		simSource := File(baseName, "sha256", digest, size,
 			WithFileTemplate(DefaultBBClientdCasFileTemplate),
 			WithTemplateArgs(clusterName, digest, size))
-		simDest := filepath.Clean(File(baseName, digest, size,
+		simDest := filepath.Clean(File(baseName, "sha256", digest, size,
 			WithFileTemplate(DefaultBBClientdScratchFileTemplate),
 			WithTemplateArgs(invocationPrefix, destPrefix, f.Name)))
 		toReturn = append(toReturn, &Hardlink{Dest: simDest, Src: simSource})

--- a/lib/kbuildbarn/urls.go
+++ b/lib/kbuildbarn/urls.go
@@ -50,8 +50,8 @@ func performRequest(client *http.Client, url string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-func Url(baseName, hash, size string, opts ...Option) string {
-	cfg := generateOptions(baseName, hash, size, opts...)
+func Url(baseName, hashFn, hash, size string, opts ...Option) string {
+	cfg := generateOptions(baseName, hashFn, hash, size, opts...)
 	u := &url.URL{
 		Scheme: cfg.Scheme,
 		Host:   baseName,
@@ -60,8 +60,8 @@ func Url(baseName, hash, size string, opts ...Option) string {
 	return u.String()
 }
 
-func File(baseName, hash, size string, opts ...Option) string {
-	cfg := generateOptions(baseName, hash, size, opts...)
+func File(baseName, hashFn, hash, size string, opts ...Option) string {
+	cfg := generateOptions(baseName, hashFn, hash, size, opts...)
 	return filepath.Join(baseName, fmt.Sprintf(cfg.PathTemplate, cfg.TemplateArgs...))
 }
 
@@ -73,12 +73,12 @@ func readAndClose(rc io.ReadCloser) ([]byte, error) {
 
 // RetryUntilSuccess just blasts through all possible urls until it hits one that works. This is intended for
 // applications that are blind to the type of artifact
-func RetryUntilSuccess(baseName, hash, size string) ([]byte, error) {
+func RetryUntilSuccess(baseName, hashFn, hash, size string) ([]byte, error) {
 	urls := []string{
-		Url(baseName, hash, size, WithActionUrlTemplate()),
-		Url(baseName, hash, size, WithDirectoryUrlTemplate()),
-		Url(baseName, hash, size, WithCommandUrlTemplate()),
-		Url(baseName, hash, size, WithByteStreamTemplate()),
+		Url(baseName, hashFn, hash, size, WithActionUrlTemplate()),
+		Url(baseName, hashFn, hash, size, WithDirectoryUrlTemplate()),
+		Url(baseName, hashFn, hash, size, WithCommandUrlTemplate()),
+		Url(baseName, hashFn, hash, size, WithByteStreamTemplate()),
 	}
 	var errs []error
 	for _, uri := range urls {

--- a/lib/kbuildbarn/urls_test.go
+++ b/lib/kbuildbarn/urls_test.go
@@ -74,10 +74,10 @@ func TestDefaultUrlGeneration(t *testing.T) {
 	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	assert.NoError(t, err)
 	baseName := "buildbarn.local"
-	assert.Equal(t, "http://buildbarn.local/blobs/action/foo-bar", Url(baseName, hash, size, WithActionUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/command/foo-bar", Url(baseName, hash, size, WithCommandUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/directory/foo-bar", Url(baseName, hash, size, WithDirectoryUrlTemplate()))
-	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/", Url(baseName, hash, size, WithFileName("")))
+	assert.Equal(t, "http://buildbarn.local/blobs/sha256/action/foo-bar", Url(baseName, "sha256", hash, size, WithActionUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/sha256/command/foo-bar", Url(baseName, "sha256", hash, size, WithCommandUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/sha256/directory/foo-bar", Url(baseName, "sha256", hash, size, WithDirectoryUrlTemplate()))
+	assert.Equal(t, "http://buildbarn.local/blobs/sha256/file/foo-bar/", Url(baseName, "sha256", hash, size, WithFileName("")))
 }
 
 func TestFileUrlGeneration(t *testing.T) {
@@ -85,14 +85,14 @@ func TestFileUrlGeneration(t *testing.T) {
 	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "buildbarn.local"
 	assert.NoError(t, err)
-	assert.Equal(t, "http://buildbarn.local/blobs/file/foo-bar/mickey.mouse", Url(basename, hash, size, WithFileName("mickey.mouse")))
+	assert.Equal(t, "http://buildbarn.local/blobs/sha256/file/foo-bar/mickey.mouse", Url(basename, "sha256", hash, size, WithFileName("mickey.mouse")))
 }
 func TestByteStreamGeneration(t *testing.T) {
 	exampleUrl := "bytestream://build.local.enfabrica.net:8000/blobs/foo/bar"
 	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "buildbarn.local"
 	assert.NoError(t, err)
-	assert.Equal(t, "bytestream://buildbarn.local/blobs/foo/bar", Url(basename, hash, size, WithByteStreamTemplate()))
+	assert.Equal(t, "bytestream://buildbarn.local/blobs/sha256/foo/bar", Url(basename, "sha256", hash, size, WithByteStreamTemplate()))
 }
 
 func TestFileGeneration(t *testing.T) {
@@ -100,5 +100,5 @@ func TestFileGeneration(t *testing.T) {
 	hash, size, err := ParseByteStreamUrl(exampleUrl)
 	basename := "/root"
 	assert.NoError(t, err)
-	assert.Equal(t, "/root/blobs/file/foo-bar/foo.go", File(basename, hash, size, WithFileName("foo.go")))
+	assert.Equal(t, "/root/blobs/sha256/file/foo-bar/foo.go", File(basename, "sha256", hash, size, WithFileName("foo.go")))
 }


### PR DESCRIPTION
buildbarn-browser URL patterns changed with a recent upgrade - they now
include the hash function used to calculate a particular blob.

We currently use SHA256 everywhere and don't plan to change, so this
change modifies the client libraries to accept a hash function name, and
buildbarn/unit test code to hardcode "sha256".

Tested: unit tests only

Jira: INFRA-5855