### PR TITLE
machinist: Compile machinist for windows machines

### DIFF
--- a/machinist/cmd/BUILD.bazel
+++ b/machinist/cmd/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_cross_binary")
+load("//bazel/astore:defs.bzl", "astore_upload")
 
 go_library(
     name = "cmd_lib",
@@ -16,4 +17,32 @@ go_binary(
     name = "cmd",
     embed = [":cmd_lib"],
     visibility = ["//visibility:public"],
+)
+
+# Register windows machines with machinist to make it easier
+# for prometheus to collect metrics
+go_cross_binary(
+    name = "cmd_windows",
+    target = ":cmd",
+    platform = "@io_bazel_rules_go//go/toolchain:windows_amd64",
+)
+
+astore_upload(
+    name = "machinist_linux_push",
+    file = "infra/dev_machine/machinist",
+    tags = [
+        "manual",
+        "no-presubmit",
+    ],
+    targets = [":cmd"],
+)
+
+astore_upload(
+    name = "machinist_windows_push",
+    file = "infra/dev_machine/machinist",
+    tags = [
+        "manual",
+        "no-presubmit",
+    ],
+    targets = [":cmd_windows"],
 )


### PR DESCRIPTION
This change compiles machinist for windows so that the hostname and IP address of windows machines can be ingested by prometheus.


Tested:
- Windows machine dashboard: https://monitoring.corp.enfabrica.net/d/IV0hu1m7z/windows-machine-statistics?orgId=1
- Installed machinist on the windows machine
```
bbhuynh@rosaparks:/opt/prometheus$ curl http://127.0.0.1:4456/metrics_targets | python3 -m json.tool
...
    {
        "labels": {
            "hostname": "intelbs-02"
        },
        "targets": [
            "10.10.255.10"
        ]
    },
    {
        "labels": {
            "hostname": "intelbs-01"
        },
        "targets": [
            "10.10.255.17"
        ]
    },
    {
        "labels": {
            "hostname": "mtv-lab"
        },
        "targets": [
            "10.10.255.8"
        ]
    },
    {
        "labels": {
            "hostname": "windows-00"
        },
        "targets": [
            "10.10.255.8"
        ]
    }
]
```

JIRA: INFRA-8348