### PR TITLE
buildbuddy: Add python proto gen rules

### DIFF
--- a/third_party/buildbuddy/proto/BUILD.bazel
+++ b/third_party/buildbuddy/proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -64,5 +65,49 @@ go_proto_library(
     deps = [
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_go_proto",
         "//third_party/bazel/src/main/protobuf:proto",
+    ],
+)
+
+# Python proto rules below here
+
+py_proto_library(
+    name = "acl_py_proto",
+    srcs = ["acl.proto"],
+    deps = [
+        ":user_id_py_proto",
+    ],
+)
+
+py_proto_library(
+    name = "cache_py_proto",
+    srcs = [
+        "cache.proto",
+    ],
+)
+
+py_proto_library(
+    name = "invocation_py_proto",
+    srcs = ["invocation.proto"],
+    deps = [
+        ":acl_py_proto",
+        ":cache_py_proto",
+        ":context_py_proto",
+        "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_py_proto",
+        "//third_party/bazel/src/main/protobuf:command_line_py_proto",
+        "//third_party/bazel/src/main/protobuf:option_filters_py_proto",
+        "@com_google_protobuf//:protobuf_python",
+    ],
+)
+
+py_proto_library(
+    name = "user_id_py_proto",
+    srcs = ["user_id.proto"],
+)
+
+py_proto_library(
+    name = "context_py_proto",
+    srcs = ["context.proto"],
+    deps = [
+        ":user_id_py_proto",
     ],
 )


### PR DESCRIPTION
This change adds rules to generate Python stubs for Buildbuddy API protos.