### PR TITLE
Update rules_oci to support docker config

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -182,9 +182,9 @@ def stage_1():
     maybe(
         name = "rules_oci",
         repo_rule = http_archive,
-        sha256 = "58b7a175ee90c12583afeca388523adf6a4e5a0528f330b41c302b91a4d6fc06",
-        strip_prefix = "rules_oci-1.6.0",
-        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz",
+        strip_prefix = "rules_oci-1.7.2",
+        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.2/rules_oci-v1.7.2.tar.gz",
+        sha256 = "cf6b8be82cde30daef18a09519d75269650317e40d917c8633cf8e3ab5645ea5",
     )
 
     maybe(


### PR DESCRIPTION
This change updates the rules_oci version so that the `config` field can be used in `oci_pull`. Besides updating the `rules_oci` external repo to stay up-to-date, the `config` field may be required to fix the permissions issue in postsubmits. Currently, some postsubmits are failing due to a 401 permissions error pulling containers from `gcr.io`. Setting the `config` field to point to a docker `config.json` might solve the issue.

Tested:
- `bazel build --override_repository=enkit=$HOME/enkit //infra/puppet:puppet_server_image` to test that container builds are not broken with the newer version of `rules_oci`

JIRA: INFRA-9736