### PR TITLE
gee: improve commit --amend support

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3507,32 +3507,60 @@ function gee__commit() {
   else
     echo "Skipped \"git add --all\" because branch is home dir."
   fi
-  if _git_can_fail commit "$@"; then
+
+  local AMENDING=0
+  if printf "%s\0" "$@" | grep -qz "^--amend$"; then
+    _info "Amending previous commit."
+    AMENDING=1
     if _remote_branch_exists origin "${CURRENT_BRANCH}"; then
       _git fetch
       local -a COUNTS
       read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
       if [[ "${COUNTS[1]}" -gt 0 ]]; then
-        _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}."
-        _warn "You must integrate upstream changes before pushing."
+        _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}." \
+              "You must integrate these changes before attempting to amend and force-push the head commit."
         if _confirm_default_yes "Do you want to pull upstream changes now? (Y/n)  "; then
           _git rebase --autostash "origin/${CURRENT_BRANCH}"
           _check_diff_for_merge_conflict_markers
         else
-          _warn "Skipping backup of branch to origin/${CURRENT_BRANCH}"
+          _fatal "Aborted commit --amend operation because origin is ahead of local branch."
           return 0
         fi
       fi
     fi
+  fi
+
+  if _git_can_fail commit "$@"; then
     if [[ "${GEE_ENABLE_PRESUBMIT_CANCEL}" != "0" ]]; then
       if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
         # kill running presubmit job, if any exists:
         _cancel_pending_presubmit
       fi
     fi
-    # We always push upstream so that users have a backup in case they lose their
-    # laptop:
-    _push_to_origin "${CURRENT_BRANCH}"
+    if [[ "${AMENDING}" == 1 ]]; then
+      _push_to_origin "+${CURRENT_BRANCH}"  # force push is "safe" because we previously integrated.
+    else
+      if _remote_branch_exists origin "${CURRENT_BRANCH}"; then
+        _git fetch
+        local -a COUNTS
+        read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+        if [[ "${COUNTS[1]}" -gt 0 ]]; then
+          _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}."
+          _warn "You ought to integrate changes from origin before pushing."
+          if _confirm_default_yes "Do you want to pull changes from origin now? (Y/n)  "; then
+            _git rebase --autostash "origin/${CURRENT_BRANCH}"
+            _check_diff_for_merge_conflict_markers
+          else
+            _warn "Skipping push of branch to origin/${CURRENT_BRANCH}" \
+                  "Use \"git push -f\" if you know you want to overwrite the other changes in origin."
+            return 0
+          fi
+        fi
+      fi
+      # We always push upstream so that users have a backup in case they lose their
+      # laptop.  We should not need to force push here.
+      _push_to_origin "${CURRENT_BRANCH}"
+    fi
     _read_parents_file
     if [[ "${PARENTS[${CURRENT_BRANCH}]}" == upstream/refs/pull/*/head ]]; then
       _info "NOTE: This is a branch of another user's PR.  Your changes were pushed to *your* " \


### PR DESCRIPTION
Previously, gee would treat `gee commit --amend` like any other commit
operation.  It would try to integrate changes from origin before pushing
the amended commit, leading to merge conflicts.


The new functionality will detect that the user is amending the head
commit.  This means gee will need to force-push after amending head,
but gee does so in a way that adds extra checks and rebase opportunities
to try to make it harder to accidentally overwrite/discard upstream
commits.

The new functionality is:

1. if gee sees that the user is trying to amend the head commit, it will
   first check origin to see if origin is ahead of head. If origin is ahead of
   the local branch, the user is given the option of rebasing from origin
   -- otherwise, gee will abort and no commit is created.

2. the `git commit` option occurs.

3. If the commit was an --amend operation, the new commit is force-pushed to
   origin.  Otherwise, the normal flow proceeds (the user is given the
   opportunity to integrate changes from origin, if any exist, and then
   a non-force push takes place).

Tested: Manually tested both `gee commit` and `gee commit --amend`.

```
$ ./gee commit --amend
CMD: /usr/bin/git add --all
Amending previous commit.
CMD: /usr/bin/git fetch
CMD: /usr/bin/git commit --amend
[gee_amend f1d72ef] add support for commit --amend option
 Date: Mon Feb 12 12:00:57 2024 -0800
 1 file changed, 35 insertions(+), 7 deletions(-)
CMD: /usr/bin/git push --quiet -u origin +gee_amend
```
