### PR TITLE
codegen: add a 'deps' attribute to the rule

### DIFF
--- a/tools/codegen/codegen.bzl
+++ b/tools/codegen/codegen.bzl
@@ -16,7 +16,7 @@ def _codegen_impl(ctx):
         args.add("--override", kvpair)
 
     ctx.actions.run(
-        inputs = ctx.files.data + ctx.files.srcs + ctx.files.schema,
+        inputs = ctx.files.data + ctx.files.srcs + ctx.files.schema + ctx.files.deps,
         outputs = ctx.outputs.outs,
         executable = ctx.executable.codegen_tool,
         arguments = [args],
@@ -43,6 +43,10 @@ codegen = rule(
         "srcs": attr.label_list(
             allow_files = [".jinja2", ".jinja", ".template"],
             doc = "A list of jinja2 template files to import.",
+        ),
+        "deps": attr.label_list(
+            allow_files = [".jinja2", ".jinja", ".template"],
+            doc = "A list of jinja2 template files that 'srcs' depend on.",
         ),
         "schema": attr.label(
             allow_files = [".schema", "schema.yaml"],


### PR DESCRIPTION
This patch adds a `deps` label_list attribute to the `codegen()` rule.
The files listed in the `deps` are passed as `inputs` to the
implementation's `ctx.action.run()`.

This allows codegen top-level jinja2 templates to import or include
other templates, which is nice for creating re-usable template macro
libraries.