### PR TITLE
gee: reset instead of rebase when restoring a branch

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1447,7 +1447,7 @@ function _local_branch_exists() {
   BRDIR="${GEE_REPO_DIR}/${BRANCH}"
   if ! [[ -d "${BRDIR}" ]]; then
     # try to fix worktree.
-    _git worktree add "${GEE_REPO_DIR}/${BRANCH}"
+    _git worktree add -f "${GEE_REPO_DIR}/${BRANCH}"
     _info "Created ${BRDIR}"
   fi
   _update_branch_to_worktree
@@ -1843,7 +1843,7 @@ function _checkout_or_die() {
   # Do we already have a worktree?
   BRDIR="${GEE_REPO_DIR}/${BRANCH}"
   if ! [[ -d "${BRDIR}" ]]; then
-    _git worktree add "${GEE_REPO_DIR}/${BRANCH}"
+    _git worktree add -f "${GEE_REPO_DIR}/${BRANCH}"
     BRDIR="$(_get_branch_rootdir "${BRANCH}")"
     _info "Created ${BRDIR}"
   fi
@@ -2443,7 +2443,7 @@ function gee__make_branch() {
   fi
   _checkout_or_die "${CURRENT_BRANCH}"
 
-  local -a ARGS=( worktree add "${GEE_REPO_DIR}/${BRNAME}" )
+  local -a ARGS=( worktree add -f "${GEE_REPO_DIR}/${BRNAME}" )
   _git "${ARGS[@]}"
   _info "Created ${GEE_REPO_DIR}/${BRNAME}"
 
@@ -2462,9 +2462,9 @@ function gee__make_branch() {
   # into this branch.
   if _remote_branch_exists origin "${BRNAME}"; then
     _checkout_or_die "${BRNAME}"
-    _git fetch origin "${BRNAME}"
+    _git fetch origin
     local -a COUNTS
-    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${MAIN}...origin/${CURRENT_BRANCH}")
     if [[ "${COUNTS[1]}" -gt 0 ]]; then
       _warn "Remote branch origin/${BRNAME} is ${COUNTS[1]} commit(s) ahead of master." \
             "Do you want to reset your local branch to be the same as origin/${BRNAME}?"

--- a/scripts/gee
+++ b/scripts/gee
@@ -2462,8 +2462,22 @@ function gee__make_branch() {
   # into this branch.
   if _remote_branch_exists origin "${BRNAME}"; then
     _checkout_or_die "${BRNAME}"
-    _git pull --rebase origin "${BRNAME}"
-    _info "Pulled in changes from origin/${BRNAME}"
+    _git fetch origin "${BRNAME}"
+    local -a COUNTS
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+    if [[ "${COUNTS[1]}" -gt 0 ]]; then
+      _warn "Remote branch origin/${BRNAME} is ${COUNTS[1]} commit(s) ahead of master." \
+            "Do you want to reset your local branch to be the same as origin/${BRNAME}?"
+      if _confirm_default_yes "Reset ${BRNAME} to match origin/${BRNAME}?  (Y/n)  "; then
+        _git reset --hard "origin/${BRNAME}"
+      else
+        _warn "Commits from origin/${BRNAME} were not imported." \
+              "You probably want to run \"gee update\" in branch ${BRNAME}."
+      fi
+    else
+      _warn "Remote branch origin/${BRNAME} exists but was not ahead of master." \
+            "No commits were imported from origin/${BRNAME}."
+    fi
   fi
 }
 


### PR DESCRIPTION
When gee creates a new branch, it checks to see if a branch with the same
name exists in origin, and if it exists, it offers to restore the branch
from origin.

old behavior: gee would rebase the origin/branch onto master, which could
have merge conflicts.

new behavior: gee resets the branch to be identical to origin/branch, letting
the user choose when to rebase.

Tested: I used this feature in my build-00 container to restore a branch that
I had previously created from my build-04 container.  Works.

