### PR TITLE
enkit_credential_helper: Respect ENKIT_OVERRIDE_TOKEN env var

### DIFF
--- a/bazel/enkit_credential_helper/main.go
+++ b/bazel/enkit_credential_helper/main.go
@@ -71,13 +71,22 @@ func credsCheck(ctx context.Context, creds *Credentials, testURL string) error {
 	return nil
 }
 
-func fetchCreds() (*Credentials, error) {
+func readToken() (string, error) {
+	if token, ok := os.LookupEnv("ENKIT_OVERRIDE_TOKEN"); ok {
+		return token, nil
+	}
+
 	store, err := identity.NewStore("enkit", defcon.Open)
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("failed to open identity store %q: %w", "enkit", err)
 	}
 
 	_, token, err := store.Load("")
+	return token, err
+}
+
+func fetchCreds() (*Credentials, error) {
+	token, err := readToken()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change modifies `enkit_credential_helper` so that if `ENKIT_OVERRIDE_TOKEN` is set, that value is used instead of opening the token from an on-disk storage. This will fix integration issues with environments that provide this token via secrets-backed environment variables.

Tested:
* `bazel run //bazel/enkit_credential_helper -- get` (normal behavior)
* `ENKIT_OVERRIDE_TOKEN=foo bazel run //bazel/enkit_credential_helper -- get` (override behavior)