### PR TITLE
bazel/utils: fix exec_test to use the target platform.

### DIFF
--- a/bazel/utils/exec_test.bzl
+++ b/bazel/utils/exec_test.bzl
@@ -52,7 +52,8 @@ if "compute-valid.sh -delta 1799" exits with status 0.
             doc = "Executable target to be converted into a test target",
             mandatory = True,
             executable = True,
-            cfg = "host",
+            # Tests in bazel are built for the target platform.
+            cfg = "target",
         ),
         "argv": attr.string_list(
             doc = "Additional arguments to pass to the executable target",


### PR DESCRIPTION
Tests in bazel are normally built for the target platform, not
for the exec (or host) platform. The target platform is what needs to be
tested (although there can be multiple target platforms).

Further, cfg = "exec" applies to all direct and indirect
dependencies of a rule, as it changes what the target is.

Basically, any exec_test causes the entire dependency graph
of the test to be rebuilt for a different platform.
