### PR TITLE
bazel/utils/merge_kwargs.bzl: fix latent bug in merging dicts or dicts

### DIFF
--- a/bazel/utils/merge_kwargs.bzl
+++ b/bazel/utils/merge_kwargs.bzl
@@ -24,13 +24,13 @@ def merge_kwargs(d1, d2, limit = 5):
                     m[k] = list(d[k])
                     continue
 
-                if type(d[k]) == "dict":
-                    m[k] = dict(d[k])
+                if type(d[k]) != "dict":
+                    # neither list nor dict, must be scalar:
+                    m[k] = d[k]
                     continue
 
-                # type must be scalar:
-                m[k] = d[k]
-                continue
+                # Let the next if fill the dict by recursively expanding the values.
+                m[k] = {}
 
             if type(m[k]) == "dict":
                 expand_next.extend([(m[k], d[k], k2) for k2 in d[k]])

--- a/bazel/utils/merge_kwargs_test.bzl
+++ b/bazel/utils/merge_kwargs_test.bzl
@@ -42,7 +42,7 @@ def _merge_kwargs_test_impl(ctx):
     env = unittest.begin(ctx)
     got = "\n".join(["%r" % merged for merged in _create_test_data()])
     merged13 = '{"alpha": 200, "beta": [1, 2, 3, 4, 5, 6], "delta": {"d1": 11, "d2": 20, "d3": 30, "d4": 40, "d5": 50}, "gamma": {"g1": [55, 56, 57, 58, 59], "g2": {"g2a": 3, "g2b": 2, "g2c": 4}}}'
-    merged2 = '{"alpha": 300, "beta": [1, 2, 3, 9], "delta": {"d1": 10, "d2": 20, "d3": 30}, "gamma": {"g1": [55, 56, 57, 58, 59], "g2": {"g2a": 3, "g2b": 2, "g2c": 4}, "g3": 7}}'
+    merged2 = '{"alpha": 300, "beta": [1, 2, 3, 9], "delta": {"d1": 10, "d2": 20, "d3": 30}, "gamma": {"g1": [55, 56, 57], "g2": {"g2a": 1, "g2b": 2}, "g3": 7}}'
     want = "\n".join((merged13, merged2, merged13))
     asserts.equals(env, want, got)
     return unittest.end(env)


### PR DESCRIPTION
Problem:
When you have a source dict like {"key": { ... another dict ...}} where
"key" does NOT exist in the destination dict, the inner dict is copied as
is, with a simple `dict(source["key"])` pretty much (outer dict is NEW,
independent, inner DICT is shared between SOURCE and DEST).

This is BAD: if the INNER dict is later modified, the SOURCE dict is also
modified. This was caught by @salil-enf in https://github.com/enfabrica/internal/pull/37246/commits/af987146705c809679404778d36b1dccfa22d4cf,
as bazel complained about a READ ONLY / FROZEN dict being modified.

In this PR:
- make dicts always recursively copied
- update unit tests

Fun fact:
The unit test was actually catching the bug, I suspect when I originally
edited it I paid attention to the first dict and last dict, but not
the middle one - so did not notice that the second dict was also getting
changes from the first edit! Wrong!
