### PR TITLE
bazel: Add hermetic GCC 10 toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,21 @@ test --test_output=errors
 build --incompatible_strict_action_env
 run --incompatible_strict_action_env
 
+# TODO(INFRA-4384): Remove this flag once all dependencies are compatible with
+# the new platforms repo for constraints.
+build --noincompatible_use_platforms_repo_for_constraints
+
+# BUG(INFRA-4263): These flags are needed in order to use C++ toolchain
+# resolution with a hermetic toolchain, rather than letting bazel resolve the
+# toolchain to the one on the host.
+# See https://github.com/f0rmiga/gcc-toolchain/issues/88
+build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --incompatible_enable_cc_toolchain_resolution
+# See https://github.com/f0rmiga/gcc-toolchain/issues/85; without this flag,
+# moving to a hermetic C++ toolchain increases C++ build times by ~40%. With
+# this flag, the extra overhead is reduced (but not entirely eliminated)
+build --experimental_reuse_sandbox_directories
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this
@@ -23,7 +38,3 @@ run --incompatible_strict_action_env
 # (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
 # rather than user.bazelrc as suggested in the Bazel docs)
 try-import %workspace%/.bazelrc.user
-
-# TODO(INFRA-4384): Remove this flag once all dependencies are compatible with
-# the new platforms repo for constraints.
-build --noincompatible_use_platforms_repo_for_constraints

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -158,6 +158,16 @@ def stage_1():
     )
 
     maybe(
+        name = "cython",
+        repo_rule = http_archive,
+        sha256 = "00f97476cef9fcd9a89f9d2a49be3b518e1a74b91f377fe08c97fcb44bc0f7d7",
+        strip_prefix = "cython-3.0.10",
+        urls = [
+            "https://github.com/cython/cython/archive/refs/tags/3.0.10.tar.gz",
+        ],
+    )
+
+    maybe(
         name = "com_github_grpc_grpc",
         repo_rule = http_archive,
         patch_args = ["-p1"],
@@ -277,6 +287,14 @@ filegroup(
         sha256 = "2a0860a336ae836b54671cbbe0710eec17c64ef70c4c5a88ccfd47ea6e3739bd",
         urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/4.6.0/rules_proto_grpc-4.6.0.tar.gz"],
         strip_prefix = "rules_proto_grpc-4.6.0",
+    )
+
+    maybe(
+        name = "aspect_gcc_toolchain",
+        repo_rule = http_archive,
+        sha256 = "b741b99a06fd3289e38f2ed030839b0f4c5e66830bc9b7e6c9f3d08b897ac5b4",
+        urls = ["https://github.com/f0rmiga/gcc-toolchain/archive/4d27f294428dd3286ecea65b9ca9650ceeac37b6.tar.gz"],
+        strip_prefix = "gcc-toolchain-4d27f294428dd3286ecea65b9ca9650ceeac37b6",
     )
 
     # Explicitly load Jsonnet here so that we control the version, instead of

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -4,6 +4,8 @@ See README.md for more information.
 """
 
 load("//bazel/meson:meson.bzl", "meson_register_toolchains")
+load("@aspect_gcc_toolchain//toolchain:repositories.bzl", "gcc_toolchain_dependencies")
+load("@aspect_gcc_toolchain//toolchain:defs.bzl", "ARCHS", "gcc_register_toolchain")
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
@@ -32,6 +34,15 @@ def stage_2():
       dependencies are in stage 2 because they depend on the existence of
       rules_python in a load statement, which is instantiated in stage 1.
     """
+
+    gcc_toolchain_dependencies()
+
+    gcc_register_toolchain(
+        name = "gcc_toolchain_x86_64",
+        sysroot_variant = "x86_64-X11",
+        target_arch = ARCHS.x86_64,
+        gcc_version = "10.3.0",
+    )
 
     py_repositories()
 


### PR DESCRIPTION
This change adds:
- a fetch of an external repository that has WORKSPACE rules for fetching a hermetic GCC toolchain
- a gcc-toolchain-registration for a GCC 10 toolchain
- modifications to default bazel flags to allow for C++ toolchain resolution to work

Tested: `bazel test //...` works

Jira: INFRA-10286