### PR TITLE
gee: add "migrate_default_branch" command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4931,20 +4931,35 @@ function gee__migrate_default_branch() {
   if [[ "${MAIN}" != "${UPSTREAM_MAIN}" ]]; then
     _warn "Local repo's default branch is ${MAIN} but the upstream repo's default " \
           "branch is ${UPSTREAM_MAIN}.  Correcting the local branch."
-    _checkout_or_die "${MAIN}"
-    gee__mkbr "${UPSTREAM_MAIN}"
+    if _local_branch_exists "${UPSTREAM_MAIN}"; then
+      _warn "A local branch named \"${UPSTREAM_MAIN}\" already exists." \
+            "Proceeding will cause that branch to be reset."
+      _confirm_default_no "Do you want to proceed? (y/N)"
+      _checkout_or_die "${UPSTREAM_MAIN}"
+      _git reset --hard "${MAIN}"
+    else
+      _checkout_or_die "${MAIN}"
+      gee__mkbr "${UPSTREAM_MAIN}"
+    fi
     _checkout_or_die "${UPSTREAM_MAIN}"
     _git push -u origin ${UPSTREAM_MAIN}
     _read_parents_file
     local KEY VALUE
     for KEY in "${!PARENTS[@]}"; do
       VALUE="${PARENTS["${KEY}"]}"
-      if [[ "${VALUE}" -eq "${MAIN}" ]]; then
+      if [[ "${VALUE}" == "${MAIN}" ]]; then
         PARENTS["${KEY}"]="${UPSTREAM_MAIN}"
       fi
     done
     _write_parents_file
-    gee_rmbr "${MAIN}"
+
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git worktree remove --force "${MAIN}"
+    _git branch -D "${MAIN}"
+    if _remote_branch_exists origin "${MAIN}"; then
+      _git_can_fail push --quiet origin --delete "${MAIN}" | cat
+    fi
+
     MAIN=""
     _set_main
     if [[ "${MAIN}" == "${UPSTREAM_MAIN}" ]]; then
@@ -4953,7 +4968,7 @@ function gee__migrate_default_branch() {
       _fatal "Something went wrong setting default branch to ${UPSTREAM_MAIN}".
     fi
   else
-    _info "Local and usptream repos both use \"${MAIN}\" as the default branch."
+    _info "Local and upstream repos both use \"${MAIN}\" as the default branch."
   fi
 }
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -376,12 +376,14 @@ function _set_main() {
   # Use a cached result if available:
   if [[ -n "${MAIN}" ]]; then return; fi
 
-  # If a master or main branch exist on our local file system, assume:
-  if [[ -d "${REPO_DIR}/master" ]]; then
-    MAIN=master
-    return
-  elif [[ -d "${REPO_DIR}/main" ]]; then
+  # Try to guess the default branch by examining which branches exist on
+  # the local filesystem.  Try "main" first:
+  if [[ -d "${REPO_DIR}/main" ]]; then
     MAIN=main
+    return
+  # Fall back to "master" if "main" doesn't exist:
+  elif [[ -d "${REPO_DIR}/master" ]]; then
+    MAIN=master
     return
   fi
 
@@ -4917,6 +4919,44 @@ function _gee_fix_gh_resolved_base() {
   fi
 }
 
+function gee__migrate_default_branch() {
+  _set_main  # ensure MAIN is set
+
+  local UPSTREAM_URL UPSTREAM_MAIN
+  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
+  UPSTREAM_MAIN="$(
+    "${GIT}" remote show "${UPSTREAM_URL}" \
+      | awk '/HEAD branch/ {print $NF}'
+  )"
+  if [[ "${MAIN}" != "${UPSTREAM_MAIN}" ]]; then
+    _warn "Local repo's default branch is ${MAIN} but the upstream repo's default " \
+          "branch is ${UPSTREAM_MAIN}.  Correcting the local branch."
+    _checkout_or_die "${MAIN}"
+    gee__mkbr "${UPSTREAM_MAIN}"
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git push -u origin ${UPSTREAM_MAIN}
+    _read_parents_file
+    local KEY VALUE
+    for KEY in "${!PARENTS[@]}"; do
+      VALUE="${PARENTS["${KEY}"]}"
+      if [[ "${VALUE}" -eq "${MAIN}" ]]; then
+        PARENTS["${KEY}"]="${UPSTREAM_MAIN}"
+      fi
+    done
+    _write_parents_file
+    gee_rmbr "${MAIN}"
+    MAIN=""
+    _set_main
+    if [[ "${MAIN}" == "${UPSTREAM_MAIN}" ]]; then
+      _info "Successfully set default branch to ${MAIN}"
+    else
+      _fatal "Something went wrong setting default branch to ${UPSTREAM_MAIN}".
+    fi
+  else
+    _info "Local and usptream repos both use \"${MAIN}\" as the default branch."
+  fi
+}
+
 function gee__repair() {
   # Make sure all tools are available
   _install_tools
@@ -4968,6 +5008,7 @@ function gee__repair() {
       _git checkout "${BRANCH}"
       _info "... Fixed."
     fi
+
   done
 
   _info "Checking each branch in the local repository..."
@@ -5006,6 +5047,8 @@ function gee__repair() {
   if (( DIRTY )); then
     _write_parents_file
   fi
+
+  gee__migrate_default_branch
 
   gee__bazelgc
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -4873,6 +4873,71 @@ function gee__diagnose() {
 }
 
 ##########################################################################
+# migrate_default_branch command
+##########################################################################
+
+_register_help "migrate_default_branch" "Migrate to a new default branch." <<'EOT'
+Usage: gee migrate_default_branch
+
+This command performs necessary local fix-ups after an upstream
+branch migrates their default branch from an old name (ie, "master")
+to a new name (ie, "main").
+EOT
+
+function gee__migrate_default_branch() {
+  _set_main  # ensure MAIN is set
+
+  local UPSTREAM_URL UPSTREAM_MAIN
+  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
+  UPSTREAM_MAIN="$(
+    "${GIT}" remote show "${UPSTREAM_URL}" \
+      | awk '/HEAD branch/ {print $NF}'
+  )"
+  if [[ "${MAIN}" != "${UPSTREAM_MAIN}" ]]; then
+    _warn "Local repo's default branch is ${MAIN} but the upstream repo's default " \
+          "branch is ${UPSTREAM_MAIN}.  Correcting the local branch."
+    if _local_branch_exists "${UPSTREAM_MAIN}"; then
+      _warn "A local branch named \"${UPSTREAM_MAIN}\" already exists." \
+            "Proceeding will cause that branch to be reset."
+      _confirm_default_no "Do you want to proceed? (y/N)"
+      _checkout_or_die "${UPSTREAM_MAIN}"
+      _git reset --hard "${MAIN}"
+    else
+      _checkout_or_die "${MAIN}"
+      gee__mkbr "${UPSTREAM_MAIN}"
+    fi
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git push -u origin "${UPSTREAM_MAIN}"
+    _read_parents_file
+    local KEY VALUE
+    for KEY in "${!PARENTS[@]}"; do
+      VALUE="${PARENTS["${KEY}"]}"
+      if [[ "${VALUE}" == "${MAIN}" ]]; then
+        PARENTS["${KEY}"]="${UPSTREAM_MAIN}"
+      fi
+    done
+    _write_parents_file
+
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git worktree remove --force "${MAIN}"
+    _git branch -D "${MAIN}"
+    if _remote_branch_exists origin "${MAIN}"; then
+      _git_can_fail push --quiet origin --delete "${MAIN}" | cat
+    fi
+
+    MAIN=""
+    _set_main
+    if [[ "${MAIN}" == "${UPSTREAM_MAIN}" ]]; then
+      _info "Successfully set default branch to ${MAIN}"
+    else
+      _fatal "Something went wrong setting default branch to ${UPSTREAM_MAIN}".
+    fi
+  else
+    _info "Local and upstream repos both use \"${MAIN}\" as the default branch."
+  fi
+}
+
+##########################################################################
 # repair command
 ##########################################################################
 
@@ -4916,59 +4981,6 @@ function _gee_fix_gh_resolved_base() {
   if [[ "$X" != "base" ]]; then
     _warn "gh-resolved isn't pointing at upstream, fixing:"
     _git config --local "remote.upstream.gh-resolved" base
-  fi
-}
-
-function gee__migrate_default_branch() {
-  _set_main  # ensure MAIN is set
-
-  local UPSTREAM_URL UPSTREAM_MAIN
-  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
-  UPSTREAM_MAIN="$(
-    "${GIT}" remote show "${UPSTREAM_URL}" \
-      | awk '/HEAD branch/ {print $NF}'
-  )"
-  if [[ "${MAIN}" != "${UPSTREAM_MAIN}" ]]; then
-    _warn "Local repo's default branch is ${MAIN} but the upstream repo's default " \
-          "branch is ${UPSTREAM_MAIN}.  Correcting the local branch."
-    if _local_branch_exists "${UPSTREAM_MAIN}"; then
-      _warn "A local branch named \"${UPSTREAM_MAIN}\" already exists." \
-            "Proceeding will cause that branch to be reset."
-      _confirm_default_no "Do you want to proceed? (y/N)"
-      _checkout_or_die "${UPSTREAM_MAIN}"
-      _git reset --hard "${MAIN}"
-    else
-      _checkout_or_die "${MAIN}"
-      gee__mkbr "${UPSTREAM_MAIN}"
-    fi
-    _checkout_or_die "${UPSTREAM_MAIN}"
-    _git push -u origin ${UPSTREAM_MAIN}
-    _read_parents_file
-    local KEY VALUE
-    for KEY in "${!PARENTS[@]}"; do
-      VALUE="${PARENTS["${KEY}"]}"
-      if [[ "${VALUE}" == "${MAIN}" ]]; then
-        PARENTS["${KEY}"]="${UPSTREAM_MAIN}"
-      fi
-    done
-    _write_parents_file
-
-    _checkout_or_die "${UPSTREAM_MAIN}"
-    _git worktree remove --force "${MAIN}"
-    _git branch -D "${MAIN}"
-    if _remote_branch_exists origin "${MAIN}"; then
-      _git_can_fail push --quiet origin --delete "${MAIN}" | cat
-    fi
-
-    MAIN=""
-    _set_main
-    if [[ "${MAIN}" == "${UPSTREAM_MAIN}" ]]; then
-      _info "Successfully set default branch to ${MAIN}"
-    else
-      _fatal "Something went wrong setting default branch to ${UPSTREAM_MAIN}".
-    fi
-  else
-    _info "Local and upstream repos both use \"${MAIN}\" as the default branch."
   fi
 }
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -111,6 +111,7 @@ review.
 | <a href="#log">`log`</a> | Log of commits since parent branch. |
 | <a href="#lsbranches">`lsbranches`</a> | List information about each branch. |
 | <a href="#make_branch">`make_branch`</a> | Create a new child branch based on the current branch. |
+| <a href="#migrate_default_branch">`migrate_default_branch`</a> | Migrate to a new default branch. |
 | <a href="#pack">`pack`</a> | Exports all unsubmitted changes in this branch as a pack file. |
 | <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
 | <a href="#pr_check">`pr_check`</a> | Checks the status of presubmit tests for a PR. |
@@ -698,6 +699,14 @@ Usage: `gee diagnose`
 This command produces a `~/gee.diagnostics.txt` file that might
 be useful to share with the tool maintainers if something has gone
 wrong with your gee repository.
+
+### migrate_default_branch
+
+Usage: `gee migrate_default_branch`
+
+This command performs necessary local fix-ups after an upstream
+branch migrates their default branch from an old name (ie, "master")
+to a new name (ie, "main").
 
 ### repair
 


### PR DESCRIPTION
This PR prepares gee for migration of the default branch in our
repo from "master" to "main."

The `gee migrate_default_branch` command will fix-up the gee-controlled
repositories to match the default branch of the upstream repo.

Tested: I created a "main" branch in my local repo, and used the new
command to verify that gee can "switch" from "main" to "master."  This
operation should be equivalent to switching from "master" to "main" when
the upstream repo branch name changes.

