### PR TITLE
disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "enabled": false
 }


### PR DESCRIPTION
Nobody is reviewing those PRs, and they are polluting the
PR queue. Just disable renovate until we can start paying
more attention to it.