### PR TITLE
rules_python: Update to 0.24.0; add patch to handle circular deps

### DIFF
--- a/bazel/dependencies/rules_python/custom_annotations.patch
+++ b/bazel/dependencies/rules_python/custom_annotations.patch
@@ -1,0 +1,85 @@
+diff --git a/python/pip_install/pip_repository.bzl b/python/pip_install/pip_repository.bzl
+index 41533b4..acb8b9c 100644
+--- a/python/pip_install/pip_repository.bzl
++++ b/python/pip_install/pip_repository.bzl
+@@ -727,7 +727,8 @@ def package_annotation(
+         copy_executables = {},
+         data = [],
+         data_exclude_glob = [],
+-        srcs_exclude_glob = []):
++        srcs_exclude_glob = [],
++        excluded_deps = []):
+     """Annotations to apply to the BUILD file content from package generated from a `pip_repository` rule.
+
+     [cf]: https://github.com/bazelbuild/bazel-skylib/blob/main/docs/copy_file_doc.md
+@@ -742,6 +743,7 @@ def package_annotation(
+         data_exclude_glob (list, optional): A list of exclude glob patterns to add as `data` to the generated
+             `py_library` target.
+         srcs_exclude_glob (list, optional): A list of labels to add as `srcs` to the generated `py_library` target.
++        deps (list, optional): A list of labels to remove as `deps` to the generated `py_library` target.
+
+     Returns:
+         str: A json encoded string of the provided content.
+@@ -753,6 +755,7 @@ def package_annotation(
+         data = data,
+         data_exclude_glob = data_exclude_glob,
+         srcs_exclude_glob = srcs_exclude_glob,
++        excluded_deps = excluded_deps,
+     ))
+
+ # pip_repository implementation
+diff --git a/python/pip_install/tools/lib/annotation.py b/python/pip_install/tools/lib/annotation.py
+index c980080..c562340 100644
+--- a/python/pip_install/tools/lib/annotation.py
++++ b/python/pip_install/tools/lib/annotation.py
+@@ -33,6 +33,7 @@ class Annotation(OrderedDict):
+             "data",
+             "data_exclude_glob",
+             "srcs_exclude_glob",
++            "excluded_deps",
+         ):
+             if field not in content:
+                 missing.append(field)
+@@ -75,6 +76,10 @@ class Annotation(OrderedDict):
+     def srcs_exclude_glob(self) -> List[str]:
+         return self["srcs_exclude_glob"]
+
++    @property
++    def excluded_deps(self) -> List[str]:
++        return self["excluded_deps"]
++
+
+ class AnnotationsMap:
+     """A mapping of python package names to [Annotation]"""
+diff --git a/python/pip_install/tools/wheel_installer/wheel_installer.py b/python/pip_install/tools/wheel_installer/wheel_installer.py
+index 9b363c3..a4aa4f0 100644
+--- a/python/pip_install/tools/wheel_installer/wheel_installer.py
++++ b/python/pip_install/tools/wheel_installer/wheel_installer.py
+@@ -16,6 +16,7 @@ import argparse
+ import errno
+ import glob
+ import json
++import logging
+ import os
+ import re
+ import shutil
+@@ -369,6 +370,19 @@ def _extract_wheel(
+             if annotation.additive_build_content:
+                 additional_content.append(annotation.additive_build_content)
+
++            if len(annotation.excluded_deps) > 0:
++                filtered_whl_deps = [dep for dep in whl_deps if
++                                     dep not in annotation.excluded_deps]
++
++                sanitised_dependencies = [
++                    bazel.sanitised_repo_library_label(d, repo_prefix=repo_prefix) for d
++                    in filtered_whl_deps
++                ]
++                sanitised_wheel_file_dependencies = [
++                    bazel.sanitised_repo_file_label(d, repo_prefix=repo_prefix) for d in
++                    filtered_whl_deps
++                ]
++
+         contents = _generate_build_file_contents(
+             name=bazel.PY_LIBRARY_LABEL,
+             dependencies=sanitised_dependencies,

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -140,11 +140,14 @@ def stage_1():
         name = "rules_python",
         repo_rule = http_archive,
         patch_args = ["-p1"],
-        patches = ["@enkit//bazel/dependencies/rules_python:downgrade_setuptools.patch"],
-        sha256 = "29a801171f7ca190c543406f9894abf2d483c206e14d6acbd695623662320097",
-        strip_prefix = "rules_python-0.18.1",
+        patches = [
+            "@enkit//bazel/dependencies/rules_python:downgrade_setuptools.patch",
+            "@enkit//bazel/dependencies/rules_python:custom_annotations.patch",
+        ],
+        sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
+        strip_prefix = "rules_python-0.24.0",
         urls = [
-            "https://github.com/bazelbuild/rules_python/releases/download/0.18.1/rules_python-0.18.1.tar.gz",
+            "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
         ],
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,28 +7,28 @@
 absl-py==1.4.0 \
     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47 \
     --hash=sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d
-    # via -r ./requirements.in
+    # via -r requirements.in
 attrs==22.2.0 \
     --hash=sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836 \
     --hash=sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   jsonschema
 click==8.1.3 \
     --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
     --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   click-logging
 click-logging==1.0.1 \
     --hash=sha256:1c3b2835ad4834df7c42e47ac7591866535af499dded3a84403f14411c5041a8 \
     --hash=sha256:3ce04f9fa93120343f5d727108f2066b59bd9c5aac2d770a02f37c69186dbf23
-    # via -r ./requirements.in
+    # via -r requirements.in
 importlib-metadata==4.11.3 \
     --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat
 importlib-resources==5.7.1 \
     --hash=sha256:b6062987dfc51f0fcb809187cffbd60f35df7acb4589091f154214af6d0d49d3 \
@@ -38,27 +38,27 @@ jinja2==3.1.1 \
     --hash=sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119 \
     --hash=sha256:640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   jinja2-strcase
 jinja2-strcase==0.0.2 \
     --hash=sha256:d90c37f7bd40d345aacc8f78b087f66e6c5aa4c968ab23a791573fcf756c3379 \
     --hash=sha256:e3067062f6158cd836ab495f805fc0d1d83cf92049e180509b004db86f6b745c
-    # via -r ./requirements.in
+    # via -r requirements.in
 jsonschema==4.4.0 \
     --hash=sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83 \
     --hash=sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823
-    # via -r ./requirements.in
+    # via -r requirements.in
 linkify-it-py==1.0.3 \
     --hash=sha256:11e29f00150cddaa8f434153f103c14716e7e097a8fd372d9eb1ed06ed91524d \
     --hash=sha256:2b3f168d5ce75e3a425e34b341a6b73e116b5d9ed8dbbbf5dc7456843b7ce2ee
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   markdown-it-py
 markdown-it-py[linkify]==2.1.0 \
     --hash=sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27 \
     --hash=sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat
     #   mdformat-gfm
     #   mdit-py-plugins
@@ -104,36 +104,36 @@ markupsafe==2.1.1 \
     --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
     --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   jinja2
 mdformat==0.7.14 \
     --hash=sha256:530eabe496726bd5f4dec5635c37c2496f4c8abc4c15fafa606919b48d92a9d9 \
     --hash=sha256:60c457955f795e5a030e24bc96be30a29eee7836ba98b32e02581688da7670c5
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat-gfm
     #   mdformat-tables
 mdformat-gfm==0.3.5 \
     --hash=sha256:1e627edc7665b59e008b3b9e5decc18c40cbd625c196d77e5ea3bc624e80ac8a \
     --hash=sha256:5ee5f0de1d3b56d5edfced023bfff0aeed958be328e5460dac3221ac1b61ce7c
-    # via -r ./requirements.in
+    # via -r requirements.in
 mdformat-tables==0.4.1 \
     --hash=sha256:3024e88e9d29d7b8bb07fd6b59c9d5dcf14d2060122be29e30e72d27b65d7da9 \
     --hash=sha256:981f3dc7350027f78e3fd6a5fe8a16e123eec423af2d140e588d855751501019
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat-gfm
 mdit-py-plugins==0.3.0 \
     --hash=sha256:b1279701cee2dbf50e188d3da5f51fee8d78d038cdf99be57c6b9d1aa93b4073 \
     --hash=sha256:ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat-gfm
 mdurl==0.1.1 \
     --hash=sha256:6a8f6804087b7128040b2fb2ebe242bdc2affaeaa034d5fc9feeed30b443651b \
     --hash=sha256:f79c9709944df218a4cdb0fcc0b0c7ead2f44594e3e84dc566606f04ad749c20
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   markdown-it-py
 pyrsistent==0.18.1 \
     --hash=sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c \
@@ -158,7 +158,7 @@ pyrsistent==0.18.1 \
     --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
     --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   jsonschema
 pyyaml==6.0 \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
@@ -201,27 +201,27 @@ pyyaml==6.0 \
     --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
-    # via -r ./requirements.in
+    # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-    # via -r ./requirements.in
+    # via -r requirements.in
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   mdformat
 uc-micro-py==1.0.1 \
     --hash=sha256:316cfb8b6862a0f1d03540f0ae6e7b033ff1fa0ddbe60c12cbe0d4cec846a69f \
     --hash=sha256:b7cdf4ea79433043ddfe2c82210208f26f7962c0cfbe3bacb05ee879a7fdb596
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   linkify-it-py
 zipp==3.8.0 \
     --hash=sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad \
     --hash=sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099
     # via
-    #   -r ./requirements.in
+    #   -r requirements.in
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
This change:

* updates `rules_python` to the latest released version (which is just generally a good thing to do, as it reduces tech debt)
* adds a patch that allows for specific packages to be patched to avoid circular dependencies

The patch comes from
https://github.com/bazelbuild/rules_python/pull/1166#issuecomment-1641878169 and is necessary as airflow has made multiple of their packages dependent on each other on purpose for reasons that are unlikely to be walked back on. This is apparently valid in pip-land, but of course not valid in bazel. The patch is a nice medium-term workaround while the community figures out exactly how this should be handled.

Tested:
* `bazel test //...` in this repo (needed to regenerate `requirements.in`)
* affected-targets detection in internal to verify that this does solve the apache-airflow circular deps issue causing the tool to break

Not tested:
* rules_python update in internal

Jira: INFRA-7317