### PR TITLE
gee: clean up gcloud builds cancel output

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.49"
+readonly VERSION="0.2.50"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -4319,7 +4319,7 @@ function gee__pr_cancel() {
   FILTER+=" AND (status=\"WORKING\" OR status=\"QUEUED\")"  # and by job status
   while read -r -a FIELDS; do
     local ID="${FIELDS[1]}"
-    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" | head -n 1
+    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" > /dev/null
     COUNT=$((COUNT + 1))
   done < <(_cmd gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds list \
               --format=yaml \

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,9 +2,16 @@
 
 ## Releases
 
+### 0.2.50
+
+* gee commit: cancels invalidates presubmits, on by default. (#1067)
+* gee find: only search the bazel symlinks if primary search fails.  (#1064)
+* gee bisect: add `--good` option. (#1057)
+* gee pr_make: don't auto-assign @me if PR is a draft. (#1045)
+
 ### 0.2.49
 
-* gee hello: also check and repair gh authentication (#XXXX).
+* gee hello: also check and repair gh authentication (#1042).
 * gee up: fix resolution of updated/deleted merge conflicts (#1040).
 
 ### 0.2.48

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.49
+gee version: 0.2.50
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
This PR cleans up a previous mistake.  I thought `gcloud builds cancel` outputted messages
to stdout, but it turns out the only message I care about is written to stderr, and everything
written to stdout can be discarded.

Tested: tested in my own work environment.


