### PR TITLE
Use nomad_job_id as the user process in the table.

### DIFF
--- a/experimental/nomad_resource_plugin/licensedevice/docker/docker.go
+++ b/experimental/nomad_resource_plugin/licensedevice/docker/docker.go
@@ -111,11 +111,9 @@ func (c *Client) GetCurrent(ctx context.Context) ([]*types.License, error) {
 			ids := strings.Split(kv[1], ",")
 			for _, id := range ids {
 				inUse = append(inUse, &types.License{
-					ID:       id,
-					Status:   "IN_USE",
-					UserNode: &c.nodeID,
-					// TODO(scott): If the CJ job ID is added as a container label, we can
-					// fetch that and propagate it instead
+					ID:          id,
+					Status:      "IN_USE",
+					UserNode:    &c.nodeID,
 					UserProcess: &userProcess,
 				})
 			}

--- a/experimental/nomad_resource_plugin/licensedevice/docker/docker.go
+++ b/experimental/nomad_resource_plugin/licensedevice/docker/docker.go
@@ -41,7 +41,8 @@ var (
 )
 
 const (
-	LicenseEnvVar = "LICENSEPLUGIN_RESERVED_IDS"
+	LicenseEnvVar  = "LICENSEPLUGIN_RESERVED_IDS"
+	NomadJobEnvVar = "NOMAD_JOB_ID"
 )
 
 type Client struct {
@@ -93,6 +94,13 @@ func (c *Client) GetCurrent(ctx context.Context) ([]*types.License, error) {
 			metricDockerCounter.WithLabelValues("GetCurrent", "error_container_inspect").Inc()
 			return nil, fmt.Errorf("failed to inspect container %q: %w", container.ID, err)
 		}
+		userProcess := container.ID
+		for _, env := range details.Config.Env {
+			kv := strings.SplitN(env, "=", 2)
+			if kv[0] == NomadJobEnvVar {
+				userProcess = kv[1]
+			}
+		}
 	nextEnv:
 		for _, env := range details.Config.Env {
 			kv := strings.SplitN(env, "=", 2)
@@ -108,7 +116,7 @@ func (c *Client) GetCurrent(ctx context.Context) ([]*types.License, error) {
 					UserNode: &c.nodeID,
 					// TODO(scott): If the CJ job ID is added as a container label, we can
 					// fetch that and propagate it instead
-					UserProcess: &container.ID,
+					UserProcess: &userProcess,
 				})
 			}
 		}

--- a/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
+++ b/experimental/nomad_resource_plugin/licensedevice/sqldb/sqldb.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	QueryAllLicenses      = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state"
-	queryLocalLicenses    = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state WHERE usage_state = 'IN_USE' AND reserved_by_node = $1"
-	querySingleLicense    = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state WHERE id = $1"
-	updateLicenseState    = "UPDATE license_state SET usage_state = $2, last_state_change = $3, reserved_by_node = $4, used_by_process = $5 WHERE id = $1"
-	appendLicenseStateLog = "INSERT INTO license_state_log (license_id, node, ts, previous_state, current_state, reason, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)"
-	listenLicenseState    = "LISTEN license_state_update_channel"
-	NotifyLicenseState    = "NOTIFY license_state_update_channel"
+	QueryAllLicenses          = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state"
+	queryLocalLicenses        = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state WHERE usage_state = 'IN_USE' AND reserved_by_node = $1"
+	querySingleLicense        = "SELECT id, vendor, feature, usage_state, last_state_change, reserved_by_node, used_by_process FROM license_state WHERE id = $1"
+	updateLicenseState        = "UPDATE license_state SET usage_state = $2, last_state_change = $3, reserved_by_node = $4, used_by_process = $5 WHERE id = $1"
+	updateLicenseStateReserve = "UPDATE license_state SET usage_state = $2, last_state_change = $3, reserved_by_node = $4, used_by_process = $5 WHERE id = $1 and usage_state = 'FREE'"
+	appendLicenseStateLog     = "INSERT INTO license_state_log (license_id, node, ts, previous_state, current_state, reason, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)"
+	listenLicenseState        = "LISTEN license_state_update_channel"
+	NotifyLicenseState        = "NOTIFY license_state_update_channel"
 
 	StateFree     = "FREE"
 	stateReserved = "RESERVED"
@@ -149,7 +150,7 @@ func (t *Table) Reserve(ctx context.Context, licenseIDs []string, node string) (
 		})
 	}
 
-	return t.updateLicenses(ctx, tx, licenses, "Reserve() called on device plugin")
+	return t.updateLicenses(ctx, tx, licenses, "Reserve() called on device plugin", true)
 }
 
 func (t *Table) UpdateInUse(ctx context.Context, licenses []*types.License) (retErr error) {
@@ -207,7 +208,7 @@ nextLicense:
 		licenses = append(licenses, localLicense)
 	}
 
-	_, err = t.updateLicenses(ctx, tx, licenses, "detected in scan")
+	_, err = t.updateLicenses(ctx, tx, licenses, "detected in scan", false)
 	if err != nil {
 		metricSqlCounter.WithLabelValues("UpdateInUse", "error_update_licenses").Inc()
 		return fmt.Errorf("failed to update license status: %w", err)
@@ -242,7 +243,7 @@ func (t *Table) getLicenses(ctx context.Context, tx pgx.Tx) ([]*types.License, e
 	return licenses, nil
 }
 
-func (t *Table) updateLicenses(ctx context.Context, tx pgx.Tx, licenses []*types.License, reason string) ([]*types.License, error) {
+func (t *Table) updateLicenses(ctx context.Context, tx pgx.Tx, licenses []*types.License, reason string, reserve bool) ([]*types.License, error) {
 	ret := []*types.License{}
 
 	txTime := time.Now()
@@ -256,13 +257,16 @@ nextLicense:
 			return nil, fmt.Errorf("failed to get current state of license %q: %w", license.ID, err)
 		}
 
-		if dbLicense.Status == license.Status {
+		if !reserve && dbLicense.Status == license.Status {
 			continue nextLicense
 		}
-
+		query := updateLicenseState
+		if reserve {
+			query = updateLicenseStateReserve
+		}
 		tag, err := tx.Exec(
 			ctx,
-			updateLicenseState,
+			query,
 			license.ID,
 			license.Status,
 			txTime,
@@ -274,8 +278,13 @@ nextLicense:
 			return nil, fmt.Errorf("failed to update row for license %q: %w", license.ID, err)
 		}
 		if tag.RowsAffected() != 1 {
-			metricSqlCounter.WithLabelValues("updateLicenses", "error_too_many_rows_affected").Inc()
-			return nil, fmt.Errorf("license reserve affected %d rows; expected exactly one row affected", tag.RowsAffected)
+			if reserve {
+				metricSqlCounter.WithLabelValues("updateLicenses", "attempted_to_reserve_in_use").Inc()
+				return nil, fmt.Errorf("Unable to reserve license %q", license.ID)
+			} else {
+				metricSqlCounter.WithLabelValues("updateLicenses", "error_too_many_rows_affected").Inc()
+				return nil, fmt.Errorf("license reserve affected %d rows; expected exactly one row affected", tag.RowsAffected)
+			}
 		}
 
 		_, err = tx.Exec(


### PR DESCRIPTION
1) Add --reserve test to license manager.
2) If available, use the NOMAD_JOB_ID as the user process.
    
Jira: INFRA-10205
    
Tested: with test tool and in production for the job id.