### PR TITLE
gee: improves ability to cancel presubmits

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3574,6 +3574,7 @@ function gee__commit() {
     if [[ "${GEE_ENABLE_PRESUBMIT_CANCEL}" != "0" ]]; then
       if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
         # kill running presubmit job, if any exists:
+        _info "Killing any previous presubmit jobs."
         gee__pr_cancel
       fi
     fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -4315,6 +4315,7 @@ function gee__pr_cancel() {
   BR="$(_get_current_branch)"
   FILTER="substitutions.BRANCH_NAME=${BR}"  # filter by branch name
   FILTER+=" AND substitutions._HEAD_REPO_URL:${GHUSER}"  # and filter by github username
+  FILTER+=" AND substitutions.TRIGGER_NAME:presubmit"
   FILTER+=" AND (status=\"WORKING\" OR status=\"QUEUED\")"  # and by job status
   while read -r -a FIELDS; do
     local ID="${FIELDS[1]}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -139,8 +139,8 @@ review.
 
 * `GEE_ENABLE_PRESUBMIT_CANCEL`: If set to any value other than 0, will cause
   gee to cancel any running presubmit job when pushing a change to remote
-  branch with an open PR.  This is currently an experimental feature that is
-  disabled by default.
+  branch with an open PR.  Setting to 0 will disable this functionality.  This
+  feature is no longer experimental and now defaults to enabled.
 
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
@@ -252,7 +252,7 @@ readonly PR_LIST_MAX_FETCH=300
 readonly YESYESYES="${YESYESYES:-0}"  # for testing: disables all interactivity.
 GHUSER="${GHUSER:-}"  # can be set by _startup_checks
 VERBOSE="${VERBOSE:-1}"
-GEE_ENABLE_PRESUBMIT_CANCEL="${GEE_ENABLE_PRESUBMIT_CANCEL:-0}"
+GEE_ENABLE_PRESUBMIT_CANCEL="${GEE_ENABLE_PRESUBMIT_CANCEL:-1}"
 DRYRUN="${DRYRUN:-0}"
 UPSTREAM="${UPSTREAM:-enfabrica}"
 TESTMODE="${TESTMODE:-0}"
@@ -3510,7 +3510,7 @@ pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
 
-If the experimental GEE_ENABLE_PRESUBMIT_CANCEL feature is enabled, then gee
+Unless GEE_ENABLE_PRESUBMIT_CANCEL feature is disabled, gee
 will check to see if pushing the current commit will invalidate a presubmit job
 in the `pending` state.  If this is the case, gee will kill the previous
 presubmit before pushing the changes and thus kicking off the new presubmit.
@@ -3574,7 +3574,7 @@ function gee__commit() {
     if [[ "${GEE_ENABLE_PRESUBMIT_CANCEL}" != "0" ]]; then
       if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
         # kill running presubmit job, if any exists:
-        _cancel_pending_presubmit
+        gee__pr_cancel
       fi
     fi
     if [[ "${AMENDING}" == 1 ]]; then
@@ -4292,6 +4292,35 @@ EndOfPrTemplate
 }
 
 ##########################################################################
+# pr_cancel command
+##########################################################################
+
+_register_help "pr_cancel" \
+  "Cancels any running gcloud builds associated with this branch." \
+  "cancel" "cancel_pr" <<'EOT'
+Usage: gee pr_cancel
+
+Cancels any pending (status = QUEUED or WORKING) gcloud builds jobs
+associated with this branch.  This command can be used to cancel
+a set of presubmits that were triggered by a change to this branch.
+EOT
+
+function gee__pr_cancel() {
+  local BR="$(_get_current_branch)"
+  local -a FIELDS=()
+  local COUNT=0
+  while read -r -a FIELDS; do
+    local ID="${FIELDS[1]}"
+    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" | head -n 1
+    COUNT=$((COUNT + 1))
+  done < <(_cmd gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds list \
+              --format=yaml \
+              --filter="substitutions.BRANCH_NAME=${BR} AND (status=\"WORKING\" OR status=\"QUEUED\")" \
+              | grep ^id:)
+  _info "Killed ${COUNT} job(s)."
+}
+
+##########################################################################
 # pr_check command
 ##########################################################################
 
@@ -4304,51 +4333,6 @@ Returns the state of presubmit checks.  If the --wait option is provided,
 this command will continue to report check status until all pending
 checks have completed.
 EOT
-
-function _get_presubmit_info() {
-  # Returns the status, gcloud id, and gcloud project of any running presubmit.
-  local -n S=$1  # first argument is a variable to assign to.
-  local -n I=$2
-  local -n P=$3
-  S="unknown"
-  I="unknown"
-  P="unknown"
-  local LINE
-  local -a FIELDS=()
-  while read -r -a FIELDS; do
-    if [[ "${FIELDS[0]}" == "internal-bazel-presubmit" ]]; then
-      S="${FIELDS[2]}"
-      if [[ "${FIELDS[4]}" =~ builds/([a-f0-9-]*)\?project= ]]; then
-        I="${BASH_REMATCH[1]}"
-      else
-        _warn "Could not parse build number from URL: ${FIELDS[4]}"
-        S=unknown
-      fi
-      if [[ "${FIELDS[1]}" =~ \((.+)\) ]]; then
-        P="${BASH_REMATCH[1]}"
-      else
-        _warn "Could not parse project name from ${FIELDS[1]}"
-        S=unknown
-      fi
-    fi
-  done < <(${GH} pr checks)
-  return 0
-}
-
-function _gh_builds_cancel() {
-  local ID="$1"
-  local PROJECT="$2"
-  _cmd gcloud builds cancel "${ID}" --project "${PROJECT}" >/dev/null
-}
-
-function _cancel_pending_presubmit() {
-  local STATUS ID PROJECT
-  _get_presubmit_info STATUS ID PROJECT
-  if [[ "${STATUS}" == "pending" ]]; then
-    _info "Killing previous pending presubmit job ${ID}."
-    _gh_builds_cancel "${ID}" "${PROJECT}"
-  fi
-}
 
 function _push_will_trigger_presubmit() {
   local BR="$1"

--- a/scripts/gee
+++ b/scripts/gee
@@ -4306,16 +4306,22 @@ a set of presubmits that were triggered by a change to this branch.
 EOT
 
 function gee__pr_cancel() {
-  local BR="$(_get_current_branch)"
+  local BR
   local -a FIELDS=()
-  local COUNT=0
+  local COUNT
+  local FILTER
+  COUNT=0
+  BR="$(_get_current_branch)"
+  FILTER="substitutions.BRANCH_NAME=${BR}"  # filter by branch name
+  FILTER+=" AND substitutions._HEAD_REPO_URL:${GHUSER}"  # and filter by github username
+  FILTER+=" AND (status=\"WORKING\" OR status=\"QUEUED\")"  # and by job status
   while read -r -a FIELDS; do
     local ID="${FIELDS[1]}"
     _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" | head -n 1
     COUNT=$((COUNT + 1))
   done < <(_cmd gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds list \
               --format=yaml \
-              --filter="substitutions.BRANCH_NAME=${BR} AND (status=\"WORKING\" OR status=\"QUEUED\")" \
+              --filter="${FILTER}" \
               | grep ^id:)
   _info "Killed ${COUNT} job(s)."
 }

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -142,8 +142,8 @@ review.
 
 * `GEE_ENABLE_PRESUBMIT_CANCEL`: If set to any value other than 0, will cause
   gee to cancel any running presubmit job when pushing a change to remote
-  branch with an open PR.  This is currently an experimental feature that is
-  disabled by default.
+  branch with an open PR.  Setting to 0 will disable this functionality.  This
+  feature is no longer experimental and now defaults to enabled.
 
 See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
 prompt that `gee bash_setup` makes available.
@@ -175,6 +175,7 @@ prompt that `gee bash_setup` makes available.
 | <a href="#make_branch">`make_branch`</a> | Create a new child branch based on the current branch. |
 | <a href="#migrate_default_branch">`migrate_default_branch`</a> | Migrate to a new default branch. |
 | <a href="#pack">`pack`</a> | Exports all unsubmitted changes in this branch as a pack file. |
+| <a href="#pr_cancel">`pr_cancel`</a> | Cancels any running gcloud builds associated with this branch. |
 | <a href="#pr_checkout">`pr_checkout`</a> | Create a client containing someone's pull request. |
 | <a href="#pr_check">`pr_check`</a> | Checks the status of presubmit tests for a PR. |
 | <a href="#pr_edit">`pr_edit`</a> | Edit an existing pull request. |
@@ -492,7 +493,7 @@ pr_checkout`, your commits will be pushed to your `origin` remote, and the
 remote PR branch.  To contribute your changes back to another user's PR branch,
 use the `gee pr_push` command.
 
-If the experimental GEE_ENABLE_PRESUBMIT_CANCEL feature is enabled, then gee
+Unless GEE_ENABLE_PRESUBMIT_CANCEL feature is disabled, gee
 will check to see if pushing the current commit will invalidate a presubmit job
 in the `pending` state.  If this is the case, gee will kill the previous
 presubmit before pushing the changes and thus kicking off the new presubmit.
@@ -640,6 +641,16 @@ to your PR description will cause the PR to be marked as a draft.  Adding the
 token "ABORT" will cause gee to abort the creation of your PR.
 
 Uses the same options as "gh pr create".
+
+### pr_cancel
+
+Aliases: cancel cancel_pr
+
+Usage: `gee pr_cancel`
+
+Cancels any pending (status = QUEUED or WORKING) gcloud builds jobs
+associated with this branch.  This command can be used to cancel
+a set of presubmits that were triggered by a change to this branch.
 
 ### pr_check
 


### PR DESCRIPTION
This PR:
  * turns on auto-cancellation of presubmits by default
  * improves detection of running presubmits by relying on `gcloud builds list`
    rather than `gh pr list`.
  * Promotes the functionality to a command `gee pr_cancel` for easier use
    and testing.

Tested:

```
$ gee pr_cancel
CMD: gcloud --project=cloud-build-290921 builds list --format=yaml --filter=substitutions.BRANCH_NAME=synth_check_he\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
Killed 0 job(s).

$ gee rerun

# it takes a moment for the jobs to start
$ gee pr_cancel
CMD: gcloud --project=cloud-build-290921 builds list --format=yaml --filter=substitutions.BRANCH_NAME=synth_check_he\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
Killed 0 job(s).

# wait a few seconds and try again:
$ gee pr_cancel
CMD: gcloud --project=cloud-build-290921 builds list --format=yaml --filter=substitutions.BRANCH_NAME=synth_check_he\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
CMD: gcloud --project cloud-build-290921 builds cancel 0865ee28-39ca-4355-9b2f-afe18ea3efef
Cancelled [https://cloudbuild.googleapis.com/v1/projects/cloud-build-290921/locations/global/builds/0865ee28-39ca-4355-9b2f-afe18ea3efef].
---
CMD: gcloud --project cloud-build-290921 builds cancel 07c40791-8450-4c2a-a86a-178847bf0019
Cancelled [https://cloudbuild.googleapis.com/v1/projects/cloud-build-290921/locations/global/builds/07c40791-8450-4c2a-a86a-178847bf0019].
---
Killed 2 job(s).
```

and then improved:

```
$ gee commit -a -m "make filter more precise by including username"
CMD: /usr/bin/git add --all
CMD: /usr/bin/git commit -a -m make\ filter\ more\ precise\ by\ including\ username
[gee_cancel_by_default 8d53c6b] make filter more precise by including username
 1 file changed, 1 insertion(+)
Killing any previous presubmit jobs.
CMD: gcloud --project=cloud-build-290921 builds list --format=yaml --filter=substitutions.BRANCH_NAME=gee_cancel_by_default\ AND\ substitutions._HEAD_REPO_URL:jonathan-enf\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
CMD: gcloud --project cloud-build-290921 builds cancel f57c94ba-f7b7-4e3b-8e27-29f97ddb8977
Cancelled [https://cloudbuild.googleapis.com/v1/projects/cloud-build-290921/locations/global/builds/f57c94ba-f7b7-4e3b-8e27-29f97ddb8977].
---
Killed 1 job(s).
CMD: /usr/bin/git fetch
CMD: /usr/bin/git push --quiet -u origin gee_cancel_by_default
```


