### PR TITLE
device plugin: Implement `Reserve`

### DIFF
--- a/experimental/nomad_resource_plugin/licensedevice/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/BUILD.bazel
@@ -31,8 +31,10 @@ go_test(
     embed = [":licensedevice"],
     deps = [
         "//experimental/nomad_resource_plugin/licensedevice/types",
+        "//lib/str",
         "@com_github_hashicorp_nomad//plugins/device",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//mock",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/experimental/nomad_resource_plugin/licensedevice/mock_test.go
+++ b/experimental/nomad_resource_plugin/licensedevice/mock_test.go
@@ -26,9 +26,9 @@ type mockReserver struct {
 	mock.Mock
 }
 
-func (m *mockReserver) Reserve(ctx context.Context, licenseID string, node string, user string) error {
-	args := m.Called(ctx, licenseID, node, user)
-	return args.Error(0)
+func (m *mockReserver) Reserve(ctx context.Context, licenseIDs []string, node string) ([]*types.License, error) {
+	args := m.Called(ctx, licenseIDs, node)
+	return args.Get(0).([]*types.License), args.Error(1)
 }
 
 func (m *mockReserver) Use(ctx context.Context, licenseID string, node string, user string) error {

--- a/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
+++ b/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
@@ -17,8 +17,8 @@ func (t *Table) GetCurrent(ctx context.Context) ([]*types.License, error) {
 	return nil, fmt.Errorf("GetCurrent unimplemented")
 }
 
-func (t *Table) Reserve(ctx context.Context, licenseID string, node string, user string) error {
-	return fmt.Errorf("Reserve unimplemented")
+func (t *Table) Reserve(ctx context.Context, licenseIDs []string, node string) ([]*types.License, error) {
+	return nil, fmt.Errorf("Reserve unimplemented")
 }
 
 func (t *Table) Use(ctx context.Context, licenseID string, node string, user string) error {

--- a/experimental/nomad_resource_plugin/licensedevice/types/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/types/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["types.go"],
     importpath = "github.com/enfabrica/enkit/experimental/nomad_resource_plugin/licensedevice/types",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_hashicorp_nomad//plugins/device"],
 )
 
 alias(

--- a/experimental/nomad_resource_plugin/licensedevice/types/types.go
+++ b/experimental/nomad_resource_plugin/licensedevice/types/types.go
@@ -2,7 +2,10 @@ package types
 
 import (
 	"context"
+	"path/filepath"
 	"time"
+
+	"github.com/hashicorp/nomad/plugins/device"
 )
 
 type License struct {
@@ -34,8 +37,16 @@ type License struct {
 	UserProcess *string
 }
 
+func (l *License) MountInfo(root string) *device.Mount {
+	return &device.Mount{
+		HostPath: filepath.Join(root, l.Vendor, l.Feature, l.ID),
+		TaskPath: filepath.Join("/tmp/license_handles", l.Vendor, l.Feature, l.ID),
+		ReadOnly: true,
+	}
+}
+
 type Reserver interface {
-	Reserve(ctx context.Context, licenseID string, node string, user string) error
+	Reserve(ctx context.Context, licenseIDs []string, node string) ([]*License, error)
 
 	Use(ctx context.Context, licenseID string, node string, user string) error
 


### PR DESCRIPTION
This change implements the `Reserve` method in terms of the interfaces:

* calling `Reserve` will attempt to lock specific license instances in
  the DB
* upon success, the information on which license handle files to mount
  into the task are returned

Tested: added basic unit test
