### PR TITLE
go: Update version to 1.21

### DIFF
--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -56,14 +56,14 @@ def stage_2():
     # `--@io_bazel_rules_go//go/toolchain:sdk_version=` flag to bazel. The
     # default seems to be whichever go_download_sdk rule is listed first here.
     go_download_sdk(
-        name = "go_sdk_1_20",
-        version = "1.20.3",
+        name = "go_sdk_1_21",
+        version = "1.21.4",
     )
 
     go_rules_dependencies()
     go_register_toolchains()
 
-    gazelle_dependencies(go_sdk = "go_sdk_1_20")
+    gazelle_dependencies(go_sdk = "go_sdk_1_21")
     go_embed_data_dependencies()
 
     rules_proto_dependencies()


### PR DESCRIPTION
This change updates the Golang toolchain used to the latest release, to fix the build for new third-party dependencies that will be added in a future change.

Tested: `bazel test //...` seems to be equivalently clean