### PR TITLE
dropbear: fix a few issues in internal integration

### DIFF
--- a/bazel/dependencies/dropbear.BUILD.bazel
+++ b/bazel/dependencies/dropbear.BUILD.bazel
@@ -19,7 +19,7 @@ configure_make(
 )
 
 
-load("@//bazel/utils:binary.bzl", "declare_binary")
+load("@enkit//bazel/utils:binary.bzl", "declare_binary")
 
 declare_binary(
     name = "dropbear",

--- a/bazel/dependencies/dropbear.BUILD.bazel
+++ b/bazel/dependencies/dropbear.BUILD.bazel
@@ -6,11 +6,21 @@ configure_make(
     name = "binaries",
     lib_source = ":all",
     configure_options = [
-        # configure_make rule expects all binaries in bin/ by default.
-        "--sbindir=$INSTALLDIR/bin",
         "--enable-static",
         "--enable-bundled-libtom",
     ],
+    # By default `targets` would be ["", "install"], meaning it would run
+    # `make ""` and `make "install"`.
+    #
+    # Don't run "make install" as the dropbear makefile does things to
+    # setup the privileges correctly that don't work in an RBE environment.
+    # Instead, run the few commands in postfix_script to install the
+    # binaries correctly.
+	targets = [""],
+	postfix_script = "; ".join([
+	    "mkdir -p ${INSTALLDIR}/bin",
+	    "cp dropbear dropbearkey ${INSTALLDIR}/bin",
+	]),
     out_binaries = [
         "dropbear",
         "dropbearkey",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -280,12 +280,12 @@ def stage_1():
     maybe(
         name = "dropbear",
         repo_rule = http_archive,
-        build_file = "//bazel/dependencies:dropbear.BUILD.bazel",
+        build_file = "@enkit//bazel/dependencies:dropbear.BUILD.bazel",
         sha256 = "e02c5c36eb53bfcd3f417c6e40703a50ec790a1a772269ea156a2ccef14998d2",
         urls = ["https://github.com/mkj/dropbear/archive/refs/tags/DROPBEAR_2022.83.tar.gz"],
         strip_prefix = "dropbear-DROPBEAR_2022.83",
         patches = [
-            "//bazel/dependencies/dropbear:0000-allow-blank-password.patch",
-            "//bazel/dependencies/dropbear:0001-override-authorized-keys.patch",
+            "@enkit//bazel/dependencies/dropbear:0000-allow-blank-password.patch",
+            "@enkit//bazel/dependencies/dropbear:0001-override-authorized-keys.patch",
         ],
     )


### PR DESCRIPTION
- dropbear: use @enkit to refer to the BUILD.bazel files and patches.
- dropbear: make sure it builds correctly in RBE environment.
