### PR TITLE
gee: disable window title when not running in screen or tmux

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5589,10 +5589,12 @@ function __gee_prompt_set_colors() {
 function __gee_prompt_set_window_title() {
   local title="$1"
 
-  local ESC=$'\033'
-  local SLASH=$'\134'
-  # printf "${ESC}k${ESC}${SLASH}${ESC}k%s${ESC}${SLASH}" "$1"
-  printf "\\[\033k%s\033\\\\]" "$1"
+  # if window title is supported...
+  if [[ "${TERM}" == screen* ]] || [[ "${TERM}" == tmux* ]]; then
+    local ESC=$'\033'
+    local SLASH=$'\134'
+    printf "\\[\033k%s\033\\\\]" "$1"
+  fi
 }
 
 function gee_prompt_test_colors() {


### PR DESCRIPTION
priority: low

I didn't realize that the "set window title" escape sequence was specific to
screen/tmux and isn't supported by, say, xterm, causing users of the default
gee prompt to see some extra garbage on their screens.

Tested:

```
$ echo $TERM
screen-256color
$ eval "$(./gee bash_setup)"
$ gcd master
  ( confirmed that window title changed )
$ gcd gee_prompt
  ( confirmed that window title changed )

$ TERM=xterm
$ gcd master
  ( confirmed that window title did not change )
```

