### PR TITLE
kcookie: Add NewJar function

### DIFF
--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -3,6 +3,7 @@
 See README.md for more information.
 """
 
+load("@com_github_google_go_jsonnet//bazel:repositories.bzl", "jsonnet_go_repositories")
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3_8//:defs.bzl", "interpreter")
@@ -30,3 +31,5 @@ def stage_3():
     )
 
     grpc_extra_deps()
+
+    jsonnet_go_repositories()

--- a/lib/khttp/kcookie/BUILD.bazel
+++ b/lib/khttp/kcookie/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["cookie.go"],
     importpath = "github.com/enfabrica/enkit/lib/khttp/kcookie",
     visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_net//publicsuffix:go_default_library"],
 )

--- a/lib/khttp/kcookie/cookie.go
+++ b/lib/khttp/kcookie/cookie.go
@@ -2,8 +2,12 @@
 package kcookie
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"time"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 type Modifier func(*http.Cookie)
@@ -53,4 +57,12 @@ func New(name, value string, co ...Modifier) *http.Cookie {
 		Value:    value,
 		HttpOnly: true,
 	})
+}
+
+func NewJar() (http.CookieJar, error) {
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, fmt.Errorf("can't create default CookieJar: %w", err)
+	}
+	return jar, nil
 }

--- a/lib/protocfg/BUILD.bazel
+++ b/lib/protocfg/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cfg.go"],
+    importpath = "github.com/enfabrica/enkit/lib/protocfg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_go_jsonnet//:go_default_library",
+        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)

--- a/lib/protocfg/cfg.go
+++ b/lib/protocfg/cfg.go
@@ -1,0 +1,180 @@
+package protocfg
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	"github.com/google/go-jsonnet"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+type Config[T any, PT interface {
+	*T
+	proto.Message
+}] struct {
+	Reader MessageReader
+	Parser MessageParser[T, PT]
+
+	err error
+}
+
+func FromFile[T any, PT interface {
+	*T
+	proto.Message
+}](filename string) *Config[T, PT] {
+	ext := filepath.Ext(filename)
+	switch ext {
+	case ".jsonnet":
+		return &Config[T, PT]{
+			Reader: NewJsonnetFileReader(filename),
+			Parser: Json[T, PT](),
+		}
+	case ".json":
+		return &Config[T, PT]{
+			Reader: NewFileReader(filename),
+			Parser: Json[T, PT](),
+		}
+	case ".textproto", ".prototext":
+		return &Config[T, PT]{
+			Reader: NewFileReader(filename),
+			Parser: TextProto[T, PT](),
+		}
+	case ".pb":
+		return &Config[T, PT]{
+			Reader: NewFileReader(filename),
+			Parser: BinaryProto[T, PT](),
+		}
+	default:
+		return &Config[T, PT]{
+			err: fmt.Errorf("cannot infer parser from file extension %q", ext),
+		}
+	}
+}
+
+func (c *Config[T, PT]) Load() (*T, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	msg, err := c.Reader.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := c.Parser.Parse(msg)
+	if err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func (c *Config[T, PT]) LoadOnSignals(sigs ...os.Signal) (<-chan *T, error) {
+	configChan := make(chan *T)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, sigs...)
+	readAndSend := func() {
+		cfg, err := c.Load()
+		if err != nil {
+			// TODO: log
+		} else {
+			configChan <- cfg
+		}
+	}
+	go func() {
+		readAndSend()
+		for {
+			_ = <-sigChan
+			readAndSend()
+		}
+	}()
+	return configChan, nil
+}
+
+type MessageReader interface {
+	ReadMessage() ([]byte, error)
+}
+
+type FileReader struct {
+	Filename string
+}
+
+func NewFileReader(filename string) MessageReader {
+	return &FileReader{Filename: filename}
+}
+
+func (r *FileReader) ReadMessage() ([]byte, error) {
+	return os.ReadFile(r.Filename)
+}
+
+type JsonnetFileReader struct {
+	Filename string
+}
+
+func NewJsonnetFileReader(filename string) MessageReader {
+	return &JsonnetFileReader{Filename: filename}
+}
+
+func (r *JsonnetFileReader) ReadMessage() ([]byte, error) {
+	vm := jsonnet.MakeVM()
+	jsonStr, err := vm.EvaluateFile(r.Filename)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(jsonStr), nil
+}
+
+type IOReader struct {
+	Reader io.ReadCloser
+}
+
+func (r *IOReader) ReadMessage() ([]byte, error) {
+	defer r.Reader.Close()
+	return io.ReadAll(r.Reader)
+}
+
+type MessageParser[T any, PT interface {
+	*T
+	proto.Message
+}] interface {
+	Parse([]byte) (*T, error)
+}
+
+type unmarshalFuncParser[T any, PT interface {
+	*T
+	proto.Message
+}] struct {
+	unmarshalFunc func([]byte, proto.Message) error
+}
+
+func (p *unmarshalFuncParser[T, PT]) Parse(contents []byte) (*T, error) {
+	msg := PT(new(T))
+	if err := p.unmarshalFunc(contents, msg); err != nil {
+		return nil, err
+	}
+	return (*T)(msg), nil
+}
+
+func Json[T any, PT interface {
+	*T
+	proto.Message
+}]() MessageParser[T, PT] {
+	return &unmarshalFuncParser[T, PT]{unmarshalFunc: protojson.Unmarshal}
+}
+
+func BinaryProto[T any, PT interface {
+	*T
+	proto.Message
+}]() MessageParser[T, PT] {
+	return &unmarshalFuncParser[T, PT]{unmarshalFunc: proto.Unmarshal}
+}
+
+func TextProto[T any, PT interface {
+	*T
+	proto.Message
+}]() MessageParser[T, PT] {
+	return &unmarshalFuncParser[T, PT]{unmarshalFunc: prototext.Unmarshal}
+}


### PR DESCRIPTION
This change adds a `NewJar` function to quickly create a default `http.CookieJar`, which doesn't have a sane (safe) default implementation otherwise. This makes it easier for downstream code to attach the enkit token to outgoing requests.

Tested: manual only