### PR TITLE
gee: remove "--insecure-storage" from gh auth command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -771,7 +771,8 @@ function _gh_authenticate() {
     local TOKEN=""
     read -rp "Paste your github authentication token here: " TOKEN
     _info "Trying to authenticate using your token..."
-    if ! _gh auth login -p ssh -h github.com --with-token --insecure-storage <<< "${TOKEN}"; then
+    # Note: the auth --insecure-storage flag is not supported on all versions of gh.
+    if ! _gh auth login -p ssh -h github.com --with-token <<< "${TOKEN}"; then
       _warn "\"gh auth login\" failed with exit code $?" ""
       echo ""
     fi


### PR DESCRIPTION
Even though this is the correct workaround for gh's dbus-launcher bug,
it turns out that the `--insecure-storage` flag is not supported on
every version of gh.  Rather than force every user to upgrade, I'm just
removing the flag.  I haven't seen many reports of the dbug-launcher
issue lately anyway, maybe github got around to fixing it after all.

Tested:

