### PR TITLE
bes_publisher: Propagate user-specified tags in event attributes

### DIFF
--- a/bes_publisher/buildevent/service.go
+++ b/bes_publisher/buildevent/service.go
@@ -254,6 +254,17 @@ func (b *buildStream) updateAttrs(event *bes.BuildEvent) {
 			// Assume these are "interactive" builds, for backwards-compatibility
 			b.attrs["inv_type"] = "interactive"
 		}
+
+		// Take all keys prefixed with `build_tag:` and insert them as attributes,
+		// with the prefix `bt:` (which saves space, as PubSub subscription filters
+		// are character-limited)
+		for k, v := range payload.BuildMetadata.GetMetadata() {
+			if !strings.HasPrefix(k, "build_tag:") {
+				continue
+			}
+			tagName := "bt:" + strings.TrimPrefix(k, "build_tag:")
+			b.attrs[tagName] = v
+		}
 	case *bes.BuildEvent_Finished:
 		b.attrs["result"] = payload.Finished.GetExitCode().GetName()
 	}

--- a/bes_publisher/buildevent/service_test.go
+++ b/bes_publisher/buildevent/service_test.go
@@ -97,7 +97,11 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 				&bes.BuildEvent{
 					Payload: &bes.BuildEvent_BuildMetadata{
 						BuildMetadata: &bes.BuildMetadata{
-							Metadata: map[string]string{"ROLE": "interactive"},
+							Metadata: map[string]string{
+								"ROLE":              "interactive",
+								"build_tag:foo":     "bar",
+								"not_build_tag:baz": "quux",
+							},
 						},
 					},
 				},
@@ -154,10 +158,11 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 					},
 				},
 				&pubsub.Message{
-					Data: []byte(`{"buildMetadata":{"metadata":{"ROLE":"interactive"}}}`),
+					Data: []byte(`{"buildMetadata":{"metadata":{"ROLE":"interactive","build_tag:foo":"bar","not_build_tag:baz":"quux"}}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
+						"bt:foo":   "bar",
 					},
 				},
 				&pubsub.Message{
@@ -165,6 +170,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
+						"bt:foo":   "bar",
 					},
 				},
 				&pubsub.Message{
@@ -172,6 +178,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
+						"bt:foo":   "bar",
 					},
 				},
 				&pubsub.Message{
@@ -180,6 +187,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
 						"result":   "SUCCESS",
+						"bt:foo":   "bar",
 					},
 				},
 				&pubsub.Message{
@@ -188,6 +196,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
 						"result":   "SUCCESS",
+						"bt:foo":   "bar",
 					},
 				},
 			},


### PR DESCRIPTION
This change will allow users to set
`--build_metadata=build_tag:<TAG>=<VALUE>` (where `<TAG>` and `<VALUE>` are user-specified) and will propagate these as `bt:<TAG>`/`<VALUE>` pairs on BES event messages propagated through PubSub. This will in turn allow e.g. the DV BES publisher to be configured to listen for multiple builds without going over the 256-char limit.

Tested: Added unit tests

Jira: INFRA-9511