### PR TITLE
bazel: Add `rules_oci` to WORKSPACE

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -192,6 +192,14 @@ def stage_1():
     )
 
     maybe(
+        name = "rules_oci",
+        repo_rule = http_archive,
+        sha256 = "58b7a175ee90c12583afeca388523adf6a4e5a0528f330b41c302b91a4d6fc06",
+        strip_prefix = "rules_oci-1.6.0",
+        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz",
+    )
+
+    maybe(
         name = "com_google_googleapis",
         repo_rule = http_archive,
         urls = ["https://github.com/googleapis/googleapis/archive/10c88bb5c489c8ad1edb0e7f6a17cdd07147966e.zip"],

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -20,6 +20,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchai
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 load("@rules_antlr//antlr:repositories.bzl", "rules_antlr_dependencies")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
@@ -79,6 +80,8 @@ def stage_2():
     rules_docker_go_dependencies()
     rules_docker_python_dependencies()
     rules_docker_container_dependencies()
+
+    rules_oci_dependencies()
 
     container_pull(
         name = "golang_base",

--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -9,6 +9,7 @@ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
 load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
 load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3_8//:defs.bzl", "interpreter")
 
@@ -39,6 +40,11 @@ def stage_3():
     jsonnet_go_repositories()
 
     jsonnet_go_dependencies()
+
+    oci_register_toolchains(
+        name = "oci",
+        crane_version = LATEST_CRANE_VERSION,
+    )
 
     # Begin buildbarn ecosystem dependencies
     nodejs_register_toolchains(

--- a/bazel/init/stage_4.bzl
+++ b/bazel/init/stage_4.bzl
@@ -5,6 +5,7 @@ See README.md for more information.
 
 load("@enkit_pip_deps//:requirements.bzl", python_deps = "install_deps")
 load("@npm//:repositories.bzl", "npm_repositories")
+load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 def stage_4():
     """Stage 4 initialization for WORKSPACE.
@@ -18,3 +19,9 @@ def stage_4():
     python_deps()
 
     npm_repositories()
+
+    oci_pull(
+        name = "container_golang_base",
+        digest = "sha256:75f63d4edd703030d4312dc7528a349ca34d48bec7bd754652b2d47e5a0b7873",
+        image = "gcr.io/distroless/base",
+    )


### PR DESCRIPTION
This change adds a dependency on `rules_oci` to facilitate the migration away from `rules_docker`. A single image pull of `@golang_base` is created as `@container_golang_base` (named differently so they can both coexist for a short time) as a test that the rules are working.

Tested: `bazel build @container_golang_base//...` works

Jira: INFRA-9240