### PR TITLE
server: Allow for graceful shutdown via context

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -241,11 +241,11 @@ def go_repositories():
     )
     go_repository(
         name = "com_github_bazelbuild_remote_apis",
-        importpath = "github.com/bazelbuild/remote-apis",
         # This is a copy of this patch: https://raw.githubusercontent.com/buildbarn/bb-storage/master/patches/com_github_bazelbuild_remote_apis/golang.diff
         # with modifications:
         # - s/:longrunning_/:longrunningpb_/g
         build_naming_convention = "import",
+        importpath = "github.com/bazelbuild/remote-apis",
         patches = ["@enkit//bazel/dependencies:remote_apis_fix_target_names.patch"],
         sum = "h1:jVU/1F77AdTYfbUUBYDjRpyBQ+eRhniSeeY7i7rFaOs=",
         version = "v0.0.0-20230315170832-8f539af4b407",
@@ -280,10 +280,10 @@ def go_repositories():
     )
     go_repository(
         name = "com_github_buildbarn_bb_remote_execution",
+        build_naming_convention = "import",
         importpath = "github.com/buildbarn/bb-remote-execution",
         sum = "h1:u1K0yklAdRXR4srfBPXGLXs3vS7uf7DcfJjVwdUn5vM=",
         version = "v0.0.0-20230414072355-c0df58fb74b5",
-        build_naming_convention = "import",
     )
     go_repository(
         name = "com_github_buildbarn_bb_storage",
@@ -1700,8 +1700,8 @@ def go_repositories():
     go_repository(
         name = "com_github_soheilhy_cmux",
         importpath = "github.com/soheilhy/cmux",
-        sum = "h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=",
-        version = "v0.1.4",
+        sum = "h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=",
+        version = "v0.1.5",
     )
 
     go_repository(

--- a/bb_reporter/main.go
+++ b/bb_reporter/main.go
@@ -49,7 +49,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	glog.Exit(server.Run(mux, grpcs, nil))
+	glog.Exit(server.Run(ctx, mux, grpcs, nil))
 }
 
 func exitIf(err error) {

--- a/bes_publisher/main.go
+++ b/bes_publisher/main.go
@@ -60,5 +60,5 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	glog.Exit(server.Run(mux, grpcs, nil))
+	glog.Exit(server.Run(ctx, mux, grpcs, nil))
 }

--- a/bestie/server/main.go
+++ b/bestie/server/main.go
@@ -87,10 +87,10 @@ func (s *BuildEventService) PublishBuildToolEventStream(stream bpb.PublishBuildE
 
 // Command line arguments.
 var (
-	argBaseUrl        = flag.String("base_url", "", "Base URL for accessing output artifacts in the build cluster (required)")
-	argDataset        = flag.String("dataset", "", "BigQuery dataset name (required) -- staging, production")
-	argMaxFileSize    = flag.Int("max_file_size", maxFileSize, "Maximum output file size allowed for processing")
-	argTableName      = flag.String("table_name", "testmetrics", "BigQuery table name")
+	argBaseUrl     = flag.String("base_url", "", "Base URL for accessing output artifacts in the build cluster (required)")
+	argDataset     = flag.String("dataset", "", "BigQuery dataset name (required) -- staging, production")
+	argMaxFileSize = flag.Int("max_file_size", maxFileSize, "Maximum output file size allowed for processing")
+	argTableName   = flag.String("table_name", "testmetrics", "BigQuery table name")
 	// gRPC max message size needs to match the max size of the sender (e.g.
 	// BuildBuddy, Bazel). Bazel targets ~50MB messages, so that is the default
 	// here.
@@ -122,6 +122,7 @@ func checkCommandArgs() error {
 }
 
 func main() {
+	ctx := context.Background()
 	ServiceStats.init()
 
 	flag.Parse()
@@ -137,5 +138,5 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	glog.Exit(server.Run(mux, grpcs, nil))
+	glog.Exit(server.Run(ctx, mux, grpcs, nil))
 }

--- a/flextape/server/main.go
+++ b/flextape/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 	"flag"
 	"fmt"
@@ -53,6 +54,7 @@ func loadConfig(path string) (*fpb.Config, error) {
 }
 
 func main() {
+	ctx := context.Background()
 	// TODO: Use enkit flag libraries
 	flag.Parse()
 	exitIf(checkFlags())
@@ -74,5 +76,5 @@ func main() {
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/queue", fe)
 
-	exitIf(server.Run(mux, grpcs, nil))
+	exitIf(server.Run(ctx, mux, grpcs, nil))
 }

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/sirupsen/logrus v1.9.0
-	github.com/soheilhy/cmux v0.1.4
+	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -1179,6 +1179,8 @@ github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -1386,6 +1388,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/infra/k8s_dummy/main.go
+++ b/infra/k8s_dummy/main.go
@@ -21,12 +21,12 @@ import (
 var (
 	metricPathVisits = promauto.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: "k8s_dummy",
-		Name: "path_visit_count",
+		Name:      "path_visit_count",
 	},
-	[]string{
-		"path",
-	},
-)
+		[]string{
+			"path",
+		},
+	)
 )
 
 func printPath(w http.ResponseWriter, r *http.Request) {
@@ -63,5 +63,5 @@ func main() {
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/printpath/", printPath)
 
-	server.Run(mux, nil, nil)
+	server.Run(ctx, mux, nil, nil)
 }

--- a/lib/kcerts/BUILD.bazel
+++ b/lib/kcerts/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//lib/cache:go_default_library",
+        "//lib/kflags:go_default_library",
         "//lib/logger/klog:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_x_crypto//ssh:go_default_library",


### PR DESCRIPTION
This change adds a `context` parameter to `server.Run`, which is used to shut down the server(s) by closing the underlying mux. This allows for a (semi-)graceful shutdown via e.g. signals for the apps that implement this via `signals.NotifyContext`.

`cmux` is updated since only the latest version has a `CMux.Close` method.

Tested: `k8s_dummy` now does a proper shutdown on Ctrl-C

Jira: INFRA-6066