### PR TITLE
docker: Migrate image build to oci_* rules 

### DIFF
--- a/bb_reporter/BUILD.bazel
+++ b/bb_reporter/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
@@ -29,10 +29,10 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-container_image(
+oci_image(
     name = "bb_reporter_image",
-    base = "@golang_base//image",
-    cmd = [
+    base = "@container_golang_base",
+    entrypoint = [
         "/enfabrica/bin/bb_reporter",
     ],
     tars = [
@@ -40,11 +40,9 @@ container_image(
     ],
 )
 
-container_push(
+oci_push(
     name = "bb_reporter_image_push",
-    format = "Docker",
     image = ":bb_reporter_image",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/services/bb_reporter",
-    tag = "testing",
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/services/bb_reporter",
 )

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "server_lib",
@@ -46,10 +46,10 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-container_image(
+oci_image(
     name = "bestie_image",
-    base = "@golang_base//image",
-    cmd = [
+    base = "@container_golang_base",
+    entrypoint = [
         "/enfabrica/bin/bestie",
     ],
     tars = [
@@ -57,12 +57,9 @@ container_image(
     ],
 )
 
-container_push(
+oci_push(
     name = "bestie_image_push",
-    format = "Docker",
     image = ":bestie_image",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/bestie",
-    # TODO: Change this tag to "live"
-    tag = "testing",
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/bestie",
 )

--- a/infra/k8s_dummy/BUILD.bazel
+++ b/infra/k8s_dummy/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
@@ -27,23 +27,16 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-container_image(
+oci_image(
     name = "k8s_dummy_image",
-    base = "@golang_base//image",
-    cmd = [
-        "/enfabrica/bin/k8s_dummy",
-    ],
-    tars = [
-        ":k8s_dummy_tar",
-    ],
+    base = "@container_golang_base",
+    entrypoint = ["/enfabrica/bin/k8s_dummy"],
+    tars = [":k8s_dummy_tar"],
 )
 
-container_push(
+oci_push(
     name = "k8s_dummy_image_push",
-    format = "Docker",
     image = ":k8s_dummy_image",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/k8s_dummy",
-    # TODO: Change this tag to "live"
-    tag = "testing",
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/k8s_dummy",
 )

--- a/machinist/mserver/cmd/BUILD.bazel
+++ b/machinist/mserver/cmd/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
     name = "cmd_lib",
@@ -20,19 +20,22 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "image",
-    base = "@golang_base//image",
-    embed = [":cmd_lib"],
-    visibility = ["//visibility:public"],
+pkg_tar(
+    name = "tar",
+    srcs = [":cmd"],
+    package_dir = "/enfabrica/bin",
 )
 
-container_push(
-    name = "upload-image",
-    format = "Docker",
+oci_image(
+    name = "image",
+    base = "@container_golang_base",
+    entrypoint = ["/enfabrica/bin/cmd"],
+    tars = [":tar"],
+)
+
+oci_push(
+    name = "image_push",
     image = ":image",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/machinist/controlplane",
-    tag = "latest",
-    visibility = ["//visibility:public"],
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/machinist/controlplane",
 )

--- a/monitor/BUILD.bazel
+++ b/monitor/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
     name = "monitor_lib",
@@ -23,26 +25,26 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
-
-go_image(
-    name = "monitor-image",
-    args = ["$(location :probes.toml)"],
-    base = "@golang_base//image",
-    binary = ":monitor",
-    data = [
-        ":probes.toml",
+pkg_tar(
+    name = "tar",
+    srcs = [
+        ":monitor",
+        "probes.toml",
     ],
-    visibility = ["//visibility:public"],
+    package_dir = "/enfabrica/bin",
 )
 
-container_push(
-    name = "upload-monitor-image",
-    format = "Docker",
-    image = ":monitor-image",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/monitor",
-    tag = "monitor-server",
-    visibility = ["//visibility:public"],
+oci_image(
+    name = "image",
+    base = "@container_golang_base",
+    cmd = ["/enfabrica/bin/probes.toml"],
+    entrypoint = ["/enfabrica/bin/monitor"],
+    tars = [":tar"],
+)
+
+oci_push(
+    name = "image_push",
+    image = ":image",
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/monitor",
 )

--- a/shims/buildbuddy/cmd/BUILD.bazel
+++ b/shims/buildbuddy/cmd/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
     name = "cmd_lib",
@@ -19,19 +19,22 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "bb-shim",
-    base = "@golang_base//image",
-    embed = [":cmd_lib"],
-    visibility = ["//visibility:public"],
+pkg_tar(
+    name = "tar",
+    srcs = [":cmd"],
+    package_dir = "/enfabrica/bin",
 )
 
-container_push(
-    name = "upload-shim",
-    format = "Docker",
-    image = ":bb-shim",
-    registry = "gcr.io",
-    repository = "devops-284019/infra/bb-shim",
-    tag = "latest",
-    visibility = ["//visibility:public"],
+oci_image(
+    name = "image",
+    base = "@container_golang_base",
+    entrypoint = ["/enfabrica/bin/cmd"],
+    tars = [":tar"],
+)
+
+oci_push(
+    name = "image_push",
+    image = ":image",
+    remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/bb-shim",
 )


### PR DESCRIPTION
This change migrates all images built in this repo to use `rules_oci`
rules instead of `rules_docker` rules. Thankfully, all images built in
this repo today used hermetic rules, so there is an easy migration
path.

For rules that used `container_image`, there is a simple translation to
`oci_image`.

For rules that used `go_image`, there are extra transforms:

* `pkg_tar` must be used to prep the layer data. All data was put into
  `/enfabrica/bin` to avoid conflicting with top-level dirs.
* `entrypoint` (and possibly `cmd`) must be set on the resulting image
  to maintain compatibility with `go_image`.

When translating `oci_push` rules, `latest` was chosen as a remote tag
to be uniform across the repo.

Though `gcr.io` is going to be deprecated soon, the images are not moved
to a separate repository at this time.

Tested:
* `bazel test //...` still works
* Pushed a few of the images; pulled them to make sure they ran as
  expected

Jira: INFRA-9240