### PR TITLE
auth server: Ensure that exactly one instance is always running

### DIFF
--- a/astore/server/deploy/app.yaml
+++ b/astore/server/deploy/app.yaml
@@ -3,4 +3,4 @@ runtime: go119
 instance_class: F1
 automatic_scaling:
   max_instances: 1
-  min_instances: 0
+  min_instances: 1


### PR DESCRIPTION
This change modifies the AppEngine manifest to enforce that there is always one instance running of the auth server, which should eliminate the possibility of auth errors due to the request timing out before an instance is available.

Running an instance consistently shouldn't incur too much cost, as it runs in a cheap application class.

Tested: N/A

Jira: INFRA-6047