### PR TITLE
bes_publisher: Propagate `aborted` events

### DIFF
--- a/bes_publisher/buildevent/service.go
+++ b/bes_publisher/buildevent/service.go
@@ -322,6 +322,19 @@ func (b *buildStream) maybePublish(event *bes.BuildEvent) error {
 		} else {
 			metricUnknownTargetType.WithLabelValues("unmatched_test_result").Inc()
 		}
+
+	case *bes.BuildEvent_Aborted:
+		// Look up the type of this target (see above handling in Completed) and
+		// stuff this as an attr for just this message.
+		eventID := event.GetId().GetTestSummary()
+		k := targetKey(eventID.GetLabel(), eventID.GetConfiguration().GetId())
+		targetType, ok := b.typeFromLabelAndConfiguration[k]
+		if ok {
+			extraAttrs["rule_type"] = targetType
+		} else {
+			metricUnknownTargetType.WithLabelValues("unmatched_aborted_result").Inc()
+		}
+
 	case *bes.BuildEvent_Finished:
 	case *bes.BuildEvent_BuildMetrics:
 	}


### PR DESCRIPTION
`aborted` events carry info about which tests did not run/finish in a particular invocation. This change ensures these messages are propagated (not all messages from the BES stream are propagated to save on Pubsub costs), so that downstream consumers can use them.

This is necessary to add info to DV dashboards about which regression tests did not finish.

Tested: builds only

Jira: INFRA-7972