### PR TITLE
rules_pkg: Update to latest release

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -91,10 +91,10 @@ def stage_1():
         name = "rules_pkg",
         repo_rule = http_archive,
         urls = [
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
         ],
-        sha256 = "62eeb544ff1ef41d786e329e1536c1d541bb9bcad27ae984d57f18f314018e66",
+        sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
     )
 
     maybe(


### PR DESCRIPTION
This change updates rules_pkg to the latest release to pick up new packaging rules.

Tested: `bazel test //...` in this repo