### PR TITLE
gee: normalize paths from environment

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -251,6 +251,16 @@ while ! "${PWD_CMD}" >/dev/null; do
   cd ..
 done
 
+# Normalize any paths that we get from the environment.  We perform some regex
+# matches using these paths, and spurious things like extra slashes can trip
+# things up.  "realpath -m" will convert "/foo////bar/bum/" to "/foo/bar/bum".
+if [[ -n "${GEE_DIR}" ]]; then
+  GEE_DIR="$(realpath -m "${GEE_DIR}")"
+fi
+if [[ -n "${GEE_REPO_DIR}" ]]; then
+  GEE_REPO_DIR="$(realpath -m "${GEE_REPO_DIR}")"
+fi
+
 if [[ -z "${REPO}" ]]; then
   # Examine the directory to see if we're in a repo already.
   # Try GEE_DIR if set:

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.44"
+readonly VERSION="0.2.45"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,11 @@
 
 ## Releases
 
+### 0.2.45
+
+* gee: add support for `GEE_DIR` and `GEE_REPO_DIR` environment variables (#974, #977)
+* gee: handle case where "master" and "main" branches both exist (#948)
+
 ### 0.2.43
 
 * gee setup: add support for BeyondCompare. (#945)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.44
+gee version: 0.2.45
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
Ankit found a bug in gee where gee misbehaves if the GEE_DIR environment
variable is set to a path that ends with a "/" instead of a more canonical
path representation.

This PR armors gee against such things by using `realpath -m` to convert all
paths read from the environment into their canonical form.

This PR also updates the official gee version to 0.2.45 in preparation
for a new formal release.

Tested:

Previously, this sequence of commands would fail, and now they succeed:

```
$ export GEE_DIR=/home/jonathan/shared/jonathan
$ gee gcd master
/home/jonathan/shared/jonathan/internal/master

$ export GEE_DIR=/home/jonathan/shared/jonathan/
$ gee gcd master
/home/jonathan/shared/jonathan/internal/master

$ export GEE_DIR=/home///////jonathan/shared/jonathan//.///
$ gee gcd master
/home/jonathan/shared/jonathan/internal/master
```

