### PR TITLE
experimental: Add example binaries

### DIFF
--- a/experimental/cmd/complex_cli/BUILD.bazel
+++ b/experimental/cmd/complex_cli/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "complex_cli_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/experimental/cmd/complex_cli",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_spf13_cobra//:cobra"],
+)
+
+go_binary(
+    name = "complex_cli",
+    embed = [":complex_cli_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/experimental/cmd/complex_cli/main.go
+++ b/experimental/cmd/complex_cli/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+type PrintNum struct {
+	*cobra.Command
+	base int
+}
+
+func NewPrintNum() *PrintNum {
+	c := &PrintNum{
+		Command: &cobra.Command{
+			Use:   "print-num",
+			Short: "Print a number",
+			Long:  `Print a number with various options`,
+			Args:  cobra.ExactArgs(1),
+		},
+	}
+
+	c.Command.PreRunE = c.Check
+	c.Command.RunE = c.Run
+	c.Flags().IntVar(&c.base, "base", 10, "Interpret the number as being in a specific base")
+
+	return c
+}
+
+func (c *PrintNum) Check(cmd *cobra.Command, args []string) error {
+	validBases := map[int]struct{}{
+		2:  {},
+		8:  {},
+		10: {},
+		16: {},
+	}
+
+	if _, ok := validBases[c.base]; !ok {
+		return fmt.Errorf("%d is not a valid base", c.base)
+	}
+	return nil
+}
+
+func (c *PrintNum) Run(cmd *cobra.Command, args []string) error {
+	num, err := strconv.ParseInt(args[0], c.base, 64)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid number in base %d: %w", args[0], c.base, err)
+	}
+	fmt.Printf("%d\n", num)
+	return nil
+}
+
+func main() {
+	root := &cobra.Command{
+		Use:   "complex_cli",
+		Short: "Example of a CLI app with multiple subcommands",
+	}
+
+	root.AddCommand(NewPrintNum().Command)
+
+	if err := root.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("complex_cli success")
+	}
+}

--- a/experimental/cmd/simple_cmd_line/BUILD.bazel
+++ b/experimental/cmd/simple_cmd_line/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "simple_cmd_line_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/enfabrica/enkit/experimental/cmd/simple_cmd_line",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "simple_cmd_line",
+    embed = [":simple_cmd_line_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/experimental/cmd/simple_cmd_line/main.go
+++ b/experimental/cmd/simple_cmd_line/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var (
+	intFlag    = flag.Int("int_flag", 0, "Example int flag")
+	stringFlag = flag.String("string_flag", "foo", "Example string flag")
+)
+
+func main() {
+	flag.Parse()
+
+	fmt.Println("simple command line")
+	fmt.Printf("Int flag value: %d\n", *intFlag)
+	fmt.Printf("String flag value: %q\n", *stringFlag)
+}


### PR DESCRIPTION
This change adds some simple CLI binaries that can be used to test new flag/logging libraries on.