### PR TITLE
bazel/init: update absl version to the latest one.

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -118,9 +118,9 @@ def stage_1():
     maybe(
         name = "com_google_absl",
         repo_rule = http_archive,
-        sha256 = "a4567ff02faca671b95e31d315bab18b42b6c6f1a60e91c6ea84e5a2142112c2",
-        strip_prefix = "abseil-cpp-20211102.0",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip"],
+        sha256 = "51d676b6846440210da48899e4df618a357e6e44ecde7106f1e44ea16ae8adc7",
+        strip_prefix = "abseil-cpp-20230125.3",
+	urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.zip"],
     )
 
     maybe(


### PR DESCRIPTION
... see changelog here for new changes:
https://github.com/abseil/abseil-cpp/releases

Main ones interesting to enfabrica:
- logging library integrated in absl - which allows us to deprecte
  both glog and gflags, and fix a number of pain points around flag
  parsing.
- addition of the Cleanup for scope cleanup - allowing to deprecate
  equivalent constructs

Tested:
Built and tested a large chunk of our codebase with the new absl version.
CI/CD will likely provide good signal here as well.
