### PR TITLE
Add support for cross compiling enf.ko for aarch64

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -1,4 +1,5 @@
 load("//bazel/linux:providers.bzl", "KernelBundleInfo", "KernelImageInfo", "KernelModulesInfo", "KernelTreeInfo", "RootfsImageInfo", "RuntimeBundleInfo")
+load("//bazel/linux/platforms:defs.bzl", "kernel_aarch64_transition", "kernel_aarch64_constraints")
 load("//bazel/linux:utils.bzl", "expand_deps", "get_compatible", "is_module")
 load("//bazel/linux:test.bzl", "kunit_test")
 load("//bazel/linux:uml.bzl", "kernel_uml_run")
@@ -9,141 +10,152 @@ def _kernel_modules(ctx):
     modules = ctx.attr.modules
     srcdir = ctx.file.makefile.dirname
 
-    if not ctx.attr.archs:
-        fail(location(ctx) + "rule must specify one or more architectures in 'arch'")
-
     ki = ctx.attr.kernel[KernelTreeInfo]
     bundled = []
-    for arch in ctx.attr.archs:
-        inputs = ctx.files.srcs + ctx.files.kernel
-        includes = []
-        quote_includes = []
-        extra_symbols = []
 
-        kdeps = []
-        for d in ctx.attr.kdeps:
-            kdeps.extend(get_compatible(ctx, arch, ki.package, d))
+    inputs = ctx.files.srcs + ctx.files.kernel
+    includes = []
+    quote_includes = []
+    extra_symbols = []
 
-        for d in ctx.attr.deps:
-            inputs.extend(d.files.to_list())
+    kdeps = []
+    for d in ctx.attr.kdeps:
+        kdeps.extend(get_compatible(ctx, ki.arch, ki.package, d))
 
-            if not is_module(d):
-                if CcInfo in d:
-                    inputs += d[CcInfo].compilation_context.headers.to_list()
-                    includes += d[CcInfo].compilation_context.includes.to_list()
-                    quote_includes += d[CcInfo].compilation_context.quote_includes.to_list()
-            else:
-                mods = get_compatible(ctx, arch, ki.package, d)
+    for d in ctx.attr.deps:
+        inputs.extend(d.files.to_list())
 
-                kdeps.extend(mods)
-                for mod in mods:
-                    extra_symbols.extend([f for f in mod.files if f.extension == "symvers"])
-
-        outputs = []
-        message = ""
-        copy_command = ""
-        for m in modules:
-            message += "kernel: compiling %s for arch:%s kernel:%s" % (m, arch, ki.package)
-
-            # ctx.attr.name is $kernel-$original_bazel_rule_name
-            outfile = "{kernel}/{name}/{arch}/{module}".format(
-                kernel = ki.name,
-                name = ctx.attr.name.removeprefix(ki.name + "-"),
-                arch = arch,
-                module = m,
-            )
-
-            output = ctx.actions.declare_file(outfile)
-            outputs += [output]
-            copy_command += "cp {src_dir}/{module} {output_long} && ".format(
-                src_dir = srcdir,
-                module = m,
-                output_long = output.path,
-            )
-
-            output = ctx.actions.declare_file(outfile + ".symvers")
-            outputs += [output]
-            copy_command += "cp {src_dir}/Module.symvers {output_long} && ".format(
-                src_dir = srcdir,
-                output_long = output.path,
-            )
-        copy_command += "true"
-
-        kernel_build_dir = "{kr}/{kb}".format(kr = ki.root, kb = ki.build)
-
-        extra = []
-        if arch != "host":
-            extra.append("ARCH=" + arch)
-        if ctx.attr.extra:
-            extra += ctx.attr.extra
-
-        extra_symbols = " ".join(["$PWD/" + e.path for e in extra_symbols])
-
-        if extra_symbols:
-            extra.append("KBUILD_EXTRA_SYMBOLS=\"%s\"" % (extra_symbols))
-
-        if ctx.attr.silent:
-            silent = "-s"
+        if not is_module(d):
+            if CcInfo in d:
+                inputs += d[CcInfo].compilation_context.headers.to_list()
+                includes += d[CcInfo].compilation_context.includes.to_list()
+                quote_includes += d[CcInfo].compilation_context.quote_includes.to_list()
         else:
-            silent = ""
+            mods = get_compatible(ctx, ki.arch, ki.package, d)
 
-        if ctx.attr.jobs == -1:
-            jobs = "-j$(nproc)"
-        else:
-            jobs = "-j%d" % ctx.attr.jobs
+            kdeps.extend(mods)
+            for mod in mods:
+                extra_symbols.extend([f for f in mod.files if f.extension == "symvers"])
 
