### PR TITLE
Update bazel_skylib to 1.7.1

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -134,10 +134,10 @@ def stage_1():
     maybe(
         name = "bazel_skylib",
         repo_rule = http_archive,
-        sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
+        sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
         ],
     )
 

--- a/tools/mdfmt/BUILD.bazel
+++ b/tools/mdfmt/BUILD.bazel
@@ -1,11 +1,6 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//bazel/utils:diff_test.bzl", "diff_test")
 load("//tools/mdfmt:mdfmt.bzl", "mdfmt_filter")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
-
-bzl_library(
-    name = "mdfmt_bzl",
-)
 
 py_binary(
     name = "mdfmt",


### PR DESCRIPTION
This will let us use `expand_template` and speed up the NCCL build.

Tested with presubmit on the main enf repo.