### PR TITLE
gee: handle the scenario where main and master branches both exist

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -377,8 +377,12 @@ function _set_main() {
   if [[ -n "${MAIN}" ]]; then return; fi
 
   # Try to guess the default branch by examining which branches exist on
-  # the local filesystem.  Try "main" first:
-  if [[ -d "${REPO_DIR}/main" ]]; then
+  # the local filesystem.
+  if [[ -d "${REPO_DIR}/main" ]] && [[ -d "${REPO_DIR}/master" ]]; then
+    # oh no, the user has both main and master available.  Refuse to
+    # guess and ask github.
+    _warn "Confusing!  You have both \"main\" and \"master\" branches."
+  elif [[ -d "${REPO_DIR}/main" ]]; then
     MAIN=main
     return
   # Fall back to "master" if "main" doesn't exist:
@@ -5761,6 +5765,11 @@ function _print_color_block() {
     fi
   fi
   printf " %s%3d%s" "$(tput setaf "${FG}"; tput setab "${C}")" "$C" "${_COLOR_RST}"
+}
+
+function gee__set_main_by_asking_github() {
+  _set_main_by_asking_github
+  _info "MAIN=$MAIN"
 }
 
 function gee__colortest() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -5767,11 +5767,6 @@ function _print_color_block() {
   printf " %s%3d%s" "$(tput setaf "${FG}"; tput setab "${C}")" "$C" "${_COLOR_RST}"
 }
 
-function gee__set_main_by_asking_github() {
-  _set_main_by_asking_github
-  _info "MAIN=$MAIN"
-}
-
 function gee__colortest() {
   echo "Color table:"
   for t in $(seq 0 255); do


### PR DESCRIPTION
A previous PR changed gee's behavior so that if the branch "main"
exists, gee assumes that the upstream branch's main branch is named
"main" instead of "master."

Some users have both "main" and "master" branches, and so the selection
of main branches are ambiguous.  gee started making an incorrect
assumption about the name of the upstream main branch, and this broke
some gee functionality.

This PR detects the condition where both "main" and "master" exists
and instead of making assumptions, warns the user that this arrangement
is confusing and then queries github to see what the real upstream
main branch is named.

Tested:

I created both main and master branches in my local repo and tested
gee.

```
$ ./scripts/gee up
WARNING: Confusing!  You have both "main" and "master" branches.
CMD: /usr/bin/git fetch origin
CMD: /usr/bin/git pull --rebase --autostash upstream master
From github.com:enfabrica/enkit
 * branch            master     -> FETCH_HEAD
Updating e5a5f1b..5e47a62
Fast-forward
 .bazelversion                                              |  2 +-
 bazel/dependencies/rules_foreign_cc_export_functions.patch | 11 +++++++++++
 bazel/init/stage_1.bzl                                     | 18 +++++++++++-------
 bazel/meson/meson.bzl                                      |  6 +++---
 4 files changed, 26 insertions(+), 11 deletions(-)
 create mode 100644 bazel/dependencies/rules_foreign_cc_export_functions.patch
 ```

 Without this patch, the command fails.

