### PR TITLE
gee pr_make: assign assignees

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.47"
+readonly VERSION="0.2.48"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___
@@ -4196,7 +4196,7 @@ EndOfPrTemplate
   sed -i '1{d};2{/^$/d}' "${TRIMMED}"
 
   local ASSIGNEES=()
-  mapfile -t ASSIGNEES < <(cat "${TRIMMED}" | grep ^ASSIGNEES: | xargs -n1 | grep -v ^ASSIGNEES:)
+  mapfile -t ASSIGNEES < <(grep ^ASSIGNEES: "${TRIMMED}" | xargs -n1 | grep -v ^ASSIGNEES:)
   if [[ "${#ASSIGNEES[@]}" == 0 ]]; then
     _warn "Every PR must have one or more assignees.  Assigning to you for now."
     ASSIGNEES=( "@me" )

--- a/scripts/gee
+++ b/scripts/gee
@@ -4202,6 +4202,7 @@ EndOfPrTemplate
     _warn "Every PR must have one or more assignees.  Assigning to you for now."
     ASSIGNEES=( "@me" )
   fi
+  sed -i '/^ASSIGNEES:/d' "${TRIMMED}"
 
   _push_to_origin "${CURRENT_BRANCH}"
   # gh pr is arcane and confusing, but this works:

--- a/scripts/gee
+++ b/scripts/gee
@@ -4126,7 +4126,7 @@ Tested:
 EndOfPrTemplate
 
     local OWNERS=()
-    mapfile -t OWNERS < <(_print_codeowners)
+    mapfile -t OWNERS < <(_print_codeowners | sed -e 's/@//g')
     if [[ "${#OWNERS[@]}" -eq 0 ]]; then
       printf "# This PR can be submitted with anyone's approval.\n"
     elif [[ "${#OWNERS[@]}" -eq 1 ]]; then
@@ -4136,9 +4136,8 @@ EndOfPrTemplate
       printf "# This PR requires approval from at least one code owner on each line:\n"
       printf "#  * %s\n" "${OWNERS[@]}"
     fi
-    local UNIQUE_OWNERS="$(echo "${OWNERS[*]}" | xargs -n1 | sort -u | xargs | sed -e 's/@//g' )"
-    printf "# Reduce this set of assignees:\n"
-    printf "ASSIGNEES: ${UNIQUE_OWNERS}\n\n"
+    printf "# Pick assignees:\n"
+    printf "ASSIGNEES: \n\n"
 
     if (( "${#PARENT_PRS[@]}" > 0 )); then
       printf "NOTE: this PR includes changes that are also in PR #%d.\n" "${PARENT_PRS[0]}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -4112,13 +4112,11 @@ function gee__pr_make() {
   TRIMMED="${BODYFILE}.trimmed"
   (
     cat <<'EndOfPrTemplate'
-# The first line should be the PR title.
-# For example: "scripts/gee: Add new PR template."
+# The first line should be the PR title.  For example: "scripts/gee: Add new PR template."
 
-# In this section, explain why the PR is necessary and what the PR desires to
-# achieve.  List any relevant Jira tickets.
+# Why?  What?  How?
 
-# In this section, describe what testing was done to validate your change.
+# What manual testing have you performed?
 Tested:
 
 # Having second thoughts?  Uncomment one of these two lines:
@@ -4126,6 +4124,21 @@ Tested:
 # ABORT   # To abort the creation of a PR.
 
 EndOfPrTemplate
+
+    local OWNERS=()
+    mapfile -t OWNERS < <(_print_codeowners)
+    if [[ "${#OWNERS[@]}" -eq 0 ]]; then
+      printf "# This PR can be submitted with anyone's approval.\n"
+    elif [[ "${#OWNERS[@]}" -eq 1 ]]; then
+      printf "# This PR requires approval from at least one of these code owners:\n"
+      printf "#  * %s\n" "${OWNERS[@]}"
+    else
+      printf "# This PR requires approval from at least one code owner on each line:\n"
+      printf "#  * %s\n" "${OWNERS[@]}"
+    fi
+    local UNIQUE_OWNERS="$(echo "${OWNERS[*]}" | xargs -n1 | sort -u | xargs | sed -e 's/@//g' )"
+    printf "# Reduce this set of assignees:\n"
+    printf "ASSIGNEES: ${UNIQUE_OWNERS}\n\n"
 
     if (( "${#PARENT_PRS[@]}" > 0 )); then
       printf "NOTE: this PR includes changes that are also in PR #%d.\n" "${PARENT_PRS[0]}"
@@ -4183,6 +4196,13 @@ EndOfPrTemplate
   # title when we eventually submit the PR:
   sed -i '1{d};2{/^$/d}' "${TRIMMED}"
 
+  local ASSIGNEES=()
+  mapfile -t ASSIGNEES < <(cat "${TRIMMED}" | grep ^ASSIGNEES: | xargs -n1 | grep -v ^ASSIGNEES:)
+  if [[ "${#ASSIGNEES[@]}" == 0 ]]; then
+    _warn "Every PR must have one or more assignees.  Assigning to you for now."
+    ASSIGNEES=( "@me" )
+  fi
+
   _push_to_origin "${CURRENT_BRANCH}"
   # gh pr is arcane and confusing, but this works:
   #  -R specifies the repo that we are pushing changes into.
@@ -4196,6 +4216,10 @@ EndOfPrTemplate
     -H "${GHUSER}:${CURRENT_BRANCH}"
     --body-file "${TRIMMED}"
   )
