### PR TITLE
Adds detection of "broken" tests: builds, but does not run them.

### DIFF
--- a/bazel/linux/test.bzl
+++ b/bazel/linux/test.bzl
@@ -180,6 +180,15 @@ def qemu_test(
             qemu_binary = qemu_binary,
         ),
     )
+
+    if "tags" in kwargs and "broken" in kwargs["tags"]:
+        for key in kwargs["tags"]:
+            if key.startswith("ticket:"):
+                print("SKIPPED: {} is known to fail ({})".format(name, key[7:]))
+                return
+        fail("Tests marked 'broken' must reference a Jira ticket, ex. 'ticket:LOL-1337'")
+        return
+
     exec_test(name = name, dep = runner, **kwargs)
 
 def kunit_test(


### PR DESCRIPTION
If a Bazel test rule is marked with the "broken" tag, then it should not be run, as it's known to fail & pollutes test runs with false negatives. However, if a broken test is ignored, then it runs the danger of being forgotten about.

This change attempts to strike a balance between the two: broken tests are not run, but they're A) required be associated with a Jira ticket, and B) their names are printed during evaluation.