### PR TITLE
bazel/dependencies/abseil: patch abseil to support multiple flag libraries.

### DIFF
--- a/bazel/dependencies/abseil/0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch
+++ b/bazel/dependencies/abseil/0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch
@@ -1,0 +1,61 @@
+From de04c828de9541c853bf4698b3913fac5f1f90a4 Mon Sep 17 00:00:00 2001
+From: Carlo Contavalli <carlo@enfabrica.net>
+Date: Tue, 6 Jun 2023 23:46:13 +0000
+Subject: [PATCH] absl/flags/parse.cc: provide a mechanism to let other parse
+ unknown flags.
+
+Problem:
+If multiple flag parsing libraries are used (sigh) it's important
+to have a mechanism so that 1) unknown flags are left where they are
+in argv (not moved at the beginning, not stripped, ...), and 2) a
+new argv with all known args stripped is returned.
+
+This commit implements just that.
+---
+ absl/flags/internal/parse.h | 7 +++++--
+ absl/flags/parse.cc         | 8 +++++++-
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/absl/flags/internal/parse.h b/absl/flags/internal/parse.h
+index 0a7012fc..8e6404cf 100644
+--- a/absl/flags/internal/parse.h
++++ b/absl/flags/internal/parse.h
+@@ -35,9 +35,12 @@ namespace flags_internal {
+ enum class ArgvListAction { kRemoveParsedArgs, kKeepParsedArgs };
+ enum class UsageFlagsAction { kHandleUsage, kIgnoreUsage };
+ enum class OnUndefinedFlag {
+-  kIgnoreUndefined,
++  // Undefined flags are ignored, but considered parsed (for ArgvListAction).
++  kIgnoreUndefined,   
++  // Undefined flags are ignored, and considered not parsed (for ArgvListAction).
++  kKeepUndefined,
+   kReportUndefined,
+   kAbortIfUndefined
+ };
+ 
+ std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
+diff --git a/absl/flags/parse.cc b/absl/flags/parse.cc
+index fa953f55..8dff9eb6 100644
+--- a/absl/flags/parse.cc
++++ b/absl/flags/parse.cc
+@@ -776,10 +776,16 @@ std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
+         continue;
+       }
+ 
+-      if (on_undef_flag != OnUndefinedFlag::kIgnoreUndefined) {
++      if (on_undef_flag != OnUndefinedFlag::kIgnoreUndefined &&
++          on_undef_flag != OnUndefinedFlag::kKeepUndefined) {
+         undefined_flag_names.emplace_back(arg_from_argv,
+                                           std::string(flag_name));
+       }
++
++      if (on_undef_flag == OnUndefinedFlag::kKeepUndefined && 
++          arg_list_act != ArgvListAction::kKeepParsedArgs) {
++        output_args.push_back(argv[curr_list.FrontIndex()]);
++      }
+       continue;
+     }
+ 
+-- 
+2.37.1
+

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -120,6 +120,8 @@ def stage_1():
         repo_rule = http_archive,
         sha256 = "51d676b6846440210da48899e4df618a357e6e44ecde7106f1e44ea16ae8adc7",
         strip_prefix = "abseil-cpp-20230125.3",
+        patch_args = ["-p1"],
+        patches = ["@enkit//bazel/dependencies/abseil:0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch"],
 	urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.zip"],
     )
 


### PR DESCRIPTION
In the latest abseil release there is no sane way to use multiple flag
libraries: there is no easy way to tell abseil to 1) ignore the flags
it does not know about and 2) LEAVE THEM in the returned argv 3) strip
the flags it does parse and know about. 2 out of 3 are possible using
the internal API, 3 is not.

This patch adds the ability to ignore flags abseil does not know about
AND leave them in the returned argv, which enables us to use multiple
flag libraries for code that is not based on abseil.

abseil in head provides a different function to achieve a similar
result, but it's very clumsy to use as it CHANGES the order of argv
arguments, which affects other flag parsing libraries.

Tested:
See corresponding PR in internal using and testing the feature.
