### PR TITLE
machinist: Add ARM binary targets

### DIFF
--- a/machinist/cmd/BUILD.bazel
+++ b/machinist/cmd/BUILD.bazel
@@ -27,6 +27,12 @@ go_cross_binary(
     target = ":cmd",
 )
 
+go_cross_binary(
+    name = "machinist_linux_arm",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    target = ":cmd",
+)
+
 astore_upload(
     name = "machinist_linux_push",
     file = "infra/dev_machine/machinist",
@@ -45,4 +51,10 @@ astore_upload(
         "no-presubmit",
     ],
     targets = [":cmd_windows"],
+)
+
+astore_upload(
+    name = "machinist_linux_arm_push",
+    file = "infra/dev_machine/machinist",
+    targets = [":machinist_linux_arm"],
 )


### PR DESCRIPTION
ARM targets are needed for some lab machines; this PR adds targets to build machinist for ARM, and to push an ARM build to astore.

Tested: pushed non-official build to astore via target

Jira: INFRA-10256