### PR TITLE
bazel/astore/defs.bzl: make astore_package compatible with http_archive

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -317,6 +317,10 @@ astore_package = repository_rule(
             doc = "Timeout for astore fetch operation, in seconds.",
             default = 10 * 60,
         ),
+        "patch_tool": attr.string(
+            default = "",
+            doc = "The patch utility to use (optional).",
+        ),
         "patch_args": attr.string_list(
             doc = "List of args to pass to patch tool",
         ),


### PR DESCRIPTION
`http_archive` allows specification of a `patch_tool`.  Even though the
underlying `patch` function invoked by `astore_package` supports the
`patch_tool` attribute, our existing `astore_package` is missing support for
this attribute.

This PR adds that attribute so that it will be easier to migrate `http_archive`
rules to `astore_package` rules.

Tested: existing rules stil pass.

In an `internal` repo, verified that `patch_tool` attribute worked using

```
$ bazel sync --override_repository=enkit=${HOME}/gee/enkit/astore_package_patch
```

