### PR TITLE
bazel/linux: Explicitly list all kernel tree outputs

### DIFF
--- a/bazel/linux/templates/kernel_tree.BUILD.bzl
+++ b/bazel/linux/templates/kernel_tree.BUILD.bzl
@@ -2,7 +2,7 @@ filegroup(
     name = "{name}-tree",
     # Why allow_empty = True? To support compatibility with different package formats,
     # they may expand the content in different directories, and not use others.
-    srcs = glob(["lib", "usr", "install"], allow_empty = True, exclude_directories = 0),
+    srcs = glob(["lib/**/*", "usr/**/*", "install/**/*"], allow_empty = True),
     visibility = [
         "//visibility:public",
     ],


### PR DESCRIPTION
Listing only directories as outputs of the kernel tree rule causes the "dependency checking of directories is unsound" warning and can fail under some scenarios.  One example is when the tree is used as an input of a genrule.

See https://github.com/bazelbuild/bazel/issues/1415#issuecomment-482490890 as well as https://bazel.build/reference/be/general#filegroup

We can explicitly specify all the files in the kernel tree because it's a repository rule.

For testing, I had a genrule that depended on the kernel tree.  Prior to the change it would receive an empty directory as an input (along with the "unsound" warning).  After the change the genrule could use kernel headers as expected.