### PR TITLE
lib: Add `heapdump` library

### DIFF
--- a/lib/heapdump/BUILD.bazel
+++ b/lib/heapdump/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "heapdump",
+    srcs = ["heapdump.go"],
+    importpath = "github.com/enfabrica/enkit/lib/heapdump",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":heapdump",
+    visibility = ["//visibility:public"],
+)

--- a/lib/heapdump/heapdump.go
+++ b/lib/heapdump/heapdump.go
@@ -1,0 +1,31 @@
+package heapdump
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"time"
+)
+
+var startTime string
+
+func init() {
+	startTime = fmt.Sprintf("%d", time.Now().Unix())
+}
+
+func Write(prefix string, label string) error {
+	dumpDir := filepath.Join(prefix, startTime)
+	dumpFile := filepath.Join(dumpDir, label+".out")
+	if err := os.MkdirAll(dumpDir, 0777); err != nil {
+		return fmt.Errorf("can't make dump dir %q: %w", dumpDir, err)
+	}
+
+	f, err := os.OpenFile(dumpFile, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return fmt.Errorf("can't make dump file %q: %w", dumpFile, err)
+	}
+	defer f.Close()
+
+	return pprof.Lookup("heap").WriteTo(f, 0)
+}


### PR DESCRIPTION
This change adds a thin wrapper around `pprof` to make dumping multiple heap dumps to files easier from our code, in order to aid debugging of memory usage.

Tested: used temporarily; appears to work