### PR TITLE
postsubmits: Add a container_image field to spec

### DIFF
--- a/infra/postsubmit/proto/postsubmit.proto
+++ b/infra/postsubmit/proto/postsubmit.proto
@@ -71,4 +71,9 @@ message Build {
   // buildbarn instance, but can be changed in order to target a non-prod
   // instance.
   string rbe_instance = 12;
+
+  // Docker image in which each step is performed. If not set, a default
+  // auto-updated version is used. This allows for testing specific images in
+  // some builds before deploying them more widely.
+  string container_image = 13;
 }


### PR DESCRIPTION
This change adds a field so that the container image + version can be manually overridden in postsubmit definitions.

This will help us test an image in a specific postsubmit before pushing it to all postsubmits.

Tested: N/A

Jira: INFRA-7115