### PR TITLE
gee: add GEE_ENABLE_PRESUBMIT_CANCEL feature

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -135,9 +135,10 @@ review.
 * `VERBOSE`: If set to a non-zero integer, will cause additional debug information to be logged.
   For developer use only.
 
-* `GEE_ENABLE_KILL`: If set to any value other than 0, will cause gee to cancel
-  any running presubmit job when pushing a change to remote branch with an open
-  PR.  This is currently an experimental feature that is disabled by default.
+* `GEE_ENABLE_PRESUBMIT_CANCEL`: If set to any value other than 0, will cause
+  gee to cancel any running presubmit job when pushing a change to remote
+  branch with an open PR.  This is currently an experimental feature that is
+  disabled by default.
 
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
@@ -249,7 +250,7 @@ readonly PR_LIST_MAX_FETCH=300
 readonly YESYESYES="${YESYESYES:-0}"  # for testing: disables all interactivity.
 GHUSER="${GHUSER:-}"  # can be set by _startup_checks
 VERBOSE="${VERBOSE:-1}"
-GEE_ENABLE_KILL="${GEE_ENABLE_KILL:-0}"
+GEE_ENABLE_PRESUBMIT_CANCEL="${GEE_ENABLE_PRESUBMIT_CANCEL:-0}"
 DRYRUN="${DRYRUN:-0}"
 UPSTREAM="${UPSTREAM:-enfabrica}"
 TESTMODE="${TESTMODE:-0}"
@@ -3467,10 +3468,10 @@ pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
 
-If the experimental GEE_ENABLE_KILL feature is enabled, then gee will check
-to see if pushing the current commit will invalidate a presubmit job in the
-`pending` state.  If this is the case, gee will kill the previous presubmit
-before pushing the changes and thus kicking off the new presubmit.
+If the experimental GEE_ENABLE_PRESUBMIT_CANCEL feature is enabled, then gee
+will check to see if pushing the current commit will invalidate a presubmit job
+in the `pending` state.  If this is the case, gee will kill the previous
+presubmit before pushing the changes and thus kicking off the new presubmit.
 
 Example:
 
