### PR TITLE
googletest: Update to 1.13.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,8 @@ try-import %workspace%/.bazelrc.user
 # TODO(INFRA-4384): Remove this flag once all dependencies are compatible with
 # the new platforms repo for constraints.
 build --noincompatible_use_platforms_repo_for_constraints
+
+# googletest requires C++14 or newer. Force C++20 for all builds by default.
+# The compiler used in the current container seems to only understand
+# `-std=c++2a` instead of `-std=c++20`.
+build --cxxopt=-std=c++2a --host_cxxopt=-std=c++2a

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -110,9 +110,9 @@ def stage_1():
     maybe(
         name = "com_google_googletest",
         repo_rule = http_archive,
-        sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
-        strip_prefix = "googletest-release-1.10.0",
-        url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
+        sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
+        strip_prefix = "googletest-1.13.0",
+        url = "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz",
     )
 
     maybe(

--- a/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
@@ -283,15 +283,13 @@ enkit/tools/codegen/tests/test.template
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-actions.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-cardinalities.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-function-mocker.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-actions.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-function-mockers.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-more-actions.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-more-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-nice-strict.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock.h
+enkit/../com_google_googletest/googletest/include/gtest/gtest-assertion-result.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-death-test.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-matchers.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-message.h
@@ -325,6 +323,7 @@ enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-port-arch
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-port.h
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-string.h
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-type-util.h
+enkit/../com_google_googletest/googletest/src/gtest-assertion-result.cc
 enkit/../com_google_googletest/googletest/src/gtest-death-test.cc
 enkit/../com_google_googletest/googletest/src/gtest-filepath.cc
 enkit/../com_google_googletest/googletest/src/gtest-internal-inl.h


### PR DESCRIPTION
This change updates googletest to 1.13.0, to pick up fixes to the bazel rule/macro glue within that make it more compatible with newer versions of bazel.

Updating googletest causes tests in this repo to fail, unless flags are passed to set the C++ standard higher by default. We'd prefer to match the flags passed in internal (`-std=c++20`), but those don't seem to work in this context, so we pass the next most approximate flag (`-std=c++2a`).

Tested: `bazel test //...` in this repo