### PR TITLE
gee: workaround gh auth login bug

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -771,7 +771,7 @@ function _gh_authenticate() {
     local TOKEN=""
     read -rp "Paste your github authentication token here: " TOKEN
     _info "Trying to authenticate using your token..."
-    if ! _gh auth login -p ssh -h github.com --with-token <<< "${TOKEN}"; then
+    if ! _gh auth login -p ssh -h github.com --with-token --insecure-storage <<< "${TOKEN}"; then
       _warn "\"gh auth login\" failed with exit code $?" ""
       echo ""
     fi
@@ -3920,7 +3920,7 @@ EndOfPrTemplate
 
     # Remove all comments from the description and squeeze multiple blank
     # lines into single blank lines:
-    sed 's/^ *#.*//;/\S/,/^\s*$/!d' "${BODYFILE}" > "${TRIMMED}"
+    sed -E 's/^#.*//;/\S/,/^\s*$/!d' "${BODYFILE}" > "${TRIMMED}"
 
     if grep --quiet -E "^\s*ABORT" "${TRIMMED}"; then
       _fatal "Aborting creation of new PR, as requested."
@@ -3961,6 +3961,7 @@ EndOfPrTemplate
 
   local DRAFT=0
   if grep --quiet -E "^\s*DRAFT" "${TRIMMED}"; then
+    sed -i '/^\s*DRAFT/d' "${TRIMMED}"
     DRAFT=1
     PR_ARGS+=( --draft )
   fi


### PR DESCRIPTION
Our containers lack a dbus subsystem, which causes the gh tool to misbehave
and spawn hundreds of dbus-launcher tasks.  The suggested fix from the
maintainers is to use the --insecure_storage option when calling gh auth login.

Additionally fixed a couple of unrelated pet peeves:
  * Draft PR descriptions will no longer have the word DRAFT embedded in them.
  * #-comments in code snippets won't be stripped (only lines starting with #
    will be trimmed).

Tested: tbd

