### PR TITLE
enkit bazel: Collect a sha256 from commands that download files

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -242,6 +242,13 @@ def _astore_download_and_verify(rctx, dest, uid, digest, timeout):
             digest,
         ))
 
+    # BUG(INFRA-7187): There's no native way to pass the digest via the
+    # workspace log to affected targets detection when downloading stuff using a
+    # command instead of a built-in starlark function. This is a hack - a
+    # command that always succeeds, that allows us to detect and exfiltrate the
+    # digest.
+    rctx.execute(["echo", digest], timeout = 10)
+
 def astore_download_and_extract(ctx, digest, stripPrefix, path = None, uid = None, timeout = 10 * 60):
     """Fetch and extract a package from astore.
 

--- a/lib/bazel/query.go
+++ b/lib/bazel/query.go
@@ -105,6 +105,11 @@ func (r *QueryResult) addChecksumsAttributeToExternals() error {
 				if e.DownloadAndExtractEvent.GetIntegrity() != "" {
 					checksums = append(checksums, e.DownloadAndExtractEvent.GetIntegrity())
 				}
+			case *bpb.WorkspaceEvent_ExecuteEvent:
+				if len(e.ExecuteEvent.GetArguments()) == 2 && e.ExecuteEvent.GetArguments()[0] == "echo" {
+					fmt.Printf("got checksum: %q\n", e.ExecuteEvent.GetArguments()[1])
+					checksums = append(checksums, e.ExecuteEvent.GetArguments()[1])
+				}
 			}
 		}
 


### PR DESCRIPTION
Affected targets detection currently handles external repositories by rewriting labels like `@repo//some:target` into a single label `@repo` whose only attribute is the sha256 of the downloaded archive; thus, if the archive changes, all rules that depended on some target within are also assumed to have changed. This is a bit conservative, but necessary so that:
* hashing all files within external repositories can be skipped
* dependency crawling code doesn't need to handle a variety of edge cases that might require patching third-party dependencies to work around

SHA256sums of the archives are picked up via the "workspace event log" which keeps track of each archive downloaded during the query; by querying when no dependencies are fetched, we will get a hash of each download reliably.

This works well for archives that are downloaded with a builtin starlark function that takes the checksum as a parameter, but less well for rules that make use of `repository_ctx.execute` to run an arbitrary program and do the checksum comparison in starlark - this checksum does not make it into the log - though each command executed does.

This change:
* inserts the checksum into the log in `astore_package` rules, by way of an always-passing benign command (`echo <checksum>`)
* adds to affected targets detection, to extract these checksums where they exist

While testing this change, it became apparent that changed target detection for all external repos is broken, as the keys used to map repository name strings to workspace log events no longer matched their expected values. The generation of the map key during lookup is fixed so that events are actually processed correctly.

Tested:
* patched master commits named by INFRA-7187 to pick up new astore_package rule fix, #22530
* ran `enkit bazel affected-targets list --start=infra/start_patch --end=infra/end_patch --loglevel-console=debug`
* now see ~10000 changed targets instead of ~900 (due to IP update)

Jira: INFRA-7224