### PR TITLE
licensedevice: Set incoming logger as slog's default

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -792,6 +792,12 @@ def go_repositories():
         version = "v1.0.2",
     )
     go_repository(
+        name = "com_github_evanphx_go_hclog_slog",
+        importpath = "github.com/evanphx/go-hclog-slog",
+        sum = "h1:eRU+7+VeZHe2miMDty965PPFawKkInpeJysPRzGAwAI=",
+        version = "v0.0.0-20230905211129-6d31b63d6f09",
+    )
+    go_repository(
         name = "com_github_evanphx_json_patch",
         importpath = "github.com/evanphx/json-patch",
         sum = "h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=",

--- a/experimental/nomad_resource_plugin/licensedevice/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/BUILD.bazel
@@ -10,12 +10,12 @@ go_library(
         "//experimental/nomad_resource_plugin/licensedevice/sqldb",
         "//experimental/nomad_resource_plugin/licensedevice/types",
         "//lib/str",
-        "@com_github_hashicorp_go_hclog//:go-hclog",
         "@com_github_hashicorp_nomad//plugins/base",
         "@com_github_hashicorp_nomad//plugins/device",
         "@com_github_hashicorp_nomad//plugins/shared/hclspec",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@org_golang_x_exp//slog",
     ],
 )
 

--- a/experimental/nomad_resource_plugin/licensedevice/cmd/nomad_license_manage/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/cmd/nomad_license_manage/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//experimental/nomad_resource_plugin/licensedevice/sqldb",
         "//experimental/nomad_resource_plugin/licensedevice/types",
-        "//experimental/nomad_resource_plugin/licensedevice",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
     ],

--- a/experimental/nomad_resource_plugin/licensedevice/cmd/nomad_license_plugin/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/cmd/nomad_license_plugin/BUILD.bazel
@@ -6,12 +6,12 @@ go_library(
     importpath = "github.com/enfabrica/enkit/experimental/nomad_resource_plugin/licensedevice/cmd/nomad_license_plugin",
     visibility = ["//visibility:private"],
     deps = [
-        "//lib/metrics",
-        "//lib/server",
         "//experimental/nomad_resource_plugin/licensedevice",
-        "@com_github_golang_glog//:glog",
+        "//lib/metrics",
+        "@com_github_evanphx_go_hclog_slog//hclogslog",
         "@com_github_hashicorp_go_hclog//:go-hclog",
         "@com_github_hashicorp_nomad//plugins",
+        "@org_golang_x_exp//slog",
     ],
 )
 

--- a/experimental/nomad_resource_plugin/licensedevice/plugin_test.go
+++ b/experimental/nomad_resource_plugin/licensedevice/plugin_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/plugins/device"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,8 +46,7 @@ func TestPluginIsNomadDevicePlugin(t *testing.T) {
 }
 
 func TestPluginFingerprintBeforeSetConfig(t *testing.T) {
-	l := hclog.NewNullLogger()
-	p := NewPlugin(l)
+	p := NewPlugin()
 	_, gotErr := p.Fingerprint(context.Background())
 
 	assert.Error(t, gotErr)
@@ -57,8 +55,7 @@ func TestPluginFingerprintBeforeSetConfig(t *testing.T) {
 func TestPluginFingerprint(t *testing.T) {
 	notifier := &mockNotifier{}
 
-	l := hclog.NewNullLogger()
-	p := NewPlugin(l)
+	p := NewPlugin()
 	p.globalUpdater = notifier
 	p.licenseHandleRoot = bazel.TestTmpDir()
 
@@ -149,8 +146,7 @@ func TestPluginFingerprint(t *testing.T) {
 func TestReserve(t *testing.T) {
 	reserver := &mockReserver{}
 
-	l := hclog.NewNullLogger()
-	p := NewPlugin(l)
+	p := NewPlugin()
 	p.nodeID = "client_a"
 	p.reserver = reserver
 	p.licenseHandleRoot = bazel.TestTmpDir()

--- a/experimental/nomad_resource_plugin/licensedevice/sqldb/BUILD.bazel
+++ b/experimental/nomad_resource_plugin/licensedevice/sqldb/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@org_golang_x_exp//slog",
     ],
 )
 

--- a/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
+++ b/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
@@ -3,13 +3,16 @@ package sqldb
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	// TODO(scott): Change this to "log/slog" after go-hclog-slog is updated to
+	// use the stdlib
+	"golang.org/x/exp/slog"
 
 	"github.com/enfabrica/enkit/experimental/nomad_resource_plugin/licensedevice/types"
 )

--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/evanphx/go-hclog-slog v0.0.0-20230905211129-6d31b63d6f09 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -931,6 +931,8 @@ github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
+github.com/evanphx/go-hclog-slog v0.0.0-20230905211129-6d31b63d6f09 h1:eRU+7+VeZHe2miMDty965PPFawKkInpeJysPRzGAwAI=
+github.com/evanphx/go-hclog-slog v0.0.0-20230905211129-6d31b63d6f09/go.mod h1:zQN9KGG86/ntSzooNtiMDWimgwc4pQ0o8VyhDgECudk=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -34,10 +34,10 @@ pkg_tar(
 oci_image(
     name = "enproxy_image",
     base = "@golang_base",
+    entrypoint = ["/enproxy"],
     env = {
         "HOME": "/cache",
     },
-    entrypoint = ["/enproxy"],
     tars = [":enproxy_tarball"],
     visibility = ["//visibility:private"],
     # enproxy needs to cache certificates in a directory so they survive
@@ -62,7 +62,7 @@ oci_image(
 oci_push(
     name = "upload-enproxy-image",
     image = ":enproxy_image",
-    repository = "gcr.io/devops-284019/infra/enproxy",
     remote_tags = ["latest"],
+    repository = "gcr.io/devops-284019/infra/enproxy",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change adapts the incoming `hclog.Logger` and sets it as `slog`s default logger, so that slog can be used throughout the codebase without logging to stdout/stderr accidentally.

Nomad requires that device plugins not log to stdin/stdout, using the supplied logger object instead. One way to comply is to plumb this logger object throughout, or make it global; both have drawbacks:

* loggers pollute function signatures
* polluted function signatures make said functions more tedious to test
* linked code may use other logging libraries that are not aware of this constraint

By following this method, we ensure that the global logger future library code is likely to use doesn't break the plugin's contract, while also keeping function signatures clean.

Other diffs in this PR are the result of running `gazelle` to clean up BUILD files.

Tested: Manually, by @jrp-enf 

Jira: INFRA-9678