### PR TITLE
Update visibility so the internal repo can reference enkit targets

### DIFF
--- a/bazel/utils/container/BUILD.bazel
+++ b/bazel/utils/container/BUILD.bazel
@@ -50,13 +50,8 @@ py_binary(
         ":stamp",
         requirement("absl-py"),
     ],
+    # Allow the internal repo to access this target
     visibility = [
-        "//bb_reporter:__subpackages__",
-        "//shims:__subpackages__",
-        "//proxy:__subpackages__",
-        "//bestie:__subpackages__",
-        "//infra:__subpackages__",
-        "//machinist:__subpackages__",
-        "//monitor:__subpackages__",
+        "//visibility:public",
     ],
 )

--- a/bazel/utils/container/BUILD.bazel
+++ b/bazel/utils/container/BUILD.bazel
@@ -1,3 +1,6 @@
+# The directory internal/bazel/utils/container must exist in the internal
+# repo so that dynamically generated targets from the enkit repo can be 
+# referenced locally within the internal repo
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
 
 exports_files(["container_pusher.py"])

--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -93,8 +93,11 @@ def nonhermetic_image_builder(*args, **kwargs):
         name = "{}_labels".format(name),
         outs = [output],
         srcs = [":{}".format(user_labels)],
-        tools = ["//bazel/utils/container:container_stamper"],
-        cmd = "$(location //bazel/utils/container:container_stamper) --user_labels $(location :{}) --output $(location {})".format(user_labels, output),
+        # The full repo path needs to be specified so that when this target is dynamically
+        # created in the internal repo, bazel refers to the container_stamper target in enkit
+        # instead of trying to find it under @enfabrica//bazel/utils/container
+        tools = ["@enkit//bazel/utils/container:container_stamper"],
+        cmd = "$(location @enkit//bazel/utils/container:container_stamper) --user_labels $(location :{}) --output $(location {})".format(user_labels, output),
     )
     kwargs.pop("image_path")
     kwargs.pop("namespace")
@@ -122,8 +125,8 @@ def container_image(*args, **kwargs):
         name = "{}_labels".format(name),
         outs = [output],
         srcs = [":{}".format(user_labels)],
-        tools = ["//bazel/utils/container:container_stamper"],
-        cmd = "$(location //bazel/utils/container:container_stamper) --user_labels $(location :{}) --output $(location {})".format(user_labels, output),
+        tools = ["@enkit//bazel/utils/container:container_stamper"],
+        cmd = "$(location @enkit//bazel/utils/container:container_stamper) --user_labels $(location :{}) --output $(location {})".format(user_labels, output),
     )
     kwargs["labels"] = ":{}_labels".format(name)
     oci_image(*args, **kwargs)


### PR DESCRIPTION
The `container_image` and `container_push` rule dynamically generate targets which bazel references relative to where the target was created. This change explicitly declares the full repo path to dependencies of targets that are dynamically generated so that bazel knows the correct path to resolve.

Tested:
- `bazel run --override_repository=enkit=$HOME/enkit //infra/puppet:puppet_server_image_exec`
- `bazel run --override_repository=enkit=$HOME/enkit //infra/puppet:base_puppet_server_image_builder -- --noclean_build_check`
- `bazel run --override_repository=enkit=$HOME/enkit //infra/puppet:puppet_server_image_push -- --noclean_build_check`

JIRA: INFRA-9581