### PR TITLE
Remove ex-employees from the CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-*.sh @jonathan-enf @ccontavalli @ahungrynacho @minor-fixes @aaahrens
-/scripts @amichalol @jonathan-enf @ccontavalli @minor-fixes
+*.sh @jonathan-enf @ccontavalli @ahungrynacho @mhallmark
+/scripts @amichalol @jonathan-enf @ccontavalli @mhallmark
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 *.sh @jonathan-enf @ccontavalli @ahungrynacho @mhallmark
-/scripts @amichalol @jonathan-enf @ccontavalli @mhallmark
+/scripts @jonathan-enf @ccontavalli @mhallmark
 


### PR DESCRIPTION
This change removes ex-employees from the CODEOWNERS file and replaces them with Matt Hallmark.

Tested:
- None

JIRA: INFRA-10680