### PR TITLE
buildbuddy: Update proto copybara

### DIFF
--- a/third_party/buildbuddy/copy.bara.sky
+++ b/third_party/buildbuddy/copy.bara.sky
@@ -2,25 +2,38 @@ core.workflow(
     name = "default",
     origin = git.origin(
         url = "https://github.com/buildbuddy-io/buildbuddy",
-        ref = "372b95b41a6ed82da632ee44ff0c48071c849c21",  # master as of 26Jan2022
-        partial_fetch = True,
+        ref = "9891dc69a036040d6e7eaab616d4a11186c311d5",  # v2.44.0
     ),
     destination = git.github_pr_destination(
         url = "https://github.com/enfabrica/enkit",
         destination_ref = "master",
     ),
     origin_files = glob([
-        "proto/invocation.proto",
         "proto/acl.proto",
+        "proto/api_key.proto",
         "proto/cache.proto",
+        "proto/command_line.proto",
         "proto/context.proto",
+        "proto/invocation.proto",
+        "proto/invocation_status.proto",
+        "proto/option_filters.proto",
+        "proto/remote_execution.proto",
+        "proto/resource.proto",
+        "proto/scheduler.proto",
+        "proto/semver.proto",
+        "proto/stat_filter.proto",
+        "proto/target.proto",
+        "proto/trace.proto",
         "proto/user_id.proto",
+        "proto/api/v1/common.proto",
     ]),
     destination_files = glob(
         ["third_party/buildbuddy/**"],
         exclude = [
+            "third_party/buildbuddy/copy.bara.sky",
             "third_party/buildbuddy/README.md",
             "third_party/buildbuddy/**/BUILD.bazel",
+            "third_party/buildbuddy/proto/empty.go",
         ],
     ),
     authoring = authoring.overwrite(default = "Copybara <noreply@enfabrica.net>"),


### PR DESCRIPTION
This change updates the buildbuddy proto copybara to copy more relevant protos, so that we can keep the protos up-to-date with the currently-running Buildbuddy version.

Now that Buildbuddy has been updated, the protos we're coding against are outdated, and we're not able to view responses properly. When importing the updated protos, it's evident that they've expanded their proto definitions greatly, so we need to increase the number of protos we're importing. This change imports the set of protos required by `invocation.proto` transitively. A follow-on PR will perform the actual import and BUILD file adjustments.

Jira: INFRA-9987