-        make_args = ctx.attr.make_format_str.format(
+    outputs = []
+    message = ""
+    copy_command = ""
+    for m in modules:
+        message += "kernel: compiling %s for arch:%s kernel:%s" % (m, ki.arch, ki.package)
+
+        # ctx.attr.name is $kernel-$original_bazel_rule_name
+        outfile = "{kernel}/{name}/{arch}/{module}".format(
+            kernel = ki.name,
+            name = ctx.attr.name.removeprefix(ki.name + "-"),
+            arch = ki.arch,
+            module = m,
+        )
+
+        output = ctx.actions.declare_file(outfile)
+        outputs += [output]
+        copy_command += "cp {src_dir}/{module} {output_long} && ".format(
             src_dir = srcdir,
-            kernel_build_dir = kernel_build_dir,
-            modules = " ".join(modules),
+            module = m,
+            output_long = output.path,
         )
 
-        compilation_mode = ctx.var["COMPILATION_MODE"]
-        if compilation_mode == "fastbuild":
-            cflags = "-g"
-        elif compilation_mode == "opt":
-            cflags = ""
-        elif compilation_mode == "dbg":
-            cflags = "-g -O1 -fno-inline"
-        else:
-            fail("compilation mode '{compilation_mode}' not supported".format(
-                compilation_mode = compilation_mode,
-            ))
-
-        # Force GCC to produce colored output
-        cflags += " -fdiagnostics-color=always"
-
-        for include in depset(includes).to_list():
-            cflags += " -I $PWD/%s" % include
-
-        for include in depset(quote_includes).to_list():
-            cflags += " -iquote $PWD/%s" % include
-
-        extra.append("EXTRA_CFLAGS+=\"%s\"" % cflags)
-
-        ctx.actions.run_shell(
-            mnemonic = "KernelBuild",
-            progress_message = message,
-            command = "make {silent} {jobs} {make_args} {extra_args} && {copy_command}".format(
-                silent = silent,
-                jobs = jobs,
-                make_args = make_args,
-                extra_args = " ".join(extra),
-                copy_command = copy_command,
-            ),
-            outputs = outputs,
-            inputs = inputs,
-            use_default_shell_env = True,
+        output = ctx.actions.declare_file(outfile + ".symvers")
+        outputs += [output]
+        copy_command += "cp {src_dir}/Module.symvers {output_long} && ".format(
+            src_dir = srcdir,
+            output_long = output.path,
         )
+    copy_command += "true"
 
-        bundled.append(KernelModulesInfo(
-            label = ctx.label,
-            arch = arch,
-            package = ki.package,
-            files = outputs,
-            kdeps = kdeps,
-            setup = ctx.attr.setup,
+    kernel_build_dir = "{kr}/{kb}".format(kr = ki.root, kb = ki.build)
+
+    extra = []
+    tools = []
+    if ki.arch != "host":
+        arch = ki.arch
+        # map aarch64 to arm64.  The kernel uses arm64, bazel uses aarch64. sigh.
+        if arch == "aarch64":
+            arch = "arm64"
+        extra.append("ARCH=" + arch)
+
+        toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc
+        tools = toolchain.all_files
+
+        # The compiler ends in "gcc", which we strip off to obtain the compiler prefix.
+        compiler_prefix = toolchain.compiler_executable[:-3]
+        extra.append("CROSS_COMPILE=$PWD/{}".format(compiler_prefix))
+
+    if ctx.attr.extra:
+        extra += ctx.attr.extra
+
+    extra_symbols = " ".join(["$PWD/" + e.path for e in extra_symbols])
+
+    if extra_symbols:
+        extra.append("KBUILD_EXTRA_SYMBOLS=\"%s\"" % (extra_symbols))
+
+    if ctx.attr.silent:
+        silent = "-s"
+    else:
+        silent = ""
+
+    if ctx.attr.jobs == -1:
+        jobs = "-j$(nproc)"
+    else:
+        jobs = "-j%d" % ctx.attr.jobs
+
+    make_args = ctx.attr.make_format_str.format(
+        src_dir = srcdir,
+        kernel_build_dir = kernel_build_dir,
+        modules = " ".join(modules),
+    )
+
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    if compilation_mode == "fastbuild":
+        cflags = "-g"
+    elif compilation_mode == "opt":
+        cflags = ""
+    elif compilation_mode == "dbg":
+        cflags = "-g -O1 -fno-inline"
+    else:
+        fail("compilation mode '{compilation_mode}' not supported".format(
+            compilation_mode = compilation_mode,
         ))
+
+    # Force GCC to produce colored output
+    cflags += " -fdiagnostics-color=always"
+
+    for include in depset(includes).to_list():
+        cflags += " -I $PWD/%s" % include
+
+    for include in depset(quote_includes).to_list():
+        cflags += " -iquote $PWD/%s" % include
+
+    extra.append("EXTRA_CFLAGS+=\"%s\"" % cflags)
+
+    ctx.actions.run_shell(
+        mnemonic = "KernelBuild",
+        progress_message = message,
+        command = "EXT_BUILD_ROOT=$PWD make {silent} {jobs} {make_args} {extra_args} && {copy_command}".format(
+            silent = silent,
+            jobs = jobs,
+            make_args = make_args,
+            extra_args = " ".join(extra),
+            copy_command = copy_command,
+        ),
+        outputs = outputs,
+        inputs = inputs,
+        use_default_shell_env = True,
+        tools = tools,
+    )
+
+    bundled.append(KernelModulesInfo(
+        label = ctx.label,
+        arch = ki.arch,
+        package = ki.package,
+        files = outputs,
+        kdeps = kdeps,
+        setup = ctx.attr.setup,
+    ))
 
     return [
         DefaultInfo(
@@ -176,10 +188,6 @@ whatever you do when not debugging flaky builds.
             mandatory = True,
             providers = [DefaultInfo, KernelTreeInfo],
             doc = "The kernel to build this module against. A string like @carlo-s-favourite-kernel, referencing a kernel_tree_version(name = 'carlo-s-favourite-kernel', ...",
-        ),
-        "archs": attr.string_list(
-            default = ["host"],
-            doc = "The set of architectures supported by this module. Only the architectures needed will be built",
         ),
         "makefile": attr.label(
             mandatory = True,
@@ -229,14 +237,10 @@ Available format values are:
             doc = "The list of files that constitute this module. Generally a glob for all .c and .h files. If you use **/* with glob, we recommend excluding the patterns defined by BUILD_LEFTOVERS.",
         ),
     },
+    toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
 )
-
-def _normalize_kernel(kernel):
-    """Ensures a kernel string points to a repository rule, with bazel @ syntax."""
-    if not kernel.startswith("@"):
-        kernel = "@" + kernel
-
-    return kernel
 
 def _kernel_modules_bundle(ctx):
     modules = []
@@ -303,6 +307,51 @@ expanded in its list of modules.""",
 
 BUILD_LEFTOVERS = ["**/.*.cmd", "**/*.a", "**/*.o", "**/*.ko", "**/*.order", "**/*.symvers", "**/*.mod", "**/*.mod.c", "**/*.mod.o"]
 
+def _normalize_kernel(kernel_tree_label):
+    """Ensures a kernel string points to a repository rule, with bazel @ syntax."""
+
+    if not kernel_tree_label.startswith("@"):
+        kernel_tree_label = "@" + kernel_tree_label
+
+    # kernel_tree_string: a flat string that can be used to create other labels
+    # The label might have '@', slashes ('/'), and colons (':'). Remove those.
+    kernel_tree_string = kernel_tree_label.replace("@", "").replace("//:", "-").replace("/", "-")
+
+    arch = "host"
+    # this is janky, but if the label contains the string "arm64" or
+    # "aarch64" force the architecture to aarch64.  Really at this
+    # macro level we would like to peak inside the KernelTreeInfo
+    # provider to learn the CPU architecture.
+    if (kernel_tree_string.count("arm64") + kernel_tree_string.count("aarch64")) > 0:
+        arch = "aarch64"
+
+    return (kernel_tree_label, kernel_tree_string, arch)
+
+def _gen_module_rule(arch, *args, **kwargs):
+    if arch == "host":
+        kernel_modules_rule(*args, **kwargs)
+        return
+
+    if arch != "aarch64":
+        fail("Unknown architecture: " + arch)
+
+    kwargs["target_compatible_with"] =  kernel_aarch64_constraints
+
+    # underlying module rule needs a different name as the top level
+    # transition rule will use the original name.
+    original = kwargs["name"]
+    arch_module_name = original + "-" + arch
+    kwargs["name"] = arch_module_name
+
+    # put down original module rule
+    kernel_modules_rule(*args, **kwargs)
+
+    # add a transition with the original name
+    kernel_aarch64_transition(
+        name = original,
+        target = ":" + arch_module_name,
+    )
+
 def _kernel_module_targets(*args, **kwargs):
     """Common kernel module target setup."""
 
@@ -318,19 +367,21 @@ def _kernel_module_targets(*args, **kwargs):
         kernels.append(kwargs.pop("kernel"))
 
     if len(kernels) == 1:
-        kwargs["kernel"] = _normalize_kernel(kernels.pop())
-        return kernel_modules_rule(*args, **kwargs)
+        (kernel_tree_label, unused, arch) = _normalize_kernel(kernels.pop())
+        kwargs["kernel"] = kernel_tree_label
+        _gen_module_rule(arch, *args, **kwargs)
+        return
 
     targets = []
     original = kwargs["name"]
     for kernel in kernels:
-        kernel = _normalize_kernel(kernel)
-        name = kernel[1:] + "-" + original
+        (kernel_tree_label, kernel_tree_string, arch) = _normalize_kernel(kernel)
+        name = kernel_tree_string + "-" + original
         targets.append(":" + name)
 
         kwargs["name"] = name
-        kwargs["kernel"] = kernel
-        kernel_modules_rule(*args, **kwargs)
+        kwargs["kernel"] = kernel_tree_label
+        _gen_module_rule(arch, *args, **kwargs)
 
     # This creates a target with the name chosen by the user that
     # builds all the modules for all the requested kernels at once.
@@ -357,10 +408,10 @@ def kernel_module(*args, **kwargs):
             name ensuring it has a '.ko' suffix.
       makefile: string, name of the makefile to build the module. If not specified, kernel_module
             assumes it is just called Makefile.
-      kernel: a label, indicating the kernel_tree to build the module against. kernel_module ensures
-            the label starts with an '@', as per bazel convention.
-      kernels: list of kernel (same as above). kernel_module will instantiate multiple
-            kernel_module_rule, one per kernel, and ensure they all build in parallel.
+      kernel: a kernel tree, indicating the kernel source tree, CPU architecture,
+            and kernel configuration to build the module against.
+      kernels: list of kernel trees (same as above). kernel_module will instantiate multiple
+            kernel_module_rule, one per kernel spec, and ensure they all build in parallel.
     """
 
     if "makefile" not in kwargs:
@@ -381,6 +432,7 @@ def _kernel_tree(ctx):
     return [DefaultInfo(files = depset(ctx.files.files)), KernelTreeInfo(
         name = ctx.attr.name,
         package = ctx.attr.package,
+        arch = ctx.attr.arch,
         root = ctx.label.workspace_root,
         build = ctx.attr.build,
     )]
@@ -422,6 +474,10 @@ Example:
         "package": attr.string(
             mandatory = True,
             doc = "A string indicating which package this kernel is coming from.",
+        ),
+        "arch": attr.string(
+            doc = "Architecture this tree was built for. Will only accept moudules for this arch.",
+            default = "host",
         ),
         "build": attr.string(
             mandatory = True,

--- a/bazel/linux/platforms/BUILD.bazel
+++ b/bazel/linux/platforms/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//bazel/linux/platforms:defs.bzl", "kernel_aarch64_constraints")
+
+platform(
+    name = "kernel_aarch64",
+    constraint_values = kernel_aarch64_constraints,
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/bazel/linux/platforms/defs.bzl
+++ b/bazel/linux/platforms/defs.bzl
@@ -1,0 +1,45 @@
+load("//bazel/linux:providers.bzl", "KernelBundleInfo")
+
+# List of constraints for aarch64 kernel module building.  This is
+# used during toolchain resolution.
+kernel_aarch64_constraints = [
+    "@platforms//cpu:aarch64",
+    "@platforms//os:linux",
+]
+
+def _kernel_aarch64_transition_impl(settings, attr):
+    return {
+        "//command_line_option:platforms": "//bazel/linux/platforms:kernel_aarch64",
+    }
+
+# A transition to the kernel_aarch64 platform
+_kernel_aarch64_transition = transition(
+    implementation = _kernel_aarch64_transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:platforms",
+    ],
+)
+
+def _kernel_module_passthrough(ctx):
+    # Unfortuanetly we cannot iterate through the providers in a Target, so add support for
+    # the providers we know about.
+    bundle_info = [target[KernelBundleInfo] for target in ctx.attr.target if KernelBundleInfo in target]
+
+    return [DefaultInfo(
+        files = depset(
+            [],
+            transitive = [target[DefaultInfo].files for target in ctx.attr.target],
+        ),
+    )] + bundle_info
+
+kernel_aarch64_transition = rule(
+    implementation = _kernel_module_passthrough,
+    attrs = {
+        "target": attr.label(cfg = _kernel_aarch64_transition),
+        "_allowlist_function_transition": attr.label(
+            doc = "bazel magic that allows transitions to work",
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/bazel/linux/providers.bzl
+++ b/bazel/linux/providers.bzl
@@ -10,6 +10,7 @@ a kernel_tree on its own is not expected to be hermetic.
         "package": "A string indicating which package this kernel is coming from. For example, 'centos-kernel-5.3.0-1'.",
         "root": "Bazel directory containing the root of the kernel tree. This is generally the location of the top level BUILD.bazel file. For example, external/@centos-kernel-5.3.0-1.",
         "build": "Relative path of subdirectory to enter to build a kernel module. It is generally the 'build' parameter passed to the kernel_tree rule. For example, lib/modules/centos-kernel-5.3.0-1/build.",
+        "arch": "CPU architecture the tree is prepared for",
     },
 )
 

--- a/bazel/linux/templates/kernel_tree.BUILD.bzl
+++ b/bazel/linux/templates/kernel_tree.BUILD.bzl
@@ -2,7 +2,7 @@ filegroup(
     name = "{name}-tree",
     # Why allow_empty = True? To support compatibility with different package formats,
     # they may expand the content in different directories, and not use others.
-    srcs = glob(["lib", "usr", "install"], allow_empty = True, exclude_directories = 0),
+    srcs = glob(["lib", "usr", "install", "source"], allow_empty = True, exclude_directories = 0),
     visibility = [
         "//visibility:public",
     ],
@@ -13,6 +13,7 @@ load("{utils}", "kernel_tree")
 kernel_tree(
     name = "{name}",
     package = "{package}",
+    arch = "{arch}",
     files = [":{name}-tree"],
     build = "{build_path}",
     visibility = [

--- a/kbuild/v2/README.adoc
+++ b/kbuild/v2/README.adoc
@@ -7,25 +7,27 @@ astore.
 
 == TL;DR -- Building For Production
 
-Current as of 05/16/2022:
+Current as of 06/06/2024:
 
-To publish the kernel artifacts, run `kpub-astore` like this:
+To build and publish the amd64 and arm64 kernel artifacts, run
+`kpub-astore` like this:
 
-  $ kpub-astore -b enf/impish-19.19 -l ENF_UBUNTU_IMPISH -a kernel
+  $ kpub-astore -b enf-6.3.12 -l ENF_UBUNTU_IMPISH -a kernel
 
 The `-b` option specifies the git branch in the kernel tree. Here we
-are using `enf/impish-19.19`.
+are using `enf-6.3.12`.
 
 The `-l` option specifies the Bazel kernel label, which is used to
 form various Bazel variables.  Here we are using `ENF_UBUNTU_IMPISH`.
 
-The `-a` option specifies the root path in astore.  For a kernel
-flavour, the artifacts are published to
-`<astore_root>/<git-branch>/<flavour>`.  Here we are using the
-production path `kernel`, which will publish artifacts to the
-following paths:
+The `-a` option specifies the root path in astore.
 
-  kernel/enf/impish-19.19/generic  (Ubuntu generic)
+The artifacts are published to `<astore_root>/<git-branch>`.  Here we
+are using the production path `kernel`, which will publish artifacts
+to the following paths:
+
+  kernel/enf-6.3.12/generic         (Ubuntu amd64-generic)
+  kernel/enf-6.3.12/arm64/emulator  (Ubuntu arm64-emulator)
 
 The build outputs a Bazel file, suitable for checking into the
 internal repo in `bazel/kernel.version.bzl`.
@@ -67,7 +69,8 @@ The inputs to `kpub-astore` are:
 
 - A git branch to check out and build.
 
-- A list of Ubuntu-style kernel flavours to build.
+- A list of "kernel specs", which are CPU architectures and
+  Ubuntu-style kernel flavours to build.
 
 - A scratch directory to use for downloading and building.
 
@@ -114,6 +117,15 @@ following arguments:
 This is a tarball of the kernel vmlinuz image and all the modules from
 `lib/modules/<kernel-version>`.  This tarball is used by bazel to run
 tests using QEMU.
+
+=== ARM64 Only: A Tarball of a kernel module build area and kernel Image
+
+This output contains the following:
+
+- a build directory that is to be used for building out of tree kernel
+  modules.
+
+- The kernel image.
 
 == Install Kernel Packages via APT
 

--- a/kbuild/v2/kpub-astore
+++ b/kbuild/v2/kpub-astore
@@ -6,6 +6,8 @@ set -e
 
 TOOL_PATH="$(dirname $(realpath $0))"
 SCRIPT_PATH="${TOOL_PATH}/scripts"
+LIB_SH="${SCRIPT_PATH}/lib.sh"
+. $LIB_SH
 
 # KERNEL_REPO: enf-linux kernel repo
 DEFAULT_KERNEL_REPO="git@github.com:enfabrica/linux.git"
@@ -13,8 +15,8 @@ DEFAULT_KERNEL_REPO="git@github.com:enfabrica/linux.git"
 # KERNEL_BRANCH: enf-linux kernel branch to build
 DEFAULT_KERNEL_BRANCH="enf/impish-19.19"
 
-# KERNEL_FLAVOURS: space separated list of kernel flavours to build
-DEFAULT_KERNEL_FLAVOURS="generic"
+# KERNEL_SPECS: space separated list of kernel flavours to build
+DEFAULT_KERNEL_SPECS="amd64,generic arm64,emulator"
 
 # BUILD_ROOT -- scratch space to perform the build
 DEFAULT_BUILD_ROOT="${HOME}/scratch/kernel-builder"
@@ -41,7 +43,7 @@ DEFAULT_VERBOSE="no"
 
 RT_KERNEL_REPO="${ENF_KERNEL_REPO:-${DEFAULT_KERNEL_REPO}}"
 RT_KERNEL_BRANCH="${ENF_KERNEL_BRANCH:-${DEFAULT_KERNEL_BRANCH}}"
-RT_KERNEL_FLAVOURS="${ENF_KERNEL_FLAVOURS:-${DEFAULT_KERNEL_FLAVOURS}}"
+RT_KERNEL_SPECS="${ENF_KERNEL_SPECS:-${DEFAULT_KERNEL_SPECS}}"
 RT_BUILD_ROOT="${ENF_BUILD_ROOT:-${DEFAULT_BUILD_ROOT}}"
 RT_ENKIT="${ENF_ENKIT:-${DEFAULT_ENKIT}}"
 RT_ASTORE_ROOT="${ENF_ASTORE_ROOT:-${DEFAULT_ASTORE_ROOT}}"
@@ -67,14 +69,14 @@ OPTIONS:
 
 		The default is "$DEFAULT_KERNEL_BRANCH".
 
-    -f flavours
+    -s kernel specs
 
-		A space separated list of kernel flavours
-		(configurations) to build.  See
-		debian.master/rules.d/amd64.mk in the kernel
+		A space separated list of kernel specs
+		(configurations) to build.  Takes the form <ARCH>,<FLAVOUR>.
+		See debian.master/rules.d/<arch>.mk in the kernel
 		repo for a list of available flavours.
 
-		The default is "$DEFAULT_KERNEL_FLAVOURS".
+		The default is "$DEFAULT_KERNEL_SPECS".
 
     -o output build directory
 
@@ -125,7 +127,7 @@ The above options can also be set via environment variables:
 
 ENF_KERNEL_REPO:      (current_value: ${ENF_KERNEL_REPO:-unset})
 ENF_KERNEL_BRANCH:    (current_value: ${ENF_KERNEL_BRANCH:-unset})
-ENF_KERNEL_FLAVOURS:  (current_value: ${ENF_KERNEL_FLAVOURS:-unset})
+ENF_KERNEL_SPECS:     (current_value: ${ENF_KERNEL_SPECS:-unset})
 ENF_KERNEL_LABEL:     (current_value: ${ENF_KERNEL_LABEL:-unset})
 ENF_BUILD_ROOT:	      (current_value: ${ENF_BUILD_ROOT:-unset})
 ENF_ENKIT:            (current_value: ${ENF_ENKIT:-unset})
@@ -137,7 +139,7 @@ EOF
 }
 
 # Command line argument override any environment variables
-while getopts hvpr:b:f:o:e:a:l: opt ; do
+while getopts hvpr:b:s:o:e:a:l: opt ; do
     case $opt in
         r)
             RT_KERNEL_REPO=$OPTARG
@@ -145,8 +147,8 @@ while getopts hvpr:b:f:o:e:a:l: opt ; do
         b)
             RT_KERNEL_BRANCH=$OPTARG
             ;;
-        f)
-            RT_KERNEL_FLAVOURS=$OPTARG
+        s)
+            RT_KERNEL_SPECS=$OPTARG
             ;;
         o)
             RT_BUILD_ROOT=$OPTARG
@@ -179,7 +181,7 @@ done
 shift `expr $OPTIND - 1`
 
 echo "Using configuration:"
-for var in RT_KERNEL_REPO RT_KERNEL_BRANCH RT_KERNEL_FLAVOURS RT_KERNEL_LABEL \
+for var in RT_KERNEL_REPO RT_KERNEL_BRANCH RT_KERNEL_SPECS RT_KERNEL_LABEL \
        RT_BUILD_ROOT RT_ENKIT RT_ASTORE_ROOT RT_CLEAN_BUILD RT_VERBOSE; do
     printf "%-20s:   %s\n" "$var" "$(eval echo -n \$$var)"
 done
@@ -204,50 +206,57 @@ fi
 
 # These directories and files are intermediate build artifacts used by
 # the scripts.
-KBUILD_DIR="$RT_BUILD_ROOT/build"
-KERNEL_DIR="${KBUILD_DIR}/enf-linux"
-KERNEL_VERSION="${RT_BUILD_ROOT}/kernel-version.txt"
-OUTPUT_DEB_DIR="$RT_BUILD_ROOT/deb"
-OUTPUT_REPO_DIR="$RT_BUILD_ROOT/repo"
-OUTPUT_BAZEL_ARCHIVE_DIR="$RT_BUILD_ROOT/bazel-archive"
-OUTPUT_APT_ARCHIVE_DIR="$RT_BUILD_ROOT/deb-archive"
-OUTPUT_ASTORE_META_DIR="$RT_BUILD_ROOT/astore-meta"
 
-mkdir -p "$KERNEL_DIR" "$OUTPUT_ASTORE_META_DIR"
+KERNEL_SRC_DIR="${RT_BUILD_ROOT}/ksrc"
+KERNEL_VERSION="${RT_BUILD_ROOT}/kernel-version.txt"
+ASTORE_META_DIR="$RT_BUILD_ROOT/astore-meta"
+
+KBUILD_DIR="$RT_BUILD_ROOT/build"
+
+KERNEL_BUILD_DIR="${KBUILD_DIR}/kbuild"
+OUTPUT_KRELEASE_DIR="$RT_BUILD_ROOT/krelease"
+
+mkdir -p "$KERNEL_SRC_DIR" "$ASTORE_META_DIR"
 
 # Initialize the build area and clone the kernel repo
-$RUN ${SCRIPT_PATH}/init-build.sh "$KERNEL_DIR" "$RT_KERNEL_REPO" "$RT_KERNEL_BRANCH" "$KERNEL_VERSION"
+$RUN ${SCRIPT_PATH}/init-build.sh "$KERNEL_SRC_DIR" "$RT_KERNEL_REPO" "$RT_KERNEL_BRANCH" "$KERNEL_VERSION"
 
-# Builds the .deb kernel packages for all flavours
-$RUN ${SCRIPT_PATH}/build-debs.sh "$KERNEL_DIR" "$KERNEL_VERSION" "$RT_KERNEL_FLAVOURS" "$OUTPUT_DEB_DIR"
+for spec in $RT_KERNEL_SPECS ; do
+    arch=$(get_arch $spec)
+    flavour=$(get_flavour $spec)
 
-# Creates a portable Debian APT repository for each flavour
-$RUN ${SCRIPT_PATH}/repo-deb.sh "$OUTPUT_DEB_DIR" "$RT_KERNEL_FLAVOURS" "$OUTPUT_REPO_DIR"
+    case "$arch" in
+        amd64)
+            $RUN ${SCRIPT_PATH}/amd64-build-publish.sh \
+                 "$arch" "$flavour"  \
+                 "$KERNEL_SRC_DIR"   \
+                 "$KERNEL_VERSION"   \
+                 "$RT_BUILD_ROOT"    \
+                 "$RT_KERNEL_LABEL"  \
+                 "$ASTORE_BASE"      \
+                 "$ASTORE_META_DIR"
+            ;;
+        arm64)
+            $RUN ${SCRIPT_PATH}/arm64-build-publish.sh \
+                 "$arch" "$flavour"  \
+                 "$KERNEL_SRC_DIR"   \
+                 "$KERNEL_VERSION"   \
+                 "$RT_BUILD_ROOT"    \
+                 "$RT_KERNEL_LABEL"  \
+                 "$ASTORE_BASE"      \
+                 "$ASTORE_META_DIR"
+            ;;
+        *)
+            echo "Error: unsupported architecture: $arch"
+            exit 1
+    esac
 
