### PR TITLE
kbuild: add developer convenience defaults to build-kernel-tree.sh

### DIFF
--- a/kbuild/v2/scripts/build-kernel-release.sh
+++ b/kbuild/v2/scripts/build-kernel-release.sh
@@ -54,7 +54,7 @@ rsync -a "${KERNEL_SRC_DIR}/" "$ksrc_dir"
 # directly for setting up a development kernel area for bazel...
 
 cd "$ksrc_dir"
-${SCRIPT_PATH}/build-kernel-tree.sh -v "$kernel_version_suffix" -a "$ARCH" -f "$FLAVOUR"
+${SCRIPT_PATH}/build-kernel-tree.sh -q -v "$kernel_version_suffix" -a "$ARCH" -f "$FLAVOUR"
 
 # above script creates sibling dirs of $ksrc_dir named "boot" and
 # "install" and an installer script.

--- a/kbuild/v2/scripts/build-kernel-release.sh
+++ b/kbuild/v2/scripts/build-kernel-release.sh
@@ -54,12 +54,20 @@ rsync -a "${KERNEL_SRC_DIR}/" "$ksrc_dir"
 # directly for setting up a development kernel area for bazel...
 
 cd "$ksrc_dir"
-${SCRIPT_PATH}/build-kernel-tree.sh -q -v "$kernel_version_suffix" -a "$ARCH" -f "$FLAVOUR"
+${SCRIPT_PATH}/build-kernel-tree.sh -q -c -v "$kernel_version_suffix" -a "$ARCH" -f "$FLAVOUR"
 
 # above script creates sibling dirs of $ksrc_dir named "boot" and
 # "install" and an installer script.
 
 kernel_version="$(cat ${BUILD_DIR}/install/build/enf-kernel-version.txt)"
+
+# remove a bunch of unneeded stuff from build directory
+PATTERNS=".*.cmd *.a *.o *.d *.ko *.order *.mod *.mod.c *.mod.o *.log"
+for p in $PATTERNS ; do
+    find "${BUILD_DIR}/install" -name $p -type f -exec rm -f {} +
+done
+
+# TODO: remove even more stuff from the "source" and "install" directory
 
 # now tar up the results
 # - kernel source

--- a/kbuild/v2/scripts/build-kernel-tree.sh
+++ b/kbuild/v2/scripts/build-kernel-tree.sh
@@ -19,6 +19,9 @@ DEFAULT_ARCH="amd64"
 # Default kernel flavour
 DEFAULT_FLAVOUR="generic"
 
+# Default quiet
+DEFAULT_QUIET="no"
+
 # The following ENF_ variables provide an external API and can be set
 # before running this script:
 
@@ -30,6 +33,9 @@ RT_ARCH="${ENF_ARCH:-${DEFAULT_ARCH}}"
 
 # Kernel flavour
 RT_FLAVOUR="${ENF_FLAVOUR:-${DEFAULT_FLAVOUR}}"
+
+# Quiet Build
+RT_QUIET="${ENF_QUIET:-${DEFAULT_QUIET}}"
 
 usage() {
     cat <<EOF
@@ -57,6 +63,13 @@ OPTIONS:
 
         The default is "$DEFAULT_FLAVOUR".
 
+    -q quiet
+
+        Reduce the verbosity of the kernel build.
+
+        The default is a medium noisy build.
+
+
 ENVIRONMENT VARIABLES
 
 Some options can also be set via environment variables:
@@ -64,6 +77,7 @@ Some options can also be set via environment variables:
 ENF_VERSION_SUFFIX:  (current_value: ${ENF_VERSION_SUFFIX:-unset})
 ENF_ARCH:            (current_value: ${ENF_ARCH:-unset})
 ENF_FLAVOUR:         (current_value: ${ENF_FLAVOUR:-unset})
+ENF_QUIET:           (current_value: ${ENF_QUIET:-unset})
 
 In all cases, the command line arguments take precedence.
 
@@ -71,7 +85,7 @@ EOF
 }
 
 # Command line argument override any environment variables
-while getopts hcv:a:f:b: opt ; do
+while getopts hqv:a:f:b: opt ; do
     case $opt in
         v)
             RT_VERSION_SUFFIX=$OPTARG
@@ -81,6 +95,9 @@ while getopts hcv:a:f:b: opt ; do
             ;;
         f)
             RT_FLAVOUR=$OPTARG
+            ;;
+        q)
+            RT_QUIET="yes"
             ;;
         h)
             usage
@@ -169,8 +186,15 @@ esac
 
 NPROC=$(( $(nproc) / 4 ))
 
+if [ "$RT_QUIET" = "yes" ] ; then
+    QUIET="-s"
+else
+    QUIET=""
+fi
+
+
 echo "Building kernel spec: ${RT_ARCH}-${RT_FLAVOUR}"
-make -s \
+make $QUIET \
      O="$build_dir" \
      -j $NPROC \
      $arch_args \


### PR DESCRIPTION
This PR adds two defaults with flags to the `build-kernel-tree.sh`
script, which are convenient for kernel development.

1. `-c` -- perform a clean build, removing the output directory.  This
   is off by default, meaning reuse any existing output directory for
   incremental builds.  This is handy for development.
   
2. `-q` -- perform a "quiet" build.  The default is a medium noisy
   build, useful during development.
   
The kbup-astore script, which builds and publishes artifacts to
astore, using these new flags to perform a clean builds that are less
noisy.