### PR TITLE
gee: handle closed PRs that are also drafts

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3953,7 +3953,7 @@ function gee__pr_make() {
   local NUMBER="${pr_vars[0]}"
   local STATE="${pr_vars[1]}"
   local IS_DRAFT="${pr_vars[2]}"
-  local TITLE="${pr_vars[@]:3}"
+  local TITLE="${pr_vars[*]:3}"
 
   if [[ "${STATE}" == "OPEN" ]]; then
     if [[ "${IS_DRAFT}" == "false" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -3949,7 +3949,7 @@ function gee__pr_make() {
 
   local -a pr_vars
   mapfile -t pr_vars < \
-    <("${GH}" pr view --json number,state,isDraft --jq '.number, .state, .isDraft, .title')
+    <("${GH}" pr view --json number,state,isDraft,title --jq '.number, .state, .isDraft, .title')
   local NUMBER="${pr_vars[0]}"
   local STATE="${pr_vars[1]}"
   local IS_DRAFT="${pr_vars[2]}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -3947,22 +3947,28 @@ function gee__pr_make() {
   _info "Destination branch: ${DEST_BRANCH}"
   _info "Merge base: ${MERGE_BASE}"
 
-  local STATE NUMBER TITLE
-  read -r STATE NUMBER TITLE < \
-    <( _get_pull_requests "${CURRENT_BRANCH}" | grep -v ^MERGED || :) \
-    || /bin/true  # don't fail if empty
+  local -a pr_vars
+  mapfile -t pr_vars < \
+    <("${GH}" pr view --json number,state,isDraft --jq '.number, .state, .isDraft, .title')
+  local NUMBER="${pr_vars[0]}"
+  local STATE="${pr_vars[1]}"
+  local IS_DRAFT="${pr_vars[2]}"
+  local TITLE="${pr_vars[@]:3}"
+
   if [[ "${STATE}" == "OPEN" ]]; then
-    _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \
-          "Use \"gee commit\" to update existing PR."
-    _fatal Aborted.
-  elif [[ "${STATE}" == "DRAFT" ]]; then
-    _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
-    if _confirm_default_yes "Do you want to mark this PR as ready for review? (Y/n)  "; then
-      _gh pr ready "${NUMBER}" || echo $?
+    if [[ "${IS_DRAFT}" == "false" ]]; then
+      _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \
+            "Use \"gee commit\" to update existing PR."
       exit 0
     else
-      _info "Leaving PR #${NUMBER} as a draft."
-      exit 0
+      _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
+      if _confirm_default_yes "Do you want to mark this PR as ready for review? (Y/n)  "; then
+        _gh pr ready "${NUMBER}" || echo $?
+        exit 0
+      else
+        _info "Leaving PR #${NUMBER} as a draft."
+        exit 0
+      fi
     fi
   fi
 


### PR DESCRIPTION
User exposed this bug: if a PR is marked as a draft, and then closed, github
labels it as state=CLOSED and isDraft=True.  Gee's old logic confused this
with an open PR with isDraft=True.  This new logic treats state as primary
and isDraft as secondary.

Tested: manual testing

```
  gcd -m testing_gee
  vi gee
  gee commit -a -m "blah blah blah"
  gee pr_make  # a draft PR
  gh pr close
  gee pr_make  # works now.
```
