### PR TITLE
gee: add bisect command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4922,9 +4922,10 @@ a commit that causes the provided command to transition from a success
 to a failure.  During this process, gee will create a special branch
 named `bisect_<branchname>` to perform the bisect operation in.
 
-gee will scan backwards in time until it finds a commit for which the
-provided command passes, and then will use `git bisect` to attempt to
-determine which commit causes the provided command to start to fail.
+gee will attempt to find a previous last good commit by testing a day, a
+week, a month, 3 months, and finally six months into the past.  Once
+a past good commit is found, the `git bisect` command will be used to
+identify the commit that caused a transition from a pass to a fail.
 
 gee assumes that the provided command will fail at the head revision.
 If this is not the case, the behavior of this command is undefined.

--- a/scripts/gee
+++ b/scripts/gee
@@ -4937,7 +4937,10 @@ function gee__bisect() {
   CMD=( "$@" )
   local CUR_BRANCH BISECT_BRANCH
   CUR_BRANCH="$(_get_current_branch)"
-  BISECT_BRANCH="BISECT_${CUR_BRANCH}"
+  BISECT_BRANCH="BISECT_${CUR_BRANCH}_$$"
+  if _local_branch_exists "${BISECT_BRANCH}"; then
+    _fatal "Branch ${BISECT_BRANCH} already exists, cannot create it."
+  fi
   gee__mkbr "${BISECT_BRANCH}"
   _checkout_or_die "${BISECT_BRANCH}"
   _git reset --hard "${CUR_BRANCH}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly VERSION="0.2.45"
+readonly VERSION="0.2.46"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -4911,6 +4911,64 @@ function gee__bazelgc() {
 }
 
 ##########################################################################
+# bisect command
+##########################################################################
+
+_register_help "bisect" "Find a commit that caused a command to fail." <<'EOT'
+Usage: gee bisect [command...]
+
+This command wraps the `git bisect` command, and attempts to discover
+a commit that causes the provided command to transition from a success
+to a failure.  During this process, gee will create a special branch
+named `bisect_<branchname>` to perform the bisect operation in.
+
+gee will scan backwards in time until it finds a commit for which the
+provided command passes, and then will use `git bisect` to attempt to
+determine which commit causes the provided command to start to fail.
+
+gee assumes that the provided command will fail at the head revision.
+If this is not the case, the behavior of this command is undefined.
+
+EOT
+
+function gee__bisect() {
+  local CMD
+  CMD=( "$@" )
+  local CUR_BRANCH BISECT_BRANCH
+  CUR_BRANCH="$(_get_current_branch)"
+  BISECT_BRANCH="BISECT_${CUR_BRANCH}"
+  gee__mkbr "${BISECT_BRANCH}"
+  _checkout_or_die "${BISECT_BRANCH}"
+  _git reset --hard "${CUR_BRANCH}"
+  _git bisect start
+  _git bisect bad
+
+  local WHEN WHAT LAST_GOOD
+  LAST_GOOD=""
+  for WHEN in "yesterday" "last week" "last month" "3 months ago" "6 months ago"; do
+    WHAT="$(git log --since="${WHEN}" --pretty=format:%H | tail -1)"
+    _info "Checking commit from ${WHEN}: ${WHAT}"
+    _git checkout "${WHAT}"
+    if ( "${CMD[@]}" ); then
+      LAST_GOOD="${WHAT}"
+      _info "... passed: ${WHAT}"
+      _git bisect good
+      break
+    else
+      _info "... failed: ${WHAT}"
+    fi
+  done
+  if [[ -z "${LAST_GOOD}" ]]; then
+    _die "Could not find a commit within the past 6 months that passes."
+  fi
+  _git bisect run "${CMD[@]}"
+  _git checkout HEAD
+  _checkout_or_die "${CUR_BRANCH}"
+  gee__rmbr "${BISECT_BRANCH}"
+  return 0
+}
+
+##########################################################################
 # diagnose command
 ##########################################################################
 

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,13 @@
 
 ## Releases
 
+### 0.2.46
+
+* gee bisect: a helpful utility for wrapping "git bisect" (#985).
+* gee mkbr: Use reset when restoring a branch from origin instead of rebase (#983).
+* gee: explicitly specify gcloud project when querying presubmit results (#981).
+* gee bash_setup: disable window title control sequence if not running screen/tmux (#980).
+
 ### 0.2.45
 
 * gee: add support for `GEE_DIR` and `GEE_REPO_DIR` environment variables (#974, #977)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.45
+gee version: 0.2.46
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful
@@ -145,6 +145,7 @@ prompt that `gee bash_setup` makes available.
 | ------- | ------- |
 | <a href="#bash_setup">`bash_setup`</a> | Configure the bash environment for gee. |
 | <a href="#bazelgc">`bazelgc`</a> | Garbage collect your bazel cache. |
+| <a href="#bisect">`bisect`</a> | Find a commit that caused a command to fail. |
 | <a href="#cleanup">`cleanup`</a> | Automatically remove branches without local changes. |
 | <a href="#codeowners">`codeowners`</a> | Provide detailed information about required approvals for this PR. |
 | <a href="#commit">`commit`</a> | Commit all changes in this branch |
@@ -744,6 +745,23 @@ Usage: `gee bazelgc`
 
 Identifies a set of bazel cache directories that are no longer associated with
 any worktree (branch) that gee knows about, and offers to delete them.
+
+### bisect
+
+Usage: `gee bisect [command...]`
+
+This command wraps the `git bisect` command, and attempts to discover
+a commit that causes the provided command to transition from a success
+to a failure.  During this process, gee will create a special branch
+named `bisect_<branchname>` to perform the bisect operation in.
+
+gee will attempt to find a previous last good commit by testing a day, a
+week, a month, 3 months, and finally six months into the past.  Once
+a past good commit is found, the `git bisect` command will be used to
+identify the commit that caused a transition from a pass to a fail.
+
+gee assumes that the provided command will fail at the head revision.
+If this is not the case, the behavior of this command is undefined.
 
 ### diagnose
 


### PR DESCRIPTION
gee's bisect command is a wrapper around `git bisect` but automates the
process somewhat:
  1. a temporary branch is created for use during bisection, so the
     user's main branch is never changed.
  2. a heuristic is used to try to find a previous good commit at some
     point in the past.
  3. after finding the suspect commit, the tool cleans up after itself
     and removes the temporary branch.

Tested: Used to find a suspect commit in a branch I'm debugging.