@@ -3521,7 +3522,7 @@ function gee__commit() {
         fi
       fi
     fi
-    if [[ "${GEE_ENABLE_KILL}" != "0" ]]; then
+    if [[ "${GEE_ENABLE_PRESUBMIT_CANCEL}" != "0" ]]; then
       if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
         # kill running presubmit job, if any exists:
         _cancel_pending_presubmit

--- a/scripts/gee
+++ b/scripts/gee
@@ -3467,6 +3467,11 @@ pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
 
+If the experimental GEE_ENABLE_KILL feature is enabled, then gee will check
+to see if pushing the current commit will invalidate a presubmit job in the
+`pending` state.  If this is the case, gee will kill the previous presubmit
+before pushing the changes and thus kicking off the new presubmit.
+
 Example:
 
     gee commit -m "Added \"gee commit\" command."

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2034
+# (due to https://github.com/koalaman/shellcheck/issues/817)
 
 readonly VERSION="0.2.46"
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -135,6 +135,10 @@ review.
 * `VERBOSE`: If set to a non-zero integer, will cause additional debug information to be logged.
   For developer use only.
 
+* `GEE_ENABLE_KILL`: If set to any value other than 0, will cause gee to cancel
+  any running presubmit job when pushing a change to remote branch with an open
+  PR.  This is currently an experimental feature that is disabled by default.
+
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
 
@@ -245,6 +249,7 @@ readonly PR_LIST_MAX_FETCH=300
 readonly YESYESYES="${YESYESYES:-0}"  # for testing: disables all interactivity.
 GHUSER="${GHUSER:-}"  # can be set by _startup_checks
 VERBOSE="${VERBOSE:-1}"
+GEE_ENABLE_KILL="${GEE_ENABLE_KILL:-0}"
 DRYRUN="${DRYRUN:-0}"
 UPSTREAM="${UPSTREAM:-enfabrica}"
 TESTMODE="${TESTMODE:-0}"
@@ -3511,6 +3516,12 @@ function gee__commit() {
         fi
       fi
     fi
+    if [[ "${GEE_ENABLE_KILL}" != "0" ]]; then
+      if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
+        # kill running presubmit job, if any exists:
+        _cancel_pending_presubmit
+      fi
+    fi
     # We always push upstream so that users have a backup in case they lose their
     # laptop:
     _push_to_origin "${CURRENT_BRANCH}"
@@ -4107,8 +4118,68 @@ this command will continue to report check status until all pending
 checks have completed.
 EOT
 
+function _get_presubmit_info() {
+  # Returns the status, gcloud id, and gcloud project of any running presubmit.
+  local -n S=$1  # first argument is a variable to assign to.
+  local -n I=$2
+  local -n P=$3
+  S="unknown"
+  I="unknown"
+  P="unknown"
+  local LINE
+  local -a FIELDS=()
+  while read -r -a FIELDS; do
+    if [[ "${FIELDS[0]}" == "internal-bazel-presubmit" ]]; then
+      S="${FIELDS[2]}"
+      if [[ "${FIELDS[4]}" =~ builds/([a-f0-9-]*)\?project= ]]; then
+        I="${BASH_REMATCH[1]}"
+      else
+        _warn "Could not parse build number from URL: ${FIELDS[4]}"
+        S=unknown
+      fi
+      if [[ "${FIELDS[1]}" =~ \((.+)\) ]]; then
+        P="${BASH_REMATCH[1]}"
+      else
+        _warn "Could not parse project name from ${FIELDS[1]}"
+        S=unknown
+      fi
+    fi
+  done < <(${GH} pr checks)
+  return 0
+}
+
+function _gh_builds_cancel() {
+  local ID="$1"
+  local PROJECT="$2"
+  _cmd gcloud builds cancel "${ID}" --project "${PROJECT}" >/dev/null
+}
+
+function _cancel_pending_presubmit() {
+  local STATUS ID PROJECT
+  _get_presubmit_info STATUS ID PROJECT
+  if [[ "${STATUS}" == "pending" ]]; then
+    _info "Killing previous pending presubmit job ${ID}."
+    _gh_builds_cancel "${ID}" "${PROJECT}"
+  fi
+}
+
+function _push_will_trigger_presubmit() {
+  local BR="$1"
+  local LOCALHEAD ORIGINHEAD
+  if ! _remote_branch_exists origin "${BR}"; then
+    return 0  # true
+  fi
+  LOCALHEAD="$(git rev-parse "${BR}")"
+  ORIGINHEAD="$(git rev-parse "origin/${BR}")"
+  if [[ "${LOCALHEAD}" == "${ORIGINHEAD}" ]]; then
+    return 1  # false
+  else
+    return 0  # true
+  fi
+}
+
 function _parse_gh_pr_checks() {
-  # Usage: _parse_gh__pr_checks COUNTS BUILDS "${LINES[@]}"
+  # Usage: _parse_gh_pr_checks COUNTS BUILDS "${LINES[@]}"
   # where:
   #   COUNTS is the name of the associative array to populate with counts of each result type.
   #   BUILDS is the name of the array to populate with the build identifiers of failed tests.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -140,6 +140,10 @@ review.
 * `VERBOSE`: If set to a non-zero integer, will cause additional debug information to be logged.
   For developer use only.
 
+* `GEE_ENABLE_KILL`: If set to any value other than 0, will cause gee to cancel
+  any running presubmit job when pushing a change to remote branch with an open
+  PR.  This is currently an experimental feature that is disabled by default.
+
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
 
@@ -481,6 +485,11 @@ Note that if you are working in a PR-associated branch created with `gee
 pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
+
+If the experimental GEE_ENABLE_KILL feature is enabled, then gee will check
+to see if pushing the current commit will invalidate a presubmit job in the
+`pending` state.  If this is the case, gee will kill the previous presubmit
+before pushing the changes and thus kicking off the new presubmit.
 
 Example:
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -140,9 +140,10 @@ review.
 * `VERBOSE`: If set to a non-zero integer, will cause additional debug information to be logged.
   For developer use only.
 
-* `GEE_ENABLE_KILL`: If set to any value other than 0, will cause gee to cancel
-  any running presubmit job when pushing a change to remote branch with an open
-  PR.  This is currently an experimental feature that is disabled by default.
+* `GEE_ENABLE_PRESUBMIT_CANCEL`: If set to any value other than 0, will cause
+  gee to cancel any running presubmit job when pushing a change to remote
+  branch with an open PR.  This is currently an experimental feature that is
+  disabled by default.
 
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
@@ -486,10 +487,10 @@ pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
 
-If the experimental GEE_ENABLE_KILL feature is enabled, then gee will check
-to see if pushing the current commit will invalidate a presubmit job in the
-`pending` state.  If this is the case, gee will kill the previous presubmit
-before pushing the changes and thus kicking off the new presubmit.
+If the experimental GEE_ENABLE_PRESUBMIT_CANCEL feature is enabled, then gee
+will check to see if pushing the current commit will invalidate a presubmit job
+in the `pending` state.  If this is the case, gee will kill the previous
+presubmit before pushing the changes and thus kicking off the new presubmit.
 
 Example:
 


### PR DESCRIPTION
Setting `GEE_ENABLE_PRESUBMIT_CANCEL=1`` in the environment enables an
experimental gee feature that causes gee to kill a running presubmit job just
before pushing a change into a PR that modifies origin/branch (ie. an operation
that normally triggers a new presubmit job to start).

Tested: Manually tested.

* No effect when running `gee commit` in a branch without a PR.
* No effect when running `gee commit` in a branch with a PR but no outstanding changes.
* Successfully kills the gcloud job when running `gee commit` in a branch with a PR and
with outstanding changes.