-# Creates a bazel ready tarball for building kernel modules
-$RUN ${SCRIPT_PATH}/archive-bazel-deb.sh "$OUTPUT_DEB_DIR" "$RT_KERNEL_FLAVOURS" "$OUTPUT_BAZEL_ARCHIVE_DIR"
+done
 
-# Creates a tarball of a Debian APT repository for each flavour
-$RUN ${SCRIPT_PATH}/archive-deb.sh "$OUTPUT_DEB_DIR" "$OUTPUT_REPO_DIR" "$RT_KERNEL_FLAVOURS" "$OUTPUT_APT_ARCHIVE_DIR"
-
-# Uploads the bazel ready tarball for each flavour
-$RUN ${SCRIPT_PATH}/upload-deb.sh \
-     "$OUTPUT_DEB_DIR"            \
-     "$OUTPUT_BAZEL_ARCHIVE_DIR"  \
-     "$OUTPUT_APT_ARCHIVE_DIR"    \
-     "$RT_KERNEL_FLAVOURS"        \
-     "$ASTORE_BASE"               \
-     "$OUTPUT_ASTORE_META_DIR"
-
-# Generate Bazel include file from upload meta-data files
-$RUN ${SCRIPT_PATH}/gen-bazel-meta.sh    \
-     "$OUTPUT_DEB_DIR"                   \
-     "$RT_KERNEL_FLAVOURS"               \
-     "$ASTORE_BASE"                      \
-     "$OUTPUT_ASTORE_META_DIR"           \
-     "$RT_KERNEL_LABEL"
+rm -f "${ASTORE_META_DIR}/kernel.version.bzl"
+cat "${ASTORE_META_DIR}"/*.bzl > "${ASTORE_META_DIR}/kernel.version.bzl"
 
 echo
 echo "SUCCESS: All Done."
 echo "Copy the following file to the internal repo,  in internal-repo/bazel/kernel.version.bzl"
-echo "${OUTPUT_ASTORE_META_DIR}/kernel.version.bzl"
+echo "${ASTORE_META_DIR}/kernel.version.bzl"

--- a/kbuild/v2/scripts/amd64-build-publish.sh
+++ b/kbuild/v2/scripts/amd64-build-publish.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Build and publish amd64 kernel artifacts for a particular configuration
+
+set -e
+
+SCRIPT_PATH="$(dirname $(realpath $0))"
+
+ARCH=$1
+FLAVOUR=$2
+KERNEL_SRC="$3"
+KERNEL_VERSION="$4"
+BUILD_ROOT="$5"
+ASTORE_LABEL="$6"
+ASTORE_BASE="$7"
+ASTORE_META_DIR="$8"
+
+TARGET="${ARCH}-${FLAVOUR}"
+BUILD_DEB_DIR="$BUILD_ROOT/deb-build/${TARGET}"
+OUTPUT_DEB_DIR="$BUILD_ROOT/deb-out/${TARGET}"
+OUTPUT_REPO_DIR="$BUILD_ROOT/apt-repo/${TARGET}"
+OUTPUT_BAZEL_ARCHIVE_DIR="$BUILD_ROOT/bazel-archive/${TARGET}"
+OUTPUT_APT_ARCHIVE_DIR="$BUILD_ROOT/deb-archive/${TARGET}"
+
+# Builds the .deb kernel packages for arch, flavour
+${SCRIPT_PATH}/build-debs.sh "$KERNEL_SRC" "$KERNEL_VERSION" "$ARCH" "$FLAVOUR" "$BUILD_DEB_DIR" "$OUTPUT_DEB_DIR"
+
+# Creates a portable Debian APT repository for arch, flavour
+${SCRIPT_PATH}/repo-deb.sh "$OUTPUT_DEB_DIR" "$ARCH" "$FLAVOUR" "$OUTPUT_REPO_DIR"
+
+# Creates a bazel ready tarball for building kernel modules
+${SCRIPT_PATH}/archive-bazel-deb.sh "$OUTPUT_DEB_DIR" "$ARCH" "$FLAVOUR" "$OUTPUT_BAZEL_ARCHIVE_DIR"
+
+# Creates a tarball of a Debian APT repository for arch, flavour
+${SCRIPT_PATH}/archive-deb.sh "$OUTPUT_DEB_DIR" "$OUTPUT_REPO_DIR" "$ARCH" "$FLAVOUR" "$OUTPUT_APT_ARCHIVE_DIR"
+
+# Uploads the bazel ready tarball for arch, flavour
+${SCRIPT_PATH}/upload-deb.sh      \
+     "$OUTPUT_DEB_DIR"            \
+     "$OUTPUT_BAZEL_ARCHIVE_DIR"  \
+     "$OUTPUT_APT_ARCHIVE_DIR"    \
+     "$ARCH"                      \
+     "$FLAVOUR"                   \
+     "$ASTORE_BASE"               \
+     "$ASTORE_META_DIR"
+
+# Generate Bazel include file fragment from upload meta-data files
+${SCRIPT_PATH}/gen-bazel-meta.sh \
+     "$OUTPUT_DEB_DIR"           \
+     "$ARCH"                     \
+     "$FLAVOUR"                  \
+     "$ASTORE_BASE"              \
+     "$ASTORE_META_DIR"          \
+     "$ASTORE_LABEL"

--- a/kbuild/v2/scripts/archive-bazel-deb.sh
+++ b/kbuild/v2/scripts/archive-bazel-deb.sh
@@ -4,7 +4,8 @@
 #
 # Inputs:
 # - a flat directory containing the kernel .debs
-# - a space separated list of kernel flavours
+# - CPU architecture
+# - kernel flavour
 # - an output directory to place the generated bazel archive
 
 set -e
@@ -13,16 +14,18 @@ LIB_SH="$(dirname $(realpath $0))/lib.sh"
 . $LIB_SH
 
 INPUT_DEB_ROOT="$(realpath $1)"
-KERNEL_FLAVOURS="$2"
-OUTPUT_ARCHIVE_ROOT="$(realpath $3)"
+ARCH="$2"
+FLAVOUR="$3"
+OUTPUT_ARCHIVE_ROOT="$4"
+
+# This script only handles one flavour at a time now.
+KERNEL_FLAVOURS="$FLAVOUR"
 
 INSTALL_TEMPLATE="$(dirname $(realpath $0))/../template/install-bazel.sh"
 if [ ! -r "$INSTALL_TEMPLATE" ] ; then
     echo "ERROR: unable to find bazel install script template: $INSTALL_TEMPLATE"
     exit 1
 fi
-
-ARCH=amd64
 
 KERNEL_BASE=$(get_kernel_base $INPUT_DEB_ROOT)
 if [ -z "$KERNEL_BASE" ] ; then

--- a/kbuild/v2/scripts/archive-deb.sh
+++ b/kbuild/v2/scripts/archive-deb.sh
@@ -15,8 +15,12 @@ LIB_SH="$(dirname $(realpath $0))/lib.sh"
 
 INPUT_DEB_ROOT="$(realpath $1)"
 INPUT_REPO_ROOT="$(realpath $2)"
-KERNEL_FLAVOURS="$3"
-OUTPUT_ARCHIVE_ROOT="$(realpath $4)"
+ARCH="$3"
+FLAVOUR="$4"
+OUTPUT_ARCHIVE_ROOT="$5"
+
+# This script only handles one flavour at a time now.
+KERNEL_FLAVOURS="$FLAVOUR"
 
 INSTALL_TEMPLATE="$(dirname $(realpath $0))/../template/install-deb.sh"
 if [ ! -r "$INSTALL_TEMPLATE" ] ; then
@@ -24,7 +28,6 @@ if [ ! -r "$INSTALL_TEMPLATE" ] ; then
     exit 1
 fi
 
-ARCH=amd64
 DIST=focal
 COMP=main
 

--- a/kbuild/v2/scripts/arm64-build-publish.sh
+++ b/kbuild/v2/scripts/arm64-build-publish.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Build and publish arm64 kernel artifacts for a particular configuration
+
+set -e
+
+SCRIPT_PATH="$(dirname $(realpath $0))"
+
+ARCH=$1
+FLAVOUR=$2
+KERNEL_SRC="$3"
+KERNEL_VERSION="$4"
+BUILD_ROOT="$5"
+ASTORE_LABEL="$6"
+ASTORE_BASE="$7"
+ASTORE_META_DIR="$8"
+
+TARGET="${ARCH}-${FLAVOUR}"
+KERNEL_BUILD_DIR="$BUILD_ROOT/kbuild/${TARGET}"
+OUTPUT_KRELEASE_DIR="$BUILD_ROOT/krelease/${TARGET}"
+
+# Creates a tarball of build artifacts for each kernel spec:
+# - kernel version string
+# - kernel config file
+# - kernel out of tree module build artifacts
+# - kernel Image
+${SCRIPT_PATH}/build-kernel-release.sh \
+     "$KERNEL_SRC"       \
+     "$KERNEL_BUILD_DIR" \
+     "$KERNEL_VERSION"   \
+     "$ARCH"             \
+     "$FLAVOUR"          \
+     "$OUTPUT_KRELEASE_DIR"
+
+# Uploads the bazel ready kernel build tarballs
+${SCRIPT_PATH}/upload-kernel-build.sh \
+     "$KERNEL_BUILD_DIR"          \
+     "$OUTPUT_KRELEASE_DIR"       \
+     "$ARCH"                      \
+     "$FLAVOUR"                   \
+     "$ASTORE_BASE"               \
+     "$ASTORE_META_DIR"
+
+# Generate Bazel include file from upload meta-data files
+${SCRIPT_PATH}/gen-bazel-meta2.sh \
+     "$KERNEL_BUILD_DIR"          \
+     "$OUTPUT_KRELEASE_DIR"       \
+     "$ARCH"                      \
+     "$FLAVOUR"                   \
+     "$ASTORE_BASE"               \
+     "$ASTORE_META_DIR"           \
+     "$ASTORE_LABEL"

--- a/kbuild/v2/scripts/build-debs.sh
+++ b/kbuild/v2/scripts/build-debs.sh
@@ -3,20 +3,24 @@
 # This script builds the .debs for an Enfabrica kernel
 #
 # Inputs:
-# - a build directory
+# - kernel source direcotry
 # - the kernel version file
-# - a space delimited list of kernel flavours, e.g. "minimal generic"
+# - CPU architecture
+# - kernel flavour
+# - a build directory
 # - an output directory to place the generated .debs
 
 set -e
 
-KERNEL_DIR="$(realpath $1)"
+KERNEL_SRC_DIR="$(realpath $1)"
 KERNEL_VERSION="$(realpath $2)"
-KERNEL_FLAVOURS="$3"
-OUTPUT_DEB_DIR="$(realpath $4)"
+ARCH="$3"
+FLAVOUR="$4"
+BUILD_DIR="$5"
+OUTPUT_DEB_DIR="$6"
 
-if [ -z "$KERNEL_DIR" ] ; then
-    echo "ERROR: kernel build directory is not defined"
+if [ ! -d "$KERNEL_SRC_DIR" ] ; then
+    echo "ERROR: kernel source directory does not exist: $KERNEL_SRC_DIR"
     exit 1
 fi
 
@@ -24,15 +28,11 @@ if [ ! -r "$KERNEL_VERSION" ] ; then
     echo "ERROR: unable to read kernel version file"
     exit 1
 fi
-
-if [ -z "$KERNEL_FLAVOURS" ] ; then
-    echo "ERROR: kernel flavours not specified: valid values 'generic'"
-    exit 1
-fi
 kernel_version=$(cat "$KERNEL_VERSION")
 
 # clean output .deb dir
 if [ "$RT_CLEAN_BUILD" = "yes" ] ; then
+    rm -rf "$BUILD_DIR"
     rm -rf "$OUTPUT_DEB_DIR"
 fi
 
@@ -41,11 +41,31 @@ if [ -d "$OUTPUT_DEB_DIR" ] ; then
     exit 0
 fi
 
-mkdir -p "$OUTPUT_DEB_DIR"
+mkdir -p "$BUILD_DIR" "$OUTPUT_DEB_DIR"
 
-# build all the flavours
-cd "$KERNEL_DIR"
-./enfabrica/build-kernel.sh -b "local=$kernel_version" -f "$KERNEL_FLAVOURS"
+ksrc_dir="${BUILD_DIR}/source"
+rsync -a "${KERNEL_SRC_DIR}/" "$ksrc_dir"
 
-# copy out the resulting .debs
-cp -av ../linux-*deb "$OUTPUT_DEB_DIR"
+cd "$ksrc_dir"
+
+# If the git tree has any uncommitted modifications, mark the
+# version as dirty.
+if [ -n "$(git status --porcelain)" ] ; then
+    echo "WARNING: The build tree contains uncommitted changes."
+    dirty="-dirty"
+else
+    dirty=
+fi
+
+abi_suffix="${kernel_version}${dirty}"
+
+if [ "$RT_BUILD_CLEAN" = "yes" ] ; then
+    fakeroot debian/rules distclean
+fi
+
+fakeroot debian/rules clean	   abi_suffix="$abi_suffix" arch="$ARCH" flavours="$FLAVOUR"
+fakeroot debian/rules binary-debs  abi_suffix="$abi_suffix" arch="$ARCH" flavours="$FLAVOUR"
+fakeroot debian/rules binary-indep abi_suffix="$abi_suffix" arch="$ARCH" flavours="$FLAVOUR"
+
+# mv the resulting .debs
+mv ../linux-*deb "$OUTPUT_DEB_DIR"

--- a/kbuild/v2/scripts/build-kernel-release.sh
+++ b/kbuild/v2/scripts/build-kernel-release.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# This script builds a kernel release tarball
+#
+# Inputs:
+# - kernel source directory
+# - kernel build directory
+# - the kernel version file
+# - CPU architecture
+# - kernel flavour
+# - an output directory to place the generated tarball
+
+set -e
+
+SCRIPT_PATH="$(dirname $(realpath $0))"
+. "${SCRIPT_PATH}/lib.sh"
+
+KERNEL_SRC_DIR="$(realpath $1)"
+BUILD_DIR="$(realpath -m $2)"
+KERNEL_SUFFIX="$(realpath $3)"
+ARCH="$4"
+FLAVOUR="$5"
+OUTPUT_KRELEASE_DIR="$(realpath -m $6)"
+
+if [ ! -d "$KERNEL_SRC_DIR" ] ; then
+    echo "ERROR: kernel source directory does not exist: $KERNEL_SRC_DIR"
+    exit 1
+fi
+
+if [ ! -r "$KERNEL_SUFFIX" ] ; then
+    echo "ERROR: unable to read kernel version suffix file"
+    exit 1
+fi
+
+kernel_version_suffix=$(cat "$KERNEL_SUFFIX")
+
+# clean output kernel build and release dirs
+if [ "$RT_CLEAN_BUILD" = "yes" ] ; then
+    rm -rf "$BUILD_DIR"
+    rm -rf "$OUTPUT_KRELEASE_DIR"
+fi
+
+if [ -d "$OUTPUT_KRELEASE_DIR" ] ; then
+    # skip building the kernel release tarball
+    exit 0
+fi
+
+mkdir -p "$BUILD_DIR" "$OUTPUT_KRELEASE_DIR"
+
+ksrc_dir="${BUILD_DIR}/source"
+rsync -a "${KERNEL_SRC_DIR}/" "$ksrc_dir"
+
+# The following script should be a script that kernel devs can call
+# directly for setting up a development kernel area for bazel...
+
+cd "$ksrc_dir"
+${SCRIPT_PATH}/build-kernel-tree.sh -v "$kernel_version_suffix" -a "$ARCH" -f "$FLAVOUR"
+
+# above script creates sibling dirs of $ksrc_dir named "boot" and
+# "install" and an installer script.
+
+kernel_version="$(cat ${BUILD_DIR}/install/build/enf-kernel-version.txt)"
+
+# now tar up the results
+# - kernel source
+# - boot dir
+# - install dir
+# - installer script
+kernel_release_tarball="${OUTPUT_KRELEASE_DIR}/kernel-tree-image.tar.gz"
+tar czf "$kernel_release_tarball" -C "$BUILD_DIR" source install boot "install-${kernel_version}.sh"

--- a/kbuild/v2/scripts/build-kernel-tree.sh
+++ b/kbuild/v2/scripts/build-kernel-tree.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+# Build Enfabrica kernel tree release directories.
+
+set -e
+
+# Ensure this script is run from the root of the kernel tree
+if [ ! -f MAINTAINERS ] ; then
+    echo "Error: This script must be run from the root of the kernel tree"
+    exit 1
+fi
+
+# Default version suffix
+DEFAULT_VERSION_SUFFIX=""
+
+# Default kernel architecture
+DEFAULT_ARCH="amd64"
+
+# Default kernel flavour
+DEFAULT_FLAVOUR="generic"
+
+# The following ENF_ variables provide an external API and can be set
+# before running this script:
+
+# Version suffix
+RT_VERSION_SUFFIX="${ENF_VERSION_SUFFIX:-${DEFAULT_VERSION_SUFFIX}}"
+
+# Kernel arch
+RT_ARCH="${ENF_ARCH:-${DEFAULT_ARCH}}"
+
+# Kernel flavour
+RT_FLAVOUR="${ENF_FLAVOUR:-${DEFAULT_FLAVOUR}}"
+
+usage() {
+    cat <<EOF
+USAGE:
+    ${0##*/} [OPTIONS]
+
+OPTIONS:
+    -v version suffix
+        A suffix to append to the version information
+        from the debian/changelog file.
+
+        The default is "$DEFAULT_VERSION_SUFFIX".
+
+    -a kernel architecture
+
+        The CPU architecture to compile for.  One of "amd64" or "arm64".
+
+        The default is "$DEFAULT_ARCH".
+
+    -f kernel flavour
+
+        A particular kernel configuration for an architecture.
+        See debian.master/rules.d/<arch>.mk in the kernel
+        repo for a list of available flavours for an arch.
+
+        The default is "$DEFAULT_FLAVOUR".
+
+ENVIRONMENT VARIABLES
+
+Some options can also be set via environment variables:
+
+ENF_VERSION_SUFFIX:  (current_value: ${ENF_VERSION_SUFFIX:-unset})
+ENF_ARCH:            (current_value: ${ENF_ARCH:-unset})
+ENF_FLAVOUR:         (current_value: ${ENF_FLAVOUR:-unset})
+
+In all cases, the command line arguments take precedence.
+
+EOF
+}
+
+# Command line argument override any environment variables
+while getopts hcv:a:f:b: opt ; do
+    case $opt in
+        v)
+            RT_VERSION_SUFFIX=$OPTARG
+            ;;
+        a)
+            RT_ARCH=$OPTARG
+            ;;
+        f)
+            RT_FLAVOUR=$OPTARG
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift `expr $OPTIND - 1`
+
+case "$RT_ARCH" in
+    amd64 | arm64) ;;
+    *)
+        echo "Error: Unsupported architecture: $RT_ARCH."
+        echo "Supported architectures are 'amd64' and 'arm64'."
+        exit 1
+esac
+
+for var in RT_VERSION_SUFFIX RT_ARCH RT_FLAVOUR ; do
+    printf "%-20s:   %s\n" "$var" "$(eval echo -n \$$var)"
+done
+
+# Create a kernel version string
+function gen_kernel_version() {
+    local suffix="$1"
+    local flavour="$2"
+
+    # Create a kernel suffix that mimics what debian does
+    DEBIAN="debian.master"
+    pkg_name="linux"
+    linux_version=$(sed -n '1s/^linux.*(\(.*\)-.*).*$/\1/p' ${DEBIAN}/changelog)
+    if [ -z "LINUX_VERSION" ] ; then
+        echo "ERROR: unable to determine Debian kernel version"
+        exit 1
+    fi
+
+    # Next tease out the Debian changelog ABI number.  Need to match
+    # any built .debs...
+    revision=$(sed -n "s/^linux\ .*(${linux_version}-\(.*\)).*$/\1/p" ${DEBIAN}/changelog)
+    debian_abi=$(echo $revision | sed -r -e 's/([^\+~]*)\.[^\.]+(~.*)?(\+.*)?$/\1/')
+
+    kernel_version="${linux_version}-${debian_abi}${suffix}-${flavour}"
+    echo -n "$kernel_version"
+}
+
+# Generate configs
+fakeroot debian/rules clean
+fakeroot debian/rules genconfigs arch="$RT_ARCH"
+
+kconfig="CONFIGS/${RT_ARCH}-config.flavour.${RT_FLAVOUR}"
+if [ ! -r "$kconfig" ] ; then
+    echo "ERROR: Unable to find kernel config for arch-flavour: ${RT_ARCH}-${RT_FLAVOUR}"
+    exit 1
+fi
+
+# The output build directory must be a sibling of the current source directory.
+parent_dir="$(dirname $PWD)"
+build_dir="${parent_dir}/install/build"
+rm -rf $build_dir
+mkdir -p $build_dir
+
+kernel_version="$(gen_kernel_version $RT_VERSION_SUFFIX $RT_FLAVOUR)"
+echo "$kernel_version" > "${build_dir}/enf-kernel-version.txt"
+
+# setup kernel config file
+cp "$kconfig" "${build_dir}/.config"
+
+case "$RT_ARCH" in
+    arm64)
+        arch_args="ARCH=$RT_ARCH CROSS_COMPILE=aarch64-linux-gnu-"
+        arch_image="Image"
+        output_image="arch/arm64/boot/Image"
+        ;;
+    amd64)
+        arch_args=""
+        arch_image="bzImage"
+        output_image="arch/x86/boot/bzImage"
+        ;;
+    *)
+        echo "ERROR: Unknown arch: $RT_ARCH"
+        exit 1
+esac
+
+NPROC=$(( $(nproc) / 4 ))
+
+echo "Building kernel spec: ${RT_ARCH}-${RT_FLAVOUR}"
+make -s \
+     O="$build_dir" \
+     -j $NPROC \
+     $arch_args \
+     KERNELRELEASE="$kernel_version" \
+     prepare modules \
+     $arch_image
+
+# make source symlink relative
+rm -f "${build_dir}/source"
+ln -s --relative . "${build_dir}/source"
+
+# use relative path in build_dir Makefile
+cat <<EOF > "${build_dir}/Makefile"
+# Automatically generated: don't edit
+include ./source/Makefile
+EOF
+
+# remove a bunch of unneeded stuff from build directory
+PATTERNS=".*.cmd *.a *.o *.d *.ko *.order *.mod *.mod.c *.mod.o *.log"
+for p in $PATTERNS ; do
+    find "$build_dir" -name $p -type f -exec rm -f {} +
+done
+
+# TODO: remove even more stuff from the "source" and "build" directory
+
+# Create bazel installer script
+install_script="${parent_dir}/install-${kernel_version}.sh"
+cat <<EOF > "$install_script"
+#!/bin/sh
+
+echo "install"
+
+EOF
+
+chmod +x $install_script
+
+# Move kernel image into boot directory
+boot_dir="${parent_dir}/boot"
+mkdir -p "$boot_dir"
+cp "${build_dir}/$output_image" "${boot_dir}/vmlinuz-${kernel_version}"

