### PR TITLE
make: Patch with less pedantic `configure` script

### DIFF
--- a/bazel/dependencies/make_less_pedantic_configure.patch
+++ b/bazel/dependencies/make_less_pedantic_configure.patch
@@ -1,0 +1,19 @@
+diff --git a/configure b/configure
+index 58a1d4f..eb4ea7a 100755
+--- a/configure
++++ b/configure
+@@ -3007,8 +3007,12 @@ then
+    # Ok.
+    :
+ else
+-   as_fn_error $? "newly created file is older than distributed files!
+-Check your system clock" "$LINENO" 5
++   # ENFABRICA MOD: ignore timestamp checks for compatibility with filesystems
++   # that don't report accurate timestamps
++   #
++   #as_fn_error $? "newly created file is older than distributed files!
++#Check your system clock" "$LINENO" 5
++   :
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }


### PR DESCRIPTION
Buildbarn FUSE workers don't expose proper timestamps, which confuses `configure` scripts that check for such things. This change adds a patch that removes this check for the `make` tool itself, which allows `make` to build on Buildbarn FUSE workers.

Tested: `BAZEL_PROFILE=buildbarn-staging bazel build @capnproto//... --override_repository=enkit=/home/scott/dev/enkit` can get past `make` build (fails on next build with similar `configure` script issue)

Jira: INFRA-6712