### PR TITLE
Support Rocky Linux in muk

### DIFF
--- a/bazel/utils/container/muk/muk.proto
+++ b/bazel/utils/container/muk/muk.proto
@@ -43,6 +43,7 @@ message User {
 enum Distro {
   UBUNTU = 0;
   CENTOS = 1;
+  ROCKY = 3;
 }
 
 message AstoreFile {

--- a/bazel/utils/container/muk/muk.py
+++ b/bazel/utils/container/muk/muk.py
@@ -154,7 +154,7 @@ RUN DEBIAN_FRONTEND='noninteractive' TZ=UTC apt-get update && \\
         yum_install = action.yum_install
         run_cmd = """\
 RUN TZ=UTC yum update -y && \\
-    TZ=UTC yum install -y \\
+    TZ=UTC yum install --allowerasing --enablerepo=devel -y \\
     {}""".format(
             " \\\n    ".join(yum_install.packages)
         )

--- a/bazel/utils/container/muk/muk.py
+++ b/bazel/utils/container/muk/muk.py
@@ -73,7 +73,7 @@ def generate_dockerfile(build_def: mpb.ImageBuild, buf: io.TextIOBase, labels=No
             "RUN apt-get autoclean -y\n",
             'RUN rm -rf /var/cache/apt/* /var/lib/apt/lists/* "${HOME}/.cache" /tmp/*\n',
         ]
-    elif build_def.distro == mpb.Distro.CENTOS:
+    elif build_def.distro == mpb.Distro.CENTOS or build_def.distro == mpb.Distro.ROCKY:
         body += [
             "RUN yum clean all\n",
             "RUN rm -rf ${HOME}/.cache /tmp/*\n",


### PR DESCRIPTION
This change updates the `muk` tool to handle container builds based on the Rocky Linux distro.

Tested:
- `bazel run --override_repository=enkit=$HOME/enkit //infra/dev_container/mojave:mojave_base_image_builder -- --noclean_build_check` builds a new container from https://github.com/enfabrica/internal/pull/41200

JIRA: INFRA-8859