### PR TITLE
bestie: Clean up metrics

### DIFF
--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_github_xenking_zipstream//:go_default_library",
         "@com_google_cloud_go_bigquery//:go_default_library",

--- a/bestie/server/service.go
+++ b/bestie/server/service.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // List of event ID names defined by build_event_stream.proto.
@@ -40,113 +41,24 @@ var besEventIds = map[string]string{
 	"ConvenienceSymlinksIdentified": "convenience_symlinks_identified",
 }
 
-// List of all Prometheus counter IDs.
-type counterId int
-
-const (
-	cidBuildsTotal                   counterId = iota // 0
-	cidEventsTotal                                    // 1
-	cidExceptionDatasetNotFound                       // 2
-	cidExceptionExcessDelay                           // 3
-	cidExceptionProtobufError                         // 4
-	cidExceptionTableNotFound                         // 5
-	cidExceptionXmlParseError                         // 6
-	cidExceptionXmlStructuredError                    // 7
-	cidExceptionXmlUnstructuredError                  // 8
-	cidInsertDelay                                    // 9
-	cidInsertError                                    // 10
-	cidInsertOK                                       // 11
-	cidInsertTimeout                                  // 12
-	cidMetricDiscard                                  // 13
-	cidMetricUpload                                   // 14
-	cidOutputFileTooBigTotal                          // 15
-)
-
-// Service statistics.
-type serviceStats struct {
-	// General Build Event Stream stats.
-	buildsTotal           prometheus.Counter
-	eventsTotal           *prometheus.CounterVec
-	outputFileTooBigTotal prometheus.Counter
-
-	// BigQuery interaction stats.
-	bigQueryExceptionsTotal *prometheus.CounterVec
-	bigQueryInsertDelay     prometheus.Histogram
-	bigQueryInsertsTotal    *prometheus.CounterVec
-	bigQueryMetricsTotal    *prometheus.CounterVec
-}
-
-// Statistic values to report to Prometheus for this service.
-var ServiceStats serviceStats = serviceStats{
-	buildsTotal: prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "bestie",
-			Name:      "builds_total",
-			Help:      "Total number of Bazel builds seen",
-		}),
-	eventsTotal: prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "bestie",
-			Name:      "events_total",
-			Help:      "Total observed Bazel events, tagged by event ID",
-		},
-		[]string{"id"},
-	),
-	outputFileTooBigTotal: prometheus.NewCounter(
+var (
+	metricOutputFileTooBigTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bestie",
 			Name:      "output_file_too_big_total",
 			Help:      "Total output files not processed due to excessive size",
-		}),
-	bigQueryExceptionsTotal: prometheus.NewCounterVec(
+		},
+		[]string{"filetype"},
+	)
+	metricBigqueryExceptionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bestie",
 			Name:      "bigquery_exceptions_total",
 			Help:      "Total BigQuery operational exceptions, tagged by type",
 		},
 		[]string{"type"},
