### PR TITLE
fix absl patch

### DIFF
--- a/bazel/dependencies/abseil/0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch
+++ b/bazel/dependencies/abseil/0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch
@@ -1,4 +1,4 @@
-From de04c828de9541c853bf4698b3913fac5f1f90a4 Mon Sep 17 00:00:00 2001
+From 8537ac106731c3c46c4e2963ebfe90d459894395 Mon Sep 17 00:00:00 2001
 From: Carlo Contavalli <carlo@enfabrica.net>
 Date: Tue, 6 Jun 2023 23:46:13 +0000
 Subject: [PATCH] absl/flags/parse.cc: provide a mechanism to let other parse
@@ -12,15 +12,15 @@ new argv with all known args stripped is returned.
 
 This commit implements just that.
 ---
- absl/flags/internal/parse.h | 7 +++++--
- absl/flags/parse.cc         | 8 +++++++-
- 2 files changed, 12 insertions(+), 3 deletions(-)
+ absl/flags/internal/parse.h |  5 ++++-
+ absl/flags/parse.cc         | 14 +++++++++++---
+ 2 files changed, 15 insertions(+), 4 deletions(-)
 
 diff --git a/absl/flags/internal/parse.h b/absl/flags/internal/parse.h
-index 0a7012fc..8e6404cf 100644
+index 0a7012fc..ee164727 100644
 --- a/absl/flags/internal/parse.h
 +++ b/absl/flags/internal/parse.h
-@@ -35,9 +35,12 @@ namespace flags_internal {
+@@ -35,7 +35,10 @@ namespace flags_internal {
  enum class ArgvListAction { kRemoveParsedArgs, kKeepParsedArgs };
  enum class UsageFlagsAction { kHandleUsage, kIgnoreUsage };
  enum class OnUndefinedFlag {
@@ -32,13 +32,24 @@ index 0a7012fc..8e6404cf 100644
    kReportUndefined,
    kAbortIfUndefined
  };
- 
- std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
 diff --git a/absl/flags/parse.cc b/absl/flags/parse.cc
-index fa953f55..8dff9eb6 100644
+index fa953f55..5c21bb43 100644
 --- a/absl/flags/parse.cc
 +++ b/absl/flags/parse.cc
-@@ -776,10 +776,16 @@ std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
+@@ -735,8 +735,10 @@ std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
+     if (!absl::ConsumePrefix(&arg, "-") || arg.empty()) {
+       ABSL_INTERNAL_CHECK(arg_from_argv,
+                           "Flagfile cannot contain positional argument");
+-
+-      positional_args.push_back(argv[curr_list.FrontIndex()]);
++      if (on_undef_flag == OnUndefinedFlag::kKeepUndefined)
++        output_args.push_back(argv[curr_list.FrontIndex()]);
++      else
++        positional_args.push_back(argv[curr_list.FrontIndex()]);
+       continue;
+     }
+ 
+@@ -776,10 +778,16 @@ std::vector<char*> ParseCommandLineImpl(int argc, char* argv[],
          continue;
        }
  


### PR DESCRIPTION
- bazel: Runner template should be capable of running in non bash env (#875)
- enproxy: Define config changes for conditionally adding headers (#890)
- enproxy: Implement mapRequestHeadersByGroup (#891)
- bazel/linux: various feature additions in preparation for next PR (#878)
- enkit: Always build cgo-enabled enkit for Linux (#889)
- bazel/linux: fix breakages introduced by PR#878, variuos improvements (#896)
- bazel/workspace_status.sh: fix stamping. (#897)
- go: Update ecosystem (#894)
- go: Add bb-remote-execution dependency (#898)
- bazel: Make all patches repo-absolute (#901)
- enkit: Add `machine-cert` subcommand (#877)
- bb_reporter: Add no-op server (#903)
- bb_reporter: Parse to BigQuery struct (#904)
- bb_reporter: Write results to BigQuery (#905)
- bestie: Improve error reporting around fetch failures (#906)
- kbuildbarn: Fix buildbarn-browser URL generation (#907)
- enkit machine-cert: Implement `install` subcommand (#902)
- k8s: Add test webserver (#908)
- ssh agent: add timeout, flags, improve error handling. (#893)
- disable renovate. (#909)
- auth server: Ensure that exactly one instance is always running (#911)
- k8s_dummy: Add periodic logging (#910)
- bb_reporter: Add support for GKE worker metadata (#912)
- server: Allow for graceful shutdown via context (#913)
- protocfg: Add library for parsing config files (#915)
- bb_shim: Extend to take a map of bytestream hosts (#918)
- kunit: make kunit_parser publicly visible (#919)
- bazel/init: update absl version to the latest one. (#920)
- bazel/dependencies/abseil: patch abseil to support multiple flag libraries. (#921)
- absl: update the patch to avoid flag reordering.
