### PR TITLE
gee: Exit the add_parent_branches recursion when a branch has itself as a parent

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3070,6 +3070,11 @@ function _add_parent_branches_to_chain() {
   local B="$1"
   if _contains_element "${B}" "${CHAIN[@]}"; then return; fi
   if [[ "${B}" == "upstream/"* ]]; then return; fi
+
+  # If we find a branch that has itself as a parent also
+  # exit the recursion
+  if [[ "${B}" == "$(_get_parent_branch "${B}")" ]]; then return; fi
+
   _add_parent_branches_to_chain "$(_get_parent_branch "${B}")"
   if (( "${#CHAIN[@]}" > 500 )); then
     _info "CHAIN: ${CHAIN[*]}"


### PR DESCRIPTION
Using `gee` in a slightly non-standard way for the [fork-ns3 repo](https://github.com/enfabrica/fork-ns3). The `master` (which is also the github default branch) is different from the branch that we want to be doing our current development (`acf_s` branch). The way I am trying to make this known to `gee`  so that `gee rupdate` works is by adding the entry:
`acf_s acf_s ''`  in the `parents` file and changing `_add_parent_branches_to_chain()` to make this a valid condition to end the recursion.

