### PR TITLE
aarch64 kernel modules: include 'visibility' and 'tags' from parent rule

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -355,9 +355,8 @@ def _gen_module_rule(arch, *args, **kwargs):
     kwargs["name"] = arch_module_name
 
     # Skip non-transitioned targets for CI
-    tags = kwargs.get("tags", [])
-    tags += PLATFORM_NO_BUILD_TAGS
-    kwargs["tags"] = tags
+    original_tags = kwargs.get("tags", [])
+    kwargs["tags"] = original_tags + PLATFORM_NO_BUILD_TAGS
 
     # put down original module rule
     kernel_modules_rule(*args, **kwargs)
@@ -368,6 +367,8 @@ def _gen_module_rule(arch, *args, **kwargs):
     kernel_aarch64_transition(
         name = original,
         target = ":" + arch_module_name,
+        tags = original_tags,
+        visibility = kwargs["visibility"],
     )
 
 def _kernel_module_targets(*args, **kwargs):


### PR DESCRIPTION
When putting down the aarch64 transition rule for kernel modules, set
the `visibility` and `tags` from the kwargs of the parent rule.

Signed-off-by: Curt Brune <curt@enfabrica.net>