### PR TITLE
gee bisect: handle absence of commits

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5064,6 +5064,10 @@ function gee__bisect() {
   LAST_GOOD=""
   for WHEN in "yesterday" "last week" "last month" "3 months ago" "6 months ago"; do
     WHAT="$(git log --since="${WHEN}" --pretty=format:%H | tail -1)"
+    if [[ -z "${WHAT}" ]]; then
+      _info "No commits since ${WHEN}."
+      continue
+    fi
     _info "Checking commit from ${WHEN}: ${WHAT}"
     _git checkout "${WHAT}"
     if ( "${CMD[@]}" ); then


### PR DESCRIPTION
I noticed that `gee bisect` fails when searching for commits if any of the `git log --since` operations
returns an empty set (ie. during the holidays).  This PR detects and handles this condition.

Tested: Manualy testing in my local client.

