### PR TITLE
The license ID is greater than 16 characters, use text.

### DIFF
--- a/experimental/nomad_resource_plugin/licensedevice/schema/create_tables.sql
+++ b/experimental/nomad_resource_plugin/licensedevice/schema/create_tables.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS license_state (
 -- DROP TABLE IF EXISTS license_state_log
 CREATE TABLE IF NOT EXISTS license_state_log (
   id BIGSERIAL PRIMARY KEY,
-  license_id VARCHAR(16) NOT NULL REFERENCES license_state(id),
+  license_id TEXT NOT NULL REFERENCES license_state(id),
   node TEXT NOT NULL,
   ts TIMESTAMPTZ NOT NULL,
   previous_state TEXT NOT NULL,


### PR DESCRIPTION
Errors came up when reserving a license whose id was longer than 16 characters.

Tested: altered table in production