### PR TITLE
fix: use bash instead of sh

### DIFF
--- a/bazel/astore/astore_upload_dir.sh
+++ b/bazel/astore/astore_upload_dir.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 {astore} upload -G -d {dir} {targets} 

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # To learn more about status commands, read:
 #    https://docs.bazel.build/versions/main/user-manual.html#workspace_status
@@ -17,6 +17,8 @@
 echo "STABLE_ENKIT_USER $(sed -e 's@.*"\(.*\)"@\1@' < ~/.config/enkit/identity/default.toml 2>/dev/null || echo $USER)"
 
 # Prints out current branch
+# FIXME(isaac): This is empty when we're in a detached head (as in the enkit release playbook)
+# and breaks everything downstream that depends on GIT_BRANCH
 GIT_BRANCH="$(git branch --show-current)"
 echo GIT_BRANCH "$GIT_BRANCH"
 


### PR DESCRIPTION
In our dev environment sh points to bash but this is not the default on ubuntu.

This fixes our scripts to not assume sh is bash.

This doesn't fix everything in this repo - but it's a start.