--- a/kbuild/v2/scripts/init-build.sh
+++ b/kbuild/v2/scripts/init-build.sh
@@ -8,13 +8,13 @@
 
 set -e
 
-KERNEL_DIR="$(realpath $1)"
+KERNEL_SRC_DIR="$(realpath $1)"
 KERNEL_REPO="$2"
 KERNEL_BRANCH="$3"
 KERNEL_VERSION="$4"
 
 make_version() {
-    cd "$KERNEL_DIR"
+    cd "$KERNEL_SRC_DIR"
 
     # Construct a dynamic local kernel version string based on the current
     # unix epoch and the HEAD git commit hash.
@@ -29,8 +29,8 @@ make_version() {
     echo "$version" > "$KERNEL_VERSION"
 }
 
-if [ -z "$KERNEL_DIR" ] ; then
-    echo "ERROR: kernel build directory is not defined"
+if [ -z "$KERNEL_SRC_DIR" ] ; then
+    echo "ERROR: kernel src build directory is not defined"
     exit 1
 fi
 
@@ -44,19 +44,19 @@ if [ -z "$KERNEL_BRANCH" ] ; then
     exit 1
 fi
 
-# clean kernel build dir
+# clean kernel src build dir
 if [ "$RT_CLEAN_BUILD" = "yes" ] ; then
-    rm -rf "$KERNEL_DIR" "$KERNEL_VERSION"
+    rm -rf "$KERNEL_SRC_DIR" "$KERNEL_VERSION"
 fi
 
-if [ -d "$KERNEL_DIR" -a -r "$KERNEL_VERSION" ] ; then
+if [ -d "$KERNEL_SRC_DIR" -a -r "$KERNEL_VERSION" ] ; then
     # skip cloning the kernel repo.
     exit 0
 fi
 
-mkdir -p "$KERNEL_DIR"
+mkdir -p "$KERNEL_SRC_DIR"
 
 # Shallow clone the kernel tree and branch
-git clone --depth 1 --branch "$KERNEL_BRANCH" "$KERNEL_REPO" "$KERNEL_DIR"
+git clone --depth 1 --branch "$KERNEL_BRANCH" "$KERNEL_REPO" "$KERNEL_SRC_DIR"
 
 make_version

--- a/kbuild/v2/scripts/lib.sh
+++ b/kbuild/v2/scripts/lib.sh
@@ -2,6 +2,20 @@
 
 # common helpers
 
+get_arch() {
+    local spec="$1"
+
+    local arch=${spec%%,*}
+    echo -n $arch
+}
+
+get_flavour() {
+    local spec="$1"
+
+    local flavour=${spec##*,}
+    echo -n $flavour
+}
+
 get_kernel_base() {
     local deb_dir="$1"
 

--- a/kbuild/v2/scripts/repo-deb.sh
+++ b/kbuild/v2/scripts/repo-deb.sh
@@ -5,7 +5,8 @@
 #
 # Inputs:
 # - a flat directory containing the kernel .debs
-# - a space separated list of kernel flavours
+# - CPU architecture
+# - kernel flavour
 # - an output directory to place the generated APT repo
 
 set -e
@@ -14,12 +15,15 @@ LIB_SH="$(dirname $(realpath $0))/lib.sh"
 . $LIB_SH
 
 INPUT_DEB_ROOT="$(realpath $1)"
-KERNEL_FLAVOURS="$2"
-OUTPUT_REPO_ROOT="$(realpath $3)"
+ARCH="$2"
+FLAVOUR="$3"
+OUTPUT_REPO_ROOT="$4"
 
-ARCH=amd64
 DIST=focal
 COMP=main
+
+# This script only handles one flavour at a time now.
+KERNEL_FLAVOURS="$FLAVOUR"
 
 KERNEL_BASE=$(get_kernel_base $INPUT_DEB_ROOT)
 if [ -z "$KERNEL_BASE" ] ; then

--- a/kbuild/v2/scripts/upload-deb.sh
+++ b/kbuild/v2/scripts/upload-deb.sh
@@ -18,11 +18,13 @@ LIB_SH="$(dirname $(realpath $0))/lib.sh"
 INPUT_DEB_ROOT="$(realpath $1)"
 INPUT_BAZEL_ARCHIVE_ROOT="$(realpath $2)"
 INPUT_DEB_ARCHIVE_ROOT="$(realpath $3)"
-KERNEL_FLAVOURS="$4"
-ASTORE_ROOT="$5"
-ASTORE_META_DIR="$6"
+ARCH="$4"
+FLAVOUR="$5"
+ASTORE_ROOT="$6"
+ASTORE_META_DIR="$7"
 
-ARCH=amd64
+# This script only handles one flavour at a time now.
+KERNEL_FLAVOURS="$FLAVOUR"
 
 DEB_VERSION=$(get_deb_version $INPUT_DEB_ROOT)
 if [ -z "$DEB_VERSION" ] ; then
@@ -41,7 +43,6 @@ clean_up()
     rm -rf $DEB_TMPDIR
 }
 trap clean_up EXIT
-
 
 kernel_tag() {
     local flavour=$1
@@ -114,7 +115,7 @@ upload_kernel_image_modules() {
 for f in $KERNEL_FLAVOURS ; do
     kernel_version="$(deb_get_kernel_version $INPUT_DEB_ROOT $f)"
 
-    upload_bazel_archive $f        $kernel_version
-    upload_deb_archive $f          $kernel_version
+    upload_bazel_archive        $f $kernel_version
+    upload_deb_archive          $f $kernel_version
     upload_kernel_image_modules $f $kernel_version
 done

--- a/kbuild/v2/scripts/upload-kernel-build.sh
+++ b/kbuild/v2/scripts/upload-kernel-build.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# This script uploads kernel build tarball to enkit astore
+#
+# Inputs
+# - kernel version string
+# - kernel build tarball
+# - The astore root where to store kernel artifacts
+# - a directory to store astore meta data files
+
+set -e
+
+LIB_SH="$(dirname $(realpath $0))/lib.sh"
+. $LIB_SH
+
+KERNEL_BUILD_DIR="$(realpath $1)"
+KRELEASE_DIR="$(realpath $2)"
+ARCH="$3"
+FLAVOUR="$4"
+ASTORE_ROOT="$5"
+ASTORE_META_DIR="$6"
+
+kernel_version="$(cat ${KERNEL_BUILD_DIR}/install/build/enf-kernel-version.txt)"
+
+kernel_release_tarball="${KRELEASE_DIR}/kernel-tree-image.tar.gz"
+if [ ! -r "$kernel_release_tarball" ] ; then
+    echo "ERROR: unable to find kernel release tarball: $kernel_release_tarball"
+    exit 1
+fi
+
+if [ ! -d "$ASTORE_META_DIR" ] ; then
+    echo "ERROR: unable to find astore meta-data directory: $ASTORE_META_DIR"
+    exit 1
+fi
+
+astore_file="kernel-tree-image-${ARCH}-${FLAVOUR}.tar.gz"
+astore_path="${ASTORE_ROOT}/${ARCH}/${FLAVOUR}/${astore_file}"
+astore_meta="${ASTORE_META_DIR}/${astore_file}.json"
+
+upload_artifact "$kernel_release_tarball" "$astore_path" "$ARCH" "$kernel_version" "$astore_meta"


### PR DESCRIPTION
This is now ready for review.

To actually build enf_core.ko for aarch64 requires the following PR from the internal repo:
https://github.com/enfabrica/internal/pull/40341
Note: internal PR 40341 refers to kernel artifacts that were built by this enkit PR.

Also I tested building a top of master internal enf_core.ko using this enkit to make sure this enkit was backwardly compatible.  It is. So outside of review comments, this should be able to merge without breaking the current internal master.
