### PR TITLE
buildbuddy: Use rules_proto_grpc protobuf rules

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -271,6 +271,14 @@ filegroup(
         ],
     )
 
+    maybe(
+        name = "rules_proto_grpc",
+        repo_rule = http_archive,
+        sha256 = "2a0860a336ae836b54671cbbe0710eec17c64ef70c4c5a88ccfd47ea6e3739bd",
+        urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/4.6.0/rules_proto_grpc-4.6.0.tar.gz"],
+        strip_prefix = "rules_proto_grpc-4.6.0",
+    )
+
     # Explicitly load Jsonnet here so that we control the version, instead of
     # rules_jsonnet and dependencies, which tend to use an old version.
     maybe(

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -18,6 +18,7 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 def stage_2():
@@ -61,6 +62,9 @@ def stage_2():
 
     gazelle_dependencies(go_sdk = "go_sdk_1_21")
     go_embed_data_dependencies()
+
+    rules_proto_grpc_repos()
+    rules_proto_grpc_toolchains()
 
     rules_proto_dependencies()
     rules_proto_toolchains()

--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -11,6 +11,7 @@ load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
+load("@rules_proto_grpc//python:repositories.bzl", rules_proto_grpc_python_repos = "python_repos")
 load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3_8//:defs.bzl", "interpreter")
 
@@ -37,6 +38,8 @@ def stage_3():
     )
 
     grpc_extra_deps()
+
+    rules_proto_grpc_python_repos()
 
     jsonnet_go_repositories()
 

--- a/third_party/buildbuddy/proto/BUILD.bazel
+++ b/third_party/buildbuddy/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+load("@rules_proto_grpc//python:defs.bzl", py_proto_library = "python_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -72,7 +72,7 @@ go_proto_library(
 
 py_proto_library(
     name = "acl_py_proto",
-    srcs = ["acl.proto"],
+    protos = [":acl_proto"],
     deps = [
         ":user_id_py_proto",
     ],
@@ -80,14 +80,12 @@ py_proto_library(
 
 py_proto_library(
     name = "cache_py_proto",
-    srcs = [
-        "cache.proto",
-    ],
+    protos = [":cache_proto"],
 )
 
 py_proto_library(
     name = "invocation_py_proto",
-    srcs = ["invocation.proto"],
+    protos = [":invocation_proto"],
     deps = [
         ":acl_py_proto",
         ":cache_py_proto",
@@ -95,18 +93,17 @@ py_proto_library(
         "//third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_py_proto",
         "//third_party/bazel/src/main/protobuf:command_line_py_proto",
         "//third_party/bazel/src/main/protobuf:option_filters_py_proto",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
 py_proto_library(
     name = "user_id_py_proto",
-    srcs = ["user_id.proto"],
+    protos = [":user_id_proto"],
 )
 
 py_proto_library(
     name = "context_py_proto",
-    srcs = ["context.proto"],
+    protos = [":context_proto"],
     deps = [
         ":user_id_py_proto",
     ],


### PR DESCRIPTION
This change migrates the Python proto targets for Buildbuddy protos to
use rules_proto_grpc rather than the old rules from the protobuf repo.

Tested: manually built against targets in internal; doesn't break builds

Jira: INFRA-9986