### PR TITLE
Pull and push containers to/from Artifact Registry

### DIFF
--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -52,9 +52,9 @@ def stage_3():
 
     oci_pull(
         name = "golang_base",
-        digest = "sha256:75f63d4edd703030d4312dc7528a349ca34d48bec7bd754652b2d47e5a0b7873",
-        registry = "gcr.io",
-        repository = "distroless/base",
+        digest = "sha256:a4eefd667af74c5a1c5efe895a42f7748808e7f5cbc284e0e5f1517b79721ccb",
+        registry = "us-docker.pkg.dev",
+        repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
     )
 
     # Begin buildbarn ecosystem dependencies

--- a/bazel/init/stage_4.bzl
+++ b/bazel/init/stage_4.bzl
@@ -22,6 +22,7 @@ def stage_4():
 
     oci_pull(
         name = "container_golang_base",
-        digest = "sha256:75f63d4edd703030d4312dc7528a349ca34d48bec7bd754652b2d47e5a0b7873",
-        image = "gcr.io/distroless/base",
+        digest = "sha256:a4eefd667af74c5a1c5efe895a42f7748808e7f5cbc284e0e5f1517b79721ccb",
+        registry = "us-docker.pkg.dev",
+        repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
     )

--- a/bb_reporter/BUILD.bazel
+++ b/bb_reporter/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "bb_reporter_lib",
@@ -29,7 +29,7 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "bb_reporter_image",
     base = "@container_golang_base",
     entrypoint = [
@@ -40,9 +40,10 @@ oci_image(
     ],
 )
 
