### PR TITLE
licensedevice: Use hcl logger instead of slog

### DIFF
--- a/experimental/nomad_resource_plugin/licensedevice/sqldb/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/sqldb/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//experimental/nomad_resource_plugin/licensedevice/types",
+        "@com_github_hashicorp_go_hclog//:go-hclog",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_prometheus_client_golang//prometheus",


### PR DESCRIPTION
To avoid any conflicts over the stdout interface which the plugin seems to utilize, change all logging to go to the passed-in hcl logger.

Tested: locally

Jira: INFRA-9678
