### PR TITLE
gee: improve rebasing of children of submitted PRs

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4659,15 +4659,20 @@ function gee__pr_submit() {
         "merge conflicts: ${KIDS[*]}"
   if _confirm_default_yes "Rebase child branches now? (Y/n)  "; then
     local CHILD
+    _read_parents_file
     for CHILD in "${KIDS[@]}"; do
       _banner "Rebasing ${CHILD}"
-      # performs: git rebase --onto squashed_parent unsquashed_parent child
+      # First make sure that child contains all the commits from the unsquashed version of the parent:
+      _safer_rebase "${CHILD}" "${CURRENT_BRANCH}-unsquashed"
+      # Then rebase the current branch onto the squashed current branch, using only the commits
+      # not present in the unsquashed parent branch:
       _safer_rebase "${CHILD}" "${CURRENT_BRANCH}-unsquashed" "${CURRENT_BRANCH}"
+      # Simplify the tree.
+      PARENTS["${CHILD}"]="${MAIN}"
+      _info "Parent branch for \"${CHILD}\" has been set to \"${MAIN}\""
     done
+    _write_parents_file
   fi
-  # Because ${CURRENT_BRANCH} still exists and contains the squash-merged
-  # tree, there is no need to change the parentage of the branch tree
-  # (unlike gee__remove_branch, below).
 }
 
 ##########################################################################

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -5,6 +5,7 @@
 ### 0.2.48
 
 * gee pr_make: facilitate setting assignees for new PRs (#1024).
+* gee: improve rebase --onto flow to reduce merge conflicts (#1022).
 * gee commit: improve `--amend` behavior (#1021).
 * gee: additional error checking for incorrect `gh repo set-default` configuration (#1017).
 


### PR DESCRIPTION
In a chat group, someone suggested an improvement to the flow to follow when
rebasing the child branch of a branch that has been merged.  This PR captures
that improvement: to update the child branch with all of the commits of the
unsquashed parent branch, before using `rebase --onto` to move only the new
commits from the child branch on top of master.

Tested: manually testing this for a week or so in my own work.  I am my own
guinea pig.