+  local A
+  for A in "${ASSIGNEES[@]}"; do
+    PR_ARGS+=(--assignee "${A}")
+  done
 
   local DRAFT=0
   if grep --quiet -E "^\s*DRAFT" "${TRIMMED}"; then

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,10 +2,17 @@
 
 ## Releases
 
+### 0.2.48
+
+* gee pr_make: facilitate setting assignees for new PRs (#1024).
+* gee commit: improve `--amend` behavior (#1021).
+* gee: additional error checking for incorrect `gh repo set-default` configuration (#1017).
+
 ### 0.2.47
 
 * gee lspr: add `--text` option (#1009).
-* gee: handle closed PRs that are also marked as drafts (#1008).
+* gee bisect: handle empty sets of commits (#1008).
+* gee: handle closed PRs that are also marked as drafts (#1004).
 * gee: add `GEE_ENABLE_PRESUBMIT_CANCEL` feature (#1001).
 * gee: allow override of default tool paths (#991).
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.47
+gee version: 0.2.48
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
Tested: new PR creation template looks like this:

    # The first line should be the PR title.  For example: "scripts/gee: Add new PR template."
    
    # Why?  What?  How?
    
    # What manual testing have you performed?
    Tested:
    
    # Having second thoughts?  Uncomment one of these two lines:
    # DRAFT   # To mark this PR as a "draft"
    # ABORT   # To abort the creation of a PR.
    
    # This PR requires approval from at least one of these code owners:
    #  * @amichalol @ccontavalli @jonathan-enf @minor-fixes
    # Reduce this set of assignees:
    ASSIGNEES: amichalol ccontavalli jonathan-enf minor-fixes
    
    # The following files were modified in this PR:
    # scripts/gee
    #
    # Here is your commit log:
    # commit 247a1d26f9fd48ba9b42aea13e03fa7821fd8cd2
    # Author: Jonathan Mayer <jonathan@enfabrica.net>
    # Date:   Tue Feb 20 13:57:10 2024 -0800
    # 
    #     add assignees to pr creation template.
    # 
    # commit c2feceecca0f39e5f263bf732fb99ac3b4679481
    # Author: Jonathan Mayer <jonathan@enfabrica.net>
    # Date:   Tue Feb 20 14:10:24 2024 -0800
    # 
    #     delete ASSIGNEES line from PR description after parsing


