### PR TITLE
Correct container push and promote bugs

### DIFF
--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -15,8 +15,7 @@ _IMAGE_BUILDER_SH = """\
     --dev_repo={dev_repo} \\
     --staging_repo={staging_repo} \\
     --prod_repo={prod_repo} \\
-    --v=1 \\
-    $@
+    --v=4 "$@"
 """
 
 def nonhermetic_image_builder_impl(ctx):


### PR DESCRIPTION
This change fixes a bug where users were able to build and push containers to the staging repo using the `--official` flag without having to specify the `--noclean_build_check`. This change also prints the full container image path and sha256 once it is promoted from the staging repo to the prod repo.

Tested:
- `bazel run --override_repository=enkit=$HOME/enkit //infra/dev_container/mojave:mojave_dev_image_push -- --promote us-docker.pkg.dev/enfabrica-container-images/infra-prod/dev_container/hw_dev/mojave@sha256:873f80e3cd99f3e9138ffd4fa916358f057e637f4205877f74616cf60ed4653e`
- `bazel run --override_repository=enkit=$HOME/enkit //infra/dev_container/mojave:mojave_dev_image_push -- --official`

JIRA: INFRA-10676, INFRA-10675