### PR TITLE
Artifact Registry: Generate a wrapper script to run container_pusher

### DIFF
--- a/bazel/utils/container/BUILD.bazel
+++ b/bazel/utils/container/BUILD.bazel
@@ -34,16 +34,7 @@ py_library(
 py_library(
     name = "exceptions_lib",
     srcs = ["exceptions.py"],
-    visibility = [
-        "//bazel/utils/container:__subpackages__",
-        "//bb_reporter:__subpackages__",
-        "//shims:__subpackages__",
-        "//proxy:__subpackages__",
-        "//bestie:__subpackages__",
-        "//infra:__subpackages__",
-        "//machinist:__subpackages__",
-        "//monitor:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(
@@ -54,6 +45,21 @@ py_binary(
         requirement("absl-py"),
     ],
     # Allow the internal repo to access this target
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+py_binary( 
+    name = "container_pusher",
+    srcs = ["@enkit//bazel/utils/container:container_pusher.py"],
+    main = "@enkit//bazel/utils/container:container_pusher.py",
+    deps = [
+        "@rules_python//python/runfiles",
+        "@enkit//bazel/utils/container:exceptions_lib",
+        requirement("absl-py"),
+        requirement("docker"),
+    ],
     visibility = [
         "//visibility:public",
     ],

--- a/bazel/utils/container/container_pusher.py
+++ b/bazel/utils/container/container_pusher.py
@@ -1,6 +1,7 @@
 """Pushes container images to the dev, staging, and prod container registry"""
 # standard libraries
 import os
+import logging as log
 
 # third party libraries
 import docker
@@ -8,9 +9,24 @@ from absl import app, flags
 from rules_python.python.runfiles import runfiles
 
 FLAGS = flags.FLAGS
+flags.DEFINE_string("dev_script", None, "Script returned by the oci_push rule to push images to the dev repo")
+flags.DEFINE_string("staging_script", None, "Script returned by the oci_push rule to push images to the staging repo")
+flags.DEFINE_string("image_tarball", None, "Image tarball returned by the oci_tarball rule to validate image tags")
+flags.DEFINE_string("namespace", None, "Name of the image repo in Artifact Registry")
+flags.DEFINE_string("image_path", None, "Path under the Artifact Registry repo name")
+flags.DEFINE_string("project", None, "GCP project name")
+flags.DEFINE_string("region", None, "GCP region name")
 flags.DEFINE_bool("official", False, "Build and push the container from a clean master branch")
 flags.DEFINE_bool("clean_build_check", True, "Build and push the container from a clean master branch")
 flags.DEFINE_string("promote", None, "Path to the staging image including the sha256 digest to push to prod")
+
+flags.mark_flag_as_required("dev_script")
+flags.mark_flag_as_required("staging_script")
+flags.mark_flag_as_required("image_tarball")
+flags.mark_flag_as_required("namespace")
+flags.mark_flag_as_required("image_path")
+flags.mark_flag_as_required("project")
+flags.mark_flag_as_required("region")
 
 
 def validate_image(docker_client, tarball):
@@ -29,28 +45,31 @@ def promote_image(docker_client, staging_image_path, region, project, namespace,
 
 def container_pusher(docker_client, official, clean_build_check, promote):
     r = runfiles.Create()
-    dev_script = r.Rlocation("{}/{}".format(os.getenv("RUNFILES_ROOT"), os.getenv("DEV_PUSH_SCRIPT")))
-    staging_script = r.Rlocation("{}/{}".format(os.getenv("RUNFILES_ROOT"), os.getenv("STAGING_PUSH_SCRIPT")))
-    tarball = r.Rlocation("{}/{}".format(os.getenv("RUNFILES_ROOT"), os.getenv("LOCAL_IMAGE_TARBALL")))
-    region = os.getenv("REGION")
-    project = os.getenv("PROJECT")
-    namespace = os.getenv("NAMESPACE")
-    suffix = os.getenv("IMAGE_PATH")
+    dev_script = r.Rlocation(f"enfabrica/{FLAGS.dev_script}")
+    staging_script = r.Rlocation(f"enfabrica/{FLAGS.staging_script}")
+    tarball = r.Rlocation(f"enfabrica/{FLAGS.image_tarball}")
+    region = FLAGS.region
+    project = FLAGS.project
+    namespace = FLAGS.namespace
+    suffix = FLAGS.image_path
 
     # push container image to the staging repo
     if official:
         if clean_build_check:
             validate_image(docker_client, tarball)
+        log.info(f"Executing {staging_script}")
         os.execvp(staging_script, [staging_script])
     # push container image to the prod repo
     elif promote:
         if clean_build_check:
             validate_image(docker_client, tarball)
+        log.info(f"Promoting image {promote} to prod")
         promote_image(docker_client, promote, region, project, namespace, suffix)
     # push container image to the dev repo
     else:
         if clean_build_check:
             validate_image(docker_client, tarball)
+        log.info(f"Executing {dev_script}")
         os.execvp(dev_script, [dev_script])
 
 

--- a/bazel/utils/container/muk/BUILD.bazel
+++ b/bazel/utils/container/muk/BUILD.bazel
@@ -12,6 +12,7 @@ py_binary(
         requirement("absl-py"),
         requirement("docker"),
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_proto_library(


### PR DESCRIPTION
This change modifies the `container_pusher` rule to generate a wrapper script to execute the tool instead of passing arguments to the tool via environment variables. Doing so allows bazel to determine the path of dependencies when targets in the internal repo execute container rules defined in the enkit repo.

Tested:
From the internal repo, I ran the following:
- `bazel run --override_repository=enkit=$HOME/enkit //infra/smoketest:disk_benchmark_image_push -- --noclean_build_check`
- `bazel run --override_repository=enkit=$HOME/enkit //infra/smoketest:infra_benchmark_image_builder -- --noclean_build_check`

JIRA: INFRA-10279