### PR TITLE
gee setup: add "enable_bcompare"

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2280,6 +2280,7 @@ Valid configuration options are:
 * "enable_emacs": Set "emacs" as your merge tool.
 * "enable_vscode": Set "vscode" as your GUI merge tool.
 * "enable_meld": Set "meld" as your GUI merge tool.
+* "enable_bcompare": Set "BeyondCompare" as your GUI merge tool.
 EOT
 function gee__config() {
   _git config --global rerere.enabled true
@@ -2311,6 +2312,23 @@ function gee__config() {
       _git config --global diff.guitool meld
       _git config --global difftool.meld.cmd \
         "/usr/bin/meld \"\$LOCAL\" \"\$REMOTE\""
+      ;;
+    enable_bcompare)
+      _info "Setting BeyondCompare as the default GUI diff and merge tool."
+      _git config --global merge.guitool bc
+      _git config --global diff.guitool bc
+      _git config --global mergetool.bc.trustExitCode true
+      _git config --global difftool.bc.trustExitCode true
+      if ! command -v bcompare > /dev/null; then
+        _warn "bcompare is not currently installed."
+        _info \
+          "To install BeyondCompare:" \
+          "" \
+          "  wget https://www.scootersoftware.com/files/bcompare-4.4.6.27483_amd64.deb" \
+          "  sudo apt install poppler-utils" \
+          "  sudo dpkg -i ./bcompare-4.4.6.27483_amd64.deb" \
+          "  which bcompare  # ensure tool is installed"
+      fi
       ;;
     enable_emacs)
       # TODO: I'm hoping an emacs expert can contribute

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.42"
+readonly VERSION="0.2.43"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,14 @@
 
 ## Releases
 
+### 0.2.43
+
+* gee setup: add support for BeyondCompare. (#945)
+* gee migrate_default_branch: new command to ease migration from
+  master to main branch names.  (#929)
+* gee pr_submit: retry failed pull requests. (#870)
+* gee checks: wait for slow-to-start tests. (#868)
+
 ### 0.2.42
 
 * gee: make colors configurable.  Enhanced hidden "gee colortest" command.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -165,6 +165,7 @@ Valid configuration options are:
 * "enable_emacs": Set "emacs" as your merge tool.
 * "enable_vscode": Set "vscode" as your GUI merge tool.
 * "enable_meld": Set "meld" as your GUI merge tool.
+* "enable_bcompare": Set "BeyondCompare" as your GUI merge tool.
 
 ### make_branch
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.42
+gee version: 0.2.43
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
Add `gee setup enable_bcompare` to configure gee to use the commercial
BeyondCompare tool to resolve merge conflicts.  The goal here is to make
it easy for Enfabricators to evaluate the use of BeyondCompare to see if
buying a license is worthwhile.

Tested: Manually tested in my hw-dev container.

