### PR TITLE
bes_publisher: Fix propagation of build tags

### DIFF
--- a/bes_publisher/buildevent/service.go
+++ b/bes_publisher/buildevent/service.go
@@ -256,13 +256,13 @@ func (b *buildStream) updateAttrs(event *bes.BuildEvent) {
 		}
 
 		// Take all keys prefixed with `build_tag:` and insert them as attributes,
-		// with the prefix `bt:` (which saves space, as PubSub subscription filters
+		// with the prefix `bt__` (which saves space, as PubSub subscription filters
 		// are character-limited)
 		for k, v := range payload.BuildMetadata.GetMetadata() {
 			if !strings.HasPrefix(k, "build_tag:") {
 				continue
 			}
-			tagName := "bt:" + strings.TrimPrefix(k, "build_tag:")
+			tagName := "bt__" + strings.TrimPrefix(k, "build_tag:")
 			b.attrs[tagName] = v
 		}
 	case *bes.BuildEvent_Finished:

--- a/bes_publisher/buildevent/service_test.go
+++ b/bes_publisher/buildevent/service_test.go
@@ -87,14 +87,14 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 		{
 			desc: "normal build",
 			events: []*bes.BuildEvent{
-				&bes.BuildEvent{
+				{
 					Payload: &bes.BuildEvent_Started{
 						Started: &bes.BuildStarted{
 							Uuid: "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						},
 					},
 				},
-				&bes.BuildEvent{
+				{
 					Payload: &bes.BuildEvent_BuildMetadata{
 						BuildMetadata: &bes.BuildMetadata{
 							Metadata: map[string]string{
@@ -105,16 +105,16 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 						},
 					},
 				},
-				&bes.BuildEvent{
+				{
 					Payload: &bes.BuildEvent_WorkspaceStatus{
 						WorkspaceStatus: &bes.WorkspaceStatus{
 							Item: []*bes.WorkspaceStatus_Item{
-								&bes.WorkspaceStatus_Item{Key: "GIT_USER", Value: "jmcclane"},
+								{Key: "GIT_USER", Value: "jmcclane"},
 							},
 						},
 					},
 				},
-				&bes.BuildEvent{
+				{
 					Id: &bes.BuildEventId{
 						Id: &bes.BuildEventId_TestResult{
 							TestResult: &bes.BuildEventId_TestResultId{
@@ -130,7 +130,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 						},
 					},
 				},
-				&bes.BuildEvent{
+				{
 					Payload: &bes.BuildEvent_Finished{
 						Finished: &bes.BuildFinished{
 							ExitCode: &bes.BuildFinished_ExitCode{
@@ -140,7 +140,7 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 						},
 					},
 				},
-				&bes.BuildEvent{
+				{
 					Payload: &bes.BuildEvent_BuildMetrics{
 						BuildMetrics: &bes.BuildMetrics{
 							BuildGraphMetrics: &bes.BuildMetrics_BuildGraphMetrics{
@@ -151,52 +151,52 @@ func TestPublishBuildToolEventStream(t *testing.T) {
 				},
 			},
 			wantMessages: []*pubsub.Message{
-				&pubsub.Message{
+				{
 					Data: []byte(`{"started":{"uuid":"d9b5cec0-c1e6-428c-8674-a74194b27447"}}`),
 					Attributes: map[string]string{
 						"inv_id": "d9b5cec0-c1e6-428c-8674-a74194b27447",
 					},
 				},
-				&pubsub.Message{
+				{
 					Data: []byte(`{"buildMetadata":{"metadata":{"ROLE":"interactive","build_tag:foo":"bar","not_build_tag:baz":"quux"}}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
-						"bt:foo":   "bar",
+						"bt__foo":  "bar",
 					},
 				},
-				&pubsub.Message{
+				{
 					Data: []byte(`{"workspaceStatus":{"item":[{"key":"GIT_USER", "value":"jmcclane"}]}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
-						"bt:foo":   "bar",
+						"bt__foo":  "bar",
 					},
 				},
-				&pubsub.Message{
+				{
 					Data: []byte(`{"id":{"testResult":{"label":"//foo/bar:baz_test", "run":1}}, "testResult":{"status":"PASSED"}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
-						"bt:foo":   "bar",
+						"bt__foo":  "bar",
 					},
 				},
-				&pubsub.Message{
+				{
 					Data: []byte(`{"finished":{"exitCode":{"name":"SUCCESS"}}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
 						"result":   "SUCCESS",
-						"bt:foo":   "bar",
+						"bt__foo":  "bar",
 					},
 				},
-				&pubsub.Message{
+				{
 					Data: []byte(`{"buildMetrics":{"buildGraphMetrics":{"actionCount":3}}}`),
 					Attributes: map[string]string{
 						"inv_id":   "d9b5cec0-c1e6-428c-8674-a74194b27447",
 						"inv_type": "interactive",
 						"result":   "SUCCESS",
-						"bt:foo":   "bar",
+						"bt__foo":  "bar",
 					},
 				},
 			},


### PR DESCRIPTION
This change modifies how "build tags" are propagated as BES pubsub message attributes.

Previously, passing `--build_metadata=build_tag:foo=bar` would add a Pubsub attribute of `bt:foo` = `bar` on all BES pubsub messages for this build.

The problem is that filtering on `bt:foo` is not possible due to the `:` character.

This change replaces `:` with `__` which is a legal character to filter on when creating Pubsub subscriptions, and won't get conflated with single `_` characters in the key.

Tested: unit tests only

Jira: INFRA-10127