### PR TITLE
enproxy: Don't include port number in hostname matching

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -37,8 +37,8 @@ genrule(
 diff_test(
     name = "foobar.bin-diff_test",
     actual = "foobar.bin",
-    expected = "testdata/expected.foobar.bin",
     binary = True,
+    expected = "testdata/expected.foobar.bin",
 )
 
 write_to_file(

--- a/proxy/amux/amuxie/BUILD.bazel
+++ b/proxy/amux/amuxie/BUILD.bazel
@@ -2,11 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["amuxie.go"],
+    srcs = [
+        "amuxie.go",
+        "matchers.go",
+    ],
     importpath = "github.com/enfabrica/enkit/proxy/amux/amuxie",
     visibility = ["//visibility:public"],
     deps = [
         "//proxy/amux:go_default_library",
         "@com_github_kataras_muxie//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )

--- a/proxy/amux/amuxie/amuxie.go
+++ b/proxy/amux/amuxie/amuxie.go
@@ -3,10 +3,12 @@
 package amuxie
 
 import (
-	"github.com/enfabrica/enkit/proxy/amux"
-	"github.com/kataras/muxie"
 	"net/http"
 	"strings"
+
+	"github.com/kataras/muxie"
+
+	"github.com/enfabrica/enkit/proxy/amux"
 )
 
 type Mux struct {
@@ -19,9 +21,10 @@ func New() *Mux {
 
 func (m *Mux) Host(host string) amux.Mux {
 	h := muxie.NewMux()
-	m.HandleRequest(muxie.Host(host), h)
+	m.HandleRequest(NewPortStripping(host, muxie.Host(host)), h)
 	if !strings.HasSuffix(host, ".") {
-		m.HandleRequest(muxie.Host(host + "."), h)
+		absolute := host + "."
+		m.HandleRequest(NewPortStripping(absolute, muxie.Host(absolute)), h)
 	}
 
 	return &Mux{h}

--- a/proxy/amux/amuxie/matchers.go
+++ b/proxy/amux/amuxie/matchers.go
@@ -1,0 +1,66 @@
+package amuxie
+
+import (
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/kataras/muxie"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var metricPortStrippingActionCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "enproxy",
+	Subsystem: "port_stripping",
+	Name:      "action_count",
+	Help:      "Counts of the actions that the PortStripping hostname matcher took",
+},
+	[]string{
+		"host",
+		"action",
+	},
+)
+
+type PortStripping struct {
+	// Keep track of the host this is matching purely for metrics recording
+	// purposes.
+	host string
+	// Underlying matcher to delegate to after (possibly) stripping the port off
+	// the hostname
+	m muxie.Matcher
+}
+
+func NewPortStripping(host string, wrapped muxie.Matcher) muxie.Matcher {
+	return &PortStripping{
+		host: host,
+		m:    wrapped,
+	}
+}
+
+func (ps *PortStripping) Match(req *http.Request) bool {
+	stripped, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		addrError := &net.AddrError{}
+		if errors.As(err, &addrError) {
+			// SplitHostPort will fail if the address doesn't contain a port. Assume
+			// in this case the original host had no port component to strip. While
+			// this is too broad a check, it's better than nothing
+			stripped = req.Host
+			metricPortStrippingActionCount.WithLabelValues(ps.host, "noop")
+		} else {
+			// Some unknown error occurred; don't allow any matches
+			metricPortStrippingActionCount.WithLabelValues(ps.host, "failed")
+			return false
+		}
+	} else {
+		metricPortStrippingActionCount.WithLabelValues(ps.host, "stripped")
+	}
+	// Modify the request so that if it is propagated to a reverse proxy, the
+	// reverse proxy doesn't need to deal with detecting whether to strip the port
+	// again.
+	req.Host = stripped
+
+	// Delegate to the downstream matcher
+	return ps.m.Match(req)
+}

--- a/proxy/amux/mux_test.go
+++ b/proxy/amux/mux_test.go
@@ -119,4 +119,9 @@ func TestMuxConformance(t *testing.T) {
 	assert.Equal(t, http.StatusOK, Request(m, "host2.net", "/"))
 	assert.Equal(t, http.StatusOK, Request(m, "host2.net.", "/whatever"))
 	assert.Equal(t, 2, countHost2)
+	
+	// Ports shouldn't affect host mappings
+	assert.Equal(t, http.StatusOK, Request(m, "host2.net:443", "/"))
+	assert.Equal(t, http.StatusOK, Request(m, "host2.net.:443", "/whatever"))
+	assert.Equal(t, 4, countHost2)
 }


### PR DESCRIPTION
It would seem that if clients include the port number in requests to enproxy, the port number is including in the host matching logic, which will result in 404s. This is inconvenient, and will result in duplicate mappings/more complex wildcard matching to ensure all the possible spellings of a particular hostname are matched correctly.

This change proposes that the port number be stripped from requests before they are matched. The rationale is:
* enproxy only listens on a small, fixed number of ports (typically 80 and 443); by the time a hostname is considered for matching, the port has already taken effect, by nature of the request being processed in the first place
* Matching with ports would be useful if enproxy had multiple sets of matchers that it used for requests coming in on different ports; this is not a use case worth supporting at this time
* Ports should be stripped out of the host when propagating the request anyway, as downstream reverse proxies may have the same behavior/issue.

This fix comes in the form of a wrapping matcher type that:
* strips the port from the request, if present
* delegates to another matcher

...including metrics so that we can monitor this behavior over time.

Jira: INFRA-6906