### PR TITLE
gee: add "--text" option to lspr

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3832,17 +3832,18 @@ function gee__pr_list() {
       if [[ "$isDraft" == "true" ]]; then
         status+="DRAFT "
       fi
-      checks_rc=0
-      if ! gh pr checks "${number}" 2>/dev/null >/dev/null; then
-        checks_rc=$?
-      fi
-      if [[ "$checks_rc" == 0 ]]; then
+      local output checks_rc
+      set +e
+      "${GH}" pr checks "${number}" 2>/dev/null >/dev/null
+      checks_rc="$?"
+      set -e
+      if [[ "$checks_rc" -eq 0 ]]; then
         status+="Checks passed."
-      elif [[ "$checks_rc" == 8 ]]; then
+      elif [[ "$checks_rc" -eq 8 ]]; then
         status+="Checks pending."
-      elif [[ "$checks_rc" == 4 ]]; then
+      elif [[ "$checks_rc" -eq 4 ]]; then
         status+="Checks: auth failure."
-      elif [[ "$checks_rc" == 2 ]]; then
+      elif [[ "$checks_rc" -eq 2 ]]; then
         status+="Checks cancelled."
       else
         status+="CHECKS FAILED."

--- a/scripts/gee
+++ b/scripts/gee
@@ -3733,12 +3733,12 @@ function gee__pr_push() {
 _register_help "pr_list" \
   "List outstanding PRs" \
   "lspr" "list_pr" "prls" <<'EOT'
-Usage: gee pr_list [--email] [<user>]
+Usage: gee pr_list [--text] [<user>]
 
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
 
-The `--email` option provides an alternative formatting for a list of open PRs, more
+The `--text` option provides an alternative formatting for a list of open PRs, more
 suitable for pasting into an email.
 
 Example:
@@ -3759,6 +3759,25 @@ Example:
     PRs pending their review:
     #1200  taoliu0  2021-08-12T15:26:03Z  Added an example integrating SC
 
+An example of using the "--text" option:
+
+    $ /home/jonathan/gee/enkit/gee_lspr_format/scripts/gee lspr --text
+    * #29644: Lorem ipsum dolor sit amet
+      2023-12-30 APPROVED Checks passed.
+      https://github.com/enfabrica/internal/pull/29644
+
+    * #29641: consectetur adipiscing elit
+      2023-12-30 REVIEW_REQUIRED DRAFT Checks passed.
+      https://github.com/enfabrica/internal/pull/29641
+
+    * #29640: sed do eiusmod tempor incididunt
+      2023-12-30 APPROVED Checks passed.
+      https://github.com/enfabrica/internal/pull/29640
+
+    * #29625: ut labore et dolor magna aliqua
+      2023-12-29 REVIEW_REQUIRED Checks passed.
+      https://github.com/enfabrica/internal/pull/29625
+
 EOT
 function gee__lspr() { gee__pr_list "$@"; }
 function gee__list_pr() { gee__pr_list "$@"; }
@@ -3766,9 +3785,9 @@ function gee__prls() { gee__pr_list "$@"; }
 function gee__pr_list() {
   _startup_checks "pr_list"
 
-  EMAIL_FORMAT=0
-  if [[ "$1" == "--email" ]]; then
-    EMAIL_FORMAT=1
+  TEXT_FORMAT=0
+  if [[ "$1" == "--text" ]]; then
+    TEXT_FORMAT=1
     shift
   fi
 
@@ -3785,17 +3804,54 @@ function gee__pr_list() {
     YOUR="their"
   fi
 
-  if [[ "${EMAIL_FORMAT}" == 1 ]]; then
-    local -a lines
-    _gh \
+  if [[ "${TEXT_FORMAT}" == 1 ]]; then
+    local -a lines=()
+    mapfile -t lines < <(gh \
       --repo "${UPSTREAM}/${REPO}" \
       pr list \
       -L "${PR_LIST_MAX_FETCH}" \
       --author "${WHO}" \
       --state open \
       --json number,reviewDecision,mergeable,createdAt,isDraft,title \
-      --jq '.[] | "  https://github.com/enfabrica/internal/pull/\(.number)\n  \(.createdAt) \(.reviewDecision) draft=\(.isDraft)\n* \(.title)\n"' \
-      | tac
+      --jq '.[] | .number, .reviewDecision, .mergeable, .createdAt, .isDraft, .title')
+    local line number reviewDecision mergeable createdAt isDraft title checks_rc status
+    local -a fields=()
+    local II=0
+    local SIZE="${#lines[@]}"
+    # cap output to first 20 PRs.  TODO(jonathan): make this configurable.
+    if [[ "${SIZE}" -gt 120 ]]; then SIZE=120; fi
+    while (( "$II" < "${SIZE}" )); do
+      number="${lines[$(( II + 0 ))]}"
+      reviewDecision="${lines[$(( II + 1 ))]}"
+      mergeable="${lines[$(( II + 2 ))]}"
+      createdAt="${lines[$(( II + 3 ))]}"
+      isDraft="${lines[$(( II + 4 ))]}"
+      title="${lines[$(( II + 5 ))]}"
+      II="$(( II + 6 ))"
+      status=""
+      if [[ "$isDraft" == "true" ]]; then
+        status+="DRAFT "
+      fi
+      checks_rc=0
+      if ! gh pr checks "${number}" 2>/dev/null >/dev/null; then
+        checks_rc=$?
+      fi
+      if [[ "$checks_rc" == 0 ]]; then
+        status+="Checks passed."
+      elif [[ "$checks_rc" == 8 ]]; then
+        status+="Checks pending."
+      elif [[ "$checks_rc" == 4 ]]; then
+        status+="Checks: auth failure."
+      elif [[ "$checks_rc" == 2 ]]; then
+        status+="Checks cancelled."
+      else
+        status+="CHECKS FAILED."
+      fi
+      echo "* #${number}: ${title}"
+      echo "  ${createdAt:0:10} ${reviewDecision} ${status}"
+      echo "  https://github.com/enfabrica/internal/pull/${number}"
+      echo ""
+    done
     return
   fi
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.46"
+readonly VERSION="0.2.47"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3733,10 +3733,13 @@ function gee__pr_push() {
 _register_help "pr_list" \
   "List outstanding PRs" \
   "lspr" "list_pr" "prls" <<'EOT'
-Usage: gee pr_list [<user>]
+Usage: gee pr_list [--email] [<user>]
 
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
+
+The `--email` option provides an alternative formatting for a list of open PRs, more
+suitable for pasting into an email.
 
 Example:
 
@@ -3763,6 +3766,12 @@ function gee__prls() { gee__pr_list "$@"; }
 function gee__pr_list() {
   _startup_checks "pr_list"
 
+  EMAIL_FORMAT=0
+  if [[ "$1" == "--email" ]]; then
+    EMAIL_FORMAT=1
+    shift
+  fi
+
   _check_gh_auth
   local WHO WHO_3RD_PERSON USER YOUR
   WHO="@me"
@@ -3775,6 +3784,21 @@ function gee__pr_list() {
     USER="$1"
     YOUR="their"
   fi
+
+  if [[ "${EMAIL_FORMAT}" == 1 ]]; then
+    local -a lines
+    _gh \
+      --repo "${UPSTREAM}/${REPO}" \
+      pr list \
+      -L "${PR_LIST_MAX_FETCH}" \
+      --author "${WHO}" \
+      --state open \
+      --json number,reviewDecision,mergeable,createdAt,isDraft,title \
+      --jq '.[] | "  https://github.com/enfabrica/internal/pull/\(.number)\n  \(.createdAt) \(.reviewDecision) draft=\(.isDraft)\n* \(.title)\n"' \
+      | tac
+    return
+  fi
+
   if _in_gee_branch; then
     _info "PRs associated with this branch:"
     _get_pull_requests

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,13 @@
 
 ## Releases
 
+### 0.2.47
+
+* gee lspr: add `--text` option (#1009).
+* gee: handle closed PRs that are also marked as drafts (#1008).
+* gee: add `GEE_ENABLE_PRESUBMIT_CANCEL` feature (#1001).
+* gee: allow override of default tool paths (#991).
+
 ### 0.2.46
 
 * gee bisect: a helpful utility for wrapping "git bisect" (#985).

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.46
+gee version: 0.2.47
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -558,10 +558,13 @@ See also:
 
 Aliases: lspr list_pr prls
 
-Usage: `gee pr_list [<user>]`
+Usage: `gee pr_list [--email] [<user>]`
 
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
+
+The `--email` option provides an alternative formatting for a list of open PRs, more
+suitable for pasting into an email.
 
 Example:
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -558,12 +558,12 @@ See also:
 
 Aliases: lspr list_pr prls
 
-Usage: `gee pr_list [--email] [<user>]`
+Usage: `gee pr_list [--text] [<user>]`
 
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
 
-The `--email` option provides an alternative formatting for a list of open PRs, more
+The `--text` option provides an alternative formatting for a list of open PRs, more
 suitable for pasting into an email.
 
 Example:
@@ -583,6 +583,25 @@ Example:
 
     PRs pending their review:
     #1200  taoliu0  2021-08-12T15:26:03Z  Added an example integrating SC
+
+An example of using the "--text" option:
+
+    $ /home/jonathan/gee/enkit/gee_lspr_format/scripts/gee lspr --text
+    * #29644: Lorem ipsum dolor sit amet
+      2023-12-30 APPROVED Checks passed.
+      https://github.com/enfabrica/internal/pull/29644
+
+    * #29641: consectetur adipiscing elit
+      2023-12-30 REVIEW_REQUIRED DRAFT Checks passed.
+      https://github.com/enfabrica/internal/pull/29641
+
+    * #29640: sed do eiusmod tempor incididunt
+      2023-12-30 APPROVED Checks passed.
+      https://github.com/enfabrica/internal/pull/29640
+
+    * #29625: ut labore et dolor magna aliqua
+      2023-12-29 REVIEW_REQUIRED Checks passed.
+      https://github.com/enfabrica/internal/pull/29625
 
 ### pr_edit
 


### PR DESCRIPTION
Sometimes I have a lot of PRs that I need reviews for.  To help my reviewers,
it's useful to generate a list of open PRs in text format, suitable for pasting
into a chat message or email.

This PR adds a "--text" option to "gee lspr" to generate this.  It further
enhances the lspr functionality by reporting presubmit check status to
the report.

Tested:

```
$ ./gee lspr --text
* #1009: gee: add "--text" option to lspr
  2024-01-02 REVIEW_REQUIRED Checks pending.
  https://github.com/enfabrica/internal/pull/1009

* #1005: a test draft PR
  2023-12-18 REVIEW_REQUIRED DRAFT Checks passed.
  https://github.com/enfabrica/internal/pull/1005

* #840: //proxy/ptunnel:go_default_test: tagged no-presubmit
  2023-02-01 REVIEW_REQUIRED Checks passed.
  https://github.com/enfabrica/internal/pull/840

* #378: gee: starting to rewrite in golang
  2021-12-23 REVIEW_REQUIRED CHECKS FAILED.
  https://github.com/enfabrica/internal/pull/378

* #358: gee: explicit paths for enkit
  2021-12-08 REVIEW_REQUIRED CHECKS FAILED.
  https://github.com/enfabrica/internal/pull/358

```
