### PR TITLE
k8s: Add test webserver

### DIFF
--- a/bb_reporter/reporter/BUILD.bazel
+++ b/bb_reporter/reporter/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "@com_github_buildbarn_bb_remote_execution//pkg/proto/completedactionlogger",
         "@com_github_buildbarn_bb_remote_execution//pkg/proto/resourceusage",
         "@com_github_golang_glog//:go_default_library",
-        "@com_github_kylelemons_godebug//pretty:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_google_cloud_go_bigquery//:go_default_library",

--- a/infra/k8s_dummy/BUILD.bazel
+++ b/infra/k8s_dummy/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/infra/k8s_dummy",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib/server:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "k8s_dummy",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "k8s_dummy_tar",
+    srcs = [":k8s_dummy"],
+    package_dir = "/enfabrica/bin",
+)
+
+container_image(
+    name = "k8s_dummy_image",
+    base = "@golang_base//image",
+    cmd = [
+        "/enfabrica/bin/k8s_dummy",
+    ],
+    tars = [
+        ":k8s_dummy_tar",
+    ],
+)
+
+container_push(
+    name = "k8s_dummy_image_push",
+    format = "Docker",
+    image = ":k8s_dummy_image",
+    registry = "gcr.io",
+    repository = "devops-284019/infra/k8s_dummy",
+    # TODO: Change this tag to "live"
+    tag = "testing",
+)

--- a/infra/k8s_dummy/main.go
+++ b/infra/k8s_dummy/main.go
@@ -1,0 +1,40 @@
+// Webserver that exposes metrics for testing k8s setups
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/enfabrica/enkit/lib/server"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	metricPathVisits = promauto.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: "k8s_dummy",
+		Name: "path_visit_count",
+	},
+	[]string{
+		"path",
+	},
+)
+)
+
+func printPath(w http.ResponseWriter, r *http.Request) {
+	metricPathVisits.WithLabelValues(r.URL.Path).Inc()
+	w.WriteHeader(200)
+	fmt.Fprintf(w, "You reached page: %s\n", r.URL.Path)
+}
+
+func main() {
+	flag.Parse()
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/printpath/", printPath)
+
+	server.Run(mux, nil, nil)
+}


### PR DESCRIPTION
This change adds a test webserver that helps validate:
* external access works as expected
* metrics can be collected

It may be extended in the future to allow for testing gRPC, etc.

Jira: INFRA-5878