-oci_push(
+container_push(
     name = "bb_reporter_image_push",
     image = ":bb_reporter_image",
+    image_path = "services/bb_reporter",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/services/bb_reporter",
 )

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("//bazel/utils/container:container.bzl", "container_push", "container_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
@@ -46,7 +46,7 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "bestie_image",
     base = "@container_golang_base",
     entrypoint = [
@@ -57,9 +57,10 @@ oci_image(
     ],
 )
 
-oci_push(
+container_push(
     name = "bestie_image_push",
     image = ":bestie_image",
+    image_path = "bestie",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/bestie",
+    namespace = "infra",
 )

--- a/bestie/server/BUILD.bazel
+++ b/bestie/server/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//bazel/utils/container:container.bzl", "container_push", "container_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
@@ -46,7 +46,7 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-container_image(
+oci_image(
     name = "bestie_image",
     base = "@container_golang_base",
     entrypoint = [
@@ -57,10 +57,9 @@ container_image(
     ],
 )
 
-container_push(
+oci_push(
     name = "bestie_image_push",
     image = ":bestie_image",
-    image_path = "bestie",
     remote_tags = ["latest"],
-    namespace = "infra",
+    repository = "gcr.io/devops-284019/infra/bestie",
 )

--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "us-docker.pkg.dev/enfabrica-container-images/infra-prod/flextape@sha256:25603b354ca910d70342ed1de3a6f984fe8442337c6019c8e0023c0a6ec866aa"
+  "gcr.io/devops-284019/infra/flextape@sha256:6ae28991bab73296d484127cfa3afecc009ec12df008fdf4703b191714008911"

--- a/flextape/server/run.sh
+++ b/flextape/server/run.sh
@@ -9,4 +9,4 @@ docker run \
   -e "PORT=${PORT}" \
   --name=flextape \
   --restart="always" \
-  "gcr.io/devops-284019/infra/flextape@sha256:6ae28991bab73296d484127cfa3afecc009ec12df008fdf4703b191714008911"
+  "us-docker.pkg.dev/enfabrica-container-images/infra-prod/flextape@sha256:25603b354ca910d70342ed1de3a6f984fe8442337c6019c8e0023c0a6ec866aa"

--- a/infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
+++ b/infra/cloudbuild_staging/enkit_bazel_postsubmit.yml
@@ -8,14 +8,14 @@ build:
     entrypoint: /usr/bin/bazelisk
     env:
     - BAZEL_PROFILE=cloudbuild
-    name: gcr.io/devops-284019/developer:stable
+    name: us-docker.pkg.dev/enfabrica-container-images/infra-prod/developer@sha256:234a6f3523159b9b2d48f96367a160832cb44380743d7e84db78275ac061cb7f
   - args:
     - test
     - //...
     entrypoint: /usr/bin/bazelisk
     env:
     - BAZEL_PROFILE=cloudbuild
-    name: gcr.io/devops-284019/developer:stable
+    name: us-docker.pkg.dev/enfabrica-container-images/infra-prod/developer@sha256:234a6f3523159b9b2d48f96367a160832cb44380743d7e84db78275ac061cb7f
   timeout: 1200s
 createTime: '2021-12-22T17:00:24.852472140Z'
 id: 1b99a715-4526-4a8a-9667-e47f104e8f7d

--- a/infra/cloudbuild_staging/enkit_postsubmit.tf
+++ b/infra/cloudbuild_staging/enkit_postsubmit.tf
@@ -133,13 +133,13 @@ resource "google_cloudbuild_trigger" "build-trigger" {
   
   build {
     step {
-      name = "gcr.io/devops-284019/developer:stable"
+      name = "us-docker.pkg.dev/enfabrica-container-images/infra-prod/developer@sha256:234a6f3523159b9b2d48f96367a160832cb44380743d7e84db78275ac061cb7f"
       entrypoint = "/usr/bin/bazelisk"
       args = ["build", "//..."]
       env = ["BAZEL_PROFILE=cloudbuild"]
     }
     step {
-      name = "gcr.io/devops-284019/developer:stable"
+      name = "us-docker.pkg.dev/enfabrica-container-images/infra-prod/developer@sha256:234a6f3523159b9b2d48f96367a160832cb44380743d7e84db78275ac061cb7f"
       entrypoint = "/usr/bin/bazelisk"
       args = ["test", "//..."]
       env = ["BAZEL_PROFILE=cloudbuild"]

--- a/infra/k8s_dummy/BUILD.bazel
+++ b/infra/k8s_dummy/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "k8s_dummy_lib",
@@ -27,16 +27,17 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "k8s_dummy_image",
     base = "@container_golang_base",
     entrypoint = ["/enfabrica/bin/k8s_dummy"],
     tars = [":k8s_dummy_tar"],
 )
 
-oci_push(
+container_push(
     name = "k8s_dummy_image_push",
     image = ":k8s_dummy_image",
+    image_path = "k8s_dummy",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/k8s_dummy",
 )

--- a/machinist/example/deployment/docker-compose.yml
+++ b/machinist/example/deployment/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   controlplane:
-    image: gcr.io/devops-284019/infra/machinist/controlplane:latest
+    image: us-docker.pkg.dev/enfabrica-container-images/infra-prod/machinist/controlplane@sha256:eee5285a2127f8409ee3cabb48f351b29b3aac5ebf1f9af1cfe5d9436a3ee137
     command:
       - "--state=/enfabrica/dns.state.json"
       - "--dns-port=4455"

--- a/machinist/mserver/cmd/BUILD.bazel
+++ b/machinist/mserver/cmd/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "cmd_lib",
@@ -26,16 +26,17 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "image",
     base = "@container_golang_base",
     entrypoint = ["/enfabrica/bin/cmd"],
     tars = [":tar"],
 )
 
-oci_push(
+container_push(
     name = "image_push",
     image = ":image",
+    image_path = "machinist/controlplane",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/machinist/controlplane",
 )

--- a/monitor/BUILD.bazel
+++ b/monitor/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "monitor_lib",
@@ -34,7 +34,7 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "image",
     base = "@container_golang_base",
     cmd = ["/enfabrica/bin/probes.toml"],
@@ -42,9 +42,10 @@ oci_image(
     tars = [":tar"],
 )
 
-oci_push(
+container_push(
     name = "image_push",
     image = ":image",
+    image_path = "monitor",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/monitor",
 )

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -3,6 +3,6 @@ version: "3.3"
 services:
   monitor:
     network_mode: "host"
-    image: "gcr.io/devops-284019/infra/monitor:monitor-server"
+    image: "us-docker.pkg.dev/enfabrica-container-images/infra-prod/monitor@sha256:0247335422213e260471bf1ff92d741944014803e713fd3f1246cfbd908bf806"
     user: "nobody"
     restart: "unless-stopped"

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "proxy_lib",
@@ -31,7 +31,7 @@ pkg_tar(
     mode = "0755",
 )
 
-oci_image(
+container_image(
     name = "enproxy_image",
     base = "@golang_base",
     entrypoint = ["/enproxy"],
@@ -59,10 +59,11 @@ oci_image(
 #
 # WARNING: before doing so, make sure you have set all the desired
 # defaults as per instructions in the credentials/ directory.
-oci_push(
+container_push(
     name = "upload-enproxy-image",
     image = ":enproxy_image",
+    image_path = "enproxy",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/enproxy",
     visibility = ["//visibility:public"],
 )

--- a/shims/buildbuddy/cmd/BUILD.bazel
+++ b/shims/buildbuddy/cmd/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/utils/container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "cmd_lib",
@@ -25,16 +25,17 @@ pkg_tar(
     package_dir = "/enfabrica/bin",
 )
 
-oci_image(
+container_image(
     name = "image",
     base = "@container_golang_base",
     entrypoint = ["/enfabrica/bin/cmd"],
     tars = [":tar"],
 )
 
-oci_push(
+container_push(
     name = "image_push",
     image = ":image",
+    image_path = "bb-shim",
+    namespace = "infra",
     remote_tags = ["latest"],
-    repository = "gcr.io/devops-284019/infra/bb-shim",
 )


### PR DESCRIPTION
This change updates container build/push targets to use container rules instead of rules_oci.

Tested:
- `bazel test ...:all`
- `bazel build ...:all`

JIRA: INFRA-9581