### PR TITLE
rules_foreign_cc: Update to latest version

### DIFF
--- a/bazel/dependencies/rules_foreign_cc_export_functions.patch
+++ b/bazel/dependencies/rules_foreign_cc_export_functions.patch
@@ -1,0 +1,11 @@
+diff --git a/foreign_cc/private/framework.bzl b/foreign_cc/private/framework.bzl
+index c84c217..46ddc10 100644
+--- a/foreign_cc/private/framework.bzl
++++ b/foreign_cc/private/framework.bzl
+@@ -1004,3 +1004,6 @@ def _expand_locations_in_string(ctx, expandable, data):
+         return ctx.expand_location(expandable, data)
+     else:
+         return ctx.expand_location(expandable.replace("$(execpath ", "$$EXT_BUILD_ROOT$$/$(execpath "), data)
++
++# ENFABRICA PATCH: export these functions for our own rules
++expand_locations = _expand_locations

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -122,7 +122,7 @@ def stage_1():
         strip_prefix = "abseil-cpp-20230125.3",
         patch_args = ["-p1"],
         patches = ["@enkit//bazel/dependencies/abseil:0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch"],
-	urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.zip"],
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.zip"],
     )
 
     maybe(
@@ -201,18 +201,22 @@ def stage_1():
     maybe(
         name = "rules_foreign_cc",
         repo_rule = http_archive,
-        sha256 = "bcd0c5f46a49b85b384906daae41d277b3dc0ff27c7c752cc51e43048a58ec83",
-        strip_prefix = "rules_foreign_cc-0.7.1",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.7.1.tar.gz",
+        sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+        strip_prefix = "rules_foreign_cc-0.9.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+        patches = [
+            "@enkit//bazel/dependencies:rules_foreign_cc_export_functions.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     maybe(
         name = "meson",
         repo_rule = http_archive,
         build_file = "@enkit//bazel/meson:meson.BUILD.bazel",
-        sha256 = "a0f5caa1e70da12d5e63aa6a9504273759b891af36c8d87de381a4ed1380e845",
-        urls = ["https://github.com/mesonbuild/meson/releases/download/0.62.1/meson-0.62.1.tar.gz"],
-        strip_prefix = "meson-0.62.1",
+        sha256 = "d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c",
+        urls = ["https://github.com/mesonbuild/meson/releases/download/1.1.1/meson-1.1.1.tar.gz"],
+        strip_prefix = "meson-1.1.1",
     )
 
     maybe(

--- a/bazel/meson/meson.bzl
+++ b/bazel/meson/meson.bzl
@@ -21,14 +21,14 @@ def _create_meson_script(configureParameters):
     tools = get_tools_info(ctx)
     flags = get_flags_info(ctx)
     data = ctx.attr.data + ctx.attr.build_data
-    user_env = expand_locations_and_make_variables(ctx, "env", data)
+    user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data)
 
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
 
     script.append("export INSTALL_PREFIX=\"{install_prefix}\"".format(
-        install_prefix=ctx.attr.name,
+        install_prefix = ctx.attr.name,
     ))
 
     setup_args = " ".join([
@@ -55,7 +55,7 @@ def _create_meson_script(configureParameters):
     return script
 
 def _access_and_expect_label_copied(toolchain_type_, ctx):
-    tool_data = access_tool(toolchain_type_, ctx, "")
+    tool_data = access_tool(toolchain_type_, ctx)
 
     # This could be made more efficient by changing the
     # toolchain to provide the executable as a target


### PR DESCRIPTION
This change updates `rules_foreign_cc` to the latest released version.

The new version takes a function that we were using private, so this change adds a patch to re-export it. `meson.bzl` is updated where some of the function signatures/contracts changed, and meson is updated to the latest release as well.

This change will need to be coupled with #<internal PR> when updating enkit in internal, as there is a change to how make variables are written/substituted during expansion that breaks existing builds otherwise.

Tested: See https://github.com/enfabrica/internal/pull/20899

Jira: INFRA-6722