### PR TITLE
Remove duplicate kernel modules from dependencies

### DIFF
--- a/bazel/linux/utils.bzl
+++ b/bazel/linux/utils.bzl
@@ -117,6 +117,6 @@ The modules still to expand are:
         if key in dups:
             continue
         result.append(mod)
-        dups|={key : ""}
+        dups[key] = True
 
     return result

--- a/bazel/linux/utils.bzl
+++ b/bazel/linux/utils.bzl
@@ -117,5 +117,6 @@ The modules still to expand are:
         if key in dups:
             continue
         result.append(mod)
+        dups|={key : ""}
 
     return result


### PR DESCRIPTION
If a kernel_module rule has multiple dependencies that introduce the same module, we need to filter them out before we try to load them. (Functionality is described in the utils.bzl file but not fully implemented).

Tested:
 kunit_test target that was failing due to `insmod: ERROR: could not insert module driver/core/enf-ubuntu-impish-generic/enf/host/enf.ko: File exists` is now passing