-	),
-	bigQueryInsertDelay: prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "bestie",
-			Name:      "bigquery_insert_delay",
-			Help:      "Historgram of BigQuery table insertion delay, in seconds",
-			Buckets:   []float64{0.0, 5.0, 10.0, 30.0, 60.0, 90.0, 120.0},
-		},
-	),
-	bigQueryInsertsTotal: prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "bestie",
-			Name:      "bigquery_inserts_total",
-			Help:      "Total BigQuery table insertions, tagged by result status",
-		},
-		[]string{"status"},
-	),
-	bigQueryMetricsTotal: prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "bestie",
-			Name:      "bigquery_metrics_total",
-			Help:      "Total BigQuery metrics processed, tagged by result status",
-		},
-		[]string{"status"},
-	),
-}
-
-// Register all service stats metrics with Prometheus.
-func (s *serviceStats) registerPrometheusMetrics() {
-	prometheus.MustRegister(s.buildsTotal)
-	prometheus.MustRegister(s.eventsTotal)
-	prometheus.MustRegister(s.outputFileTooBigTotal)
-	prometheus.MustRegister(s.bigQueryExceptionsTotal)
-	prometheus.MustRegister(s.bigQueryInsertDelay)
-	prometheus.MustRegister(s.bigQueryInsertsTotal)
-	prometheus.MustRegister(s.bigQueryMetricsTotal)
-}
-
-// Run-time initialization of service stats struct.
-func (s *serviceStats) init() {
-	s.registerPrometheusMetrics()
-}
+	)
+)
 
 // Get the label used to identify a BES event.
 func getEventLabel(bevid interface{}) string {
@@ -160,62 +72,4 @@ func getEventLabel(bevid interface{}) string {
 		glog.Warningf("Detected unknown event id: %s", id)
 	}
 	return label
-}
-
-// Increment the designated service statistic by 1.
-func (cid counterId) increment() {
-	go updatePrometheusCounter(cid, "", float64(1.0))
-}
-
-// Update the designated service statistic by adding the specified amount.
-func (cid counterId) update(amount int) {
-	go updatePrometheusCounter(cid, "", float64(amount))
-}
-
-// Update the designated service statistic by adding the specified amount.
-// Use this method whenever a qualifying label is needed for the metric.
-func (cid counterId) updateWithLabel(label string, amount int) {
-	go updatePrometheusCounter(cid, label, float64(amount))
-}
-
-// Update the Prometheus counter corresponding to the service statistic ID.
-// NOTE: This should be invoked as a goroutine to do the actual counter update.
-func updatePrometheusCounter(cid counterId, label string, n float64) {
-	s := &ServiceStats
-	switch cid {
-	case cidBuildsTotal:
-		s.buildsTotal.Add(n)
-	case cidEventsTotal:
-		// There are too many BES event names to define a unique counter ID
-		// for each, so the caller must pass in the label to use.
-		s.eventsTotal.WithLabelValues(label).Add(n)
-	case cidExceptionDatasetNotFound:
-		s.bigQueryExceptionsTotal.WithLabelValues("dataset_not_found").Add(n)
-	case cidExceptionExcessDelay:
-		s.bigQueryExceptionsTotal.WithLabelValues("excess_delay").Add(n)
-	case cidExceptionProtobufError:
-		s.bigQueryExceptionsTotal.WithLabelValues("protobuf_error").Add(n)
-	case cidExceptionTableNotFound:
-		s.bigQueryExceptionsTotal.WithLabelValues("table_not_found").Add(n)
-	case cidExceptionXmlParseError:
-		s.bigQueryExceptionsTotal.WithLabelValues("xml_parse_error").Add(n)
-	case cidExceptionXmlStructuredError:
-		s.bigQueryExceptionsTotal.WithLabelValues("xml_structured_error").Add(n)
-	case cidExceptionXmlUnstructuredError:
-		s.bigQueryExceptionsTotal.WithLabelValues("xml_unstructured_error").Add(n)
-	case cidInsertDelay:
-		s.bigQueryInsertDelay.Observe(float64(n))
-	case cidInsertError:
-		s.bigQueryInsertsTotal.WithLabelValues("error").Add(n)
-	case cidInsertOK:
-		s.bigQueryInsertsTotal.WithLabelValues("ok").Add(n)
-	case cidInsertTimeout:
-		s.bigQueryInsertsTotal.WithLabelValues("timeout").Add(n)
-	case cidMetricDiscard:
-		s.bigQueryMetricsTotal.WithLabelValues("discard").Add(float64(n))
-	case cidMetricUpload:
-		s.bigQueryMetricsTotal.WithLabelValues("upload").Add(float64(n))
-	case cidOutputFileTooBigTotal:
-		s.outputFileTooBigTotal.Add(n)
-	}
 }

--- a/bestie/server/test_result.go
+++ b/bestie/server/test_result.go
@@ -247,7 +247,7 @@ func processZipMetrics(stream *bazelStream, fileReader io.Reader) error {
 		fileData, err := readFileWithLimit(zr, maxFileSize)
 		if err != nil {
 			if errors.Is(err, fileTooBigErr) {
-				cidOutputFileTooBigTotal.increment()
+				metricOutputFileTooBigTotal.WithLabelValues("metrics.pb").Inc()
 			}
 			errs = append(errs, fmt.Errorf("Error reading file %q: %w", fileName, err))
 			continue
@@ -279,7 +279,7 @@ func processZipMetrics(stream *bazelStream, fileReader io.Reader) error {
 func getTestMetricsFromProtobufData(pbmsg []byte) (*metricTestResult, error) {
 	tmet := &tpb.TestMetrics{}
 	if err := proto.Unmarshal(pbmsg, tmet); err != nil {
-		cidExceptionProtobufError.increment()
+		metricBigqueryExceptionsTotal.WithLabelValues("protobuf_error").Inc()
 		return nil, fmt.Errorf("Error extracting metric data from protobuf message: %w", err)
 	}
 	table := tmet.GetTable()


### PR DESCRIPTION
It is currently difficult to tell if bestie is having consistent issues due to the dashboard being incomplete; even for metrics shown, it is nontrivial to find the code location causing specific counters to get hit.

This change performs minimal changes to existing metrics (names, types etc.) but refactors their usage:
* metrics are no longer incremented in a goroutine - spawning gigantic numbers of goroutines spontaneously could be the cause of OoM issues
* metrics increments are inlined. This reduces the amount of code, and makes finding a code location for a given metric a 2-3 step process
* where metrics are limited to use in one file, the definition is moved to said file

Some small changes to metric semantics were made:
* insertion delay metric captures actual wall time from insertion start to insertion success
* file-too-big metric now has a label indicating what kind of file was too big

Further improvements to metrics should be made:
* ensure there is a minimal and orthogonal set of metrics
* ensure that a metric covers all exit points from its parent function

...but this is outside the scope of this change

Tested: builds only

Jira: INFRA-6340