### PR TITLE
feat: add bazel rules for dive

### DIFF
--- a/bazel/dive/BUILD.bazel
+++ b/bazel/dive/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["dive.sh.tpl"])

--- a/bazel/dive/dive.bzl
+++ b/bazel/dive/dive.bzl
@@ -1,0 +1,44 @@
+def _oci_dive_impl(ctx):
+    tarball = ctx.file.src
+    dive_bin = ctx.file.dive_bin
+
+    exe = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.expand_template(
+        template = ctx.file._dive_template,
+        output = exe,
+        substitutions = {
+            "{{dive_bin}}": dive_bin.path,
+            "{{tarball}}": tarball.short_path,
+        },
+        is_executable = True,
+    )
+
+    runfiles = [tarball, dive_bin]
+
+    return [
+        DefaultInfo(files = depset([exe]), runfiles = ctx.runfiles(files = runfiles), executable = exe),
+    ]
+
+oci_dive = rule(
+    implementation = _oci_dive_impl,
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = [".tar"]
+        ),
+        "dive_bin": attr.label(
+            default = "@dive_x86_64",
+            allow_single_file = True,
+        ),
+        "_dive_template": attr.label(
+            default = Label("//bazel/dive:dive.sh.tpl"),
+            allow_single_file = True,
+        ),
+    },
+    doc = """
+Analyze an OCI tar archive with dive
+""",
+    executable = True,
+)
+

--- a/bazel/dive/dive.sh.tpl
+++ b/bazel/dive/dive.sh.tpl
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errexit -o nounset
+
+readonly DIVE_BIN="{{dive_bin}}"
+readonly TARBALL="{{tarball}}"
+
+"$DIVE_BIN" "docker-archive://$TARBALL"

--- a/bazel/dive/repositories.bzl
+++ b/bazel/dive/repositories.bzl
@@ -1,0 +1,18 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def dive_dependencies():
+    maybe(
+        http_archive,
+        name = "dive_x86_64",
+        build_file_content = """
+filegroup(
+    name = "dive_x86_64",
+    srcs = ["dive"],
+    visibility = ["//visibility:public"],
+)
+""",
+        sha256 = "20a7966523a0905f950c4fbf26471734420d6788cfffcd4a8c4bc972fded3e96",
+        url = "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_linux_amd64.tar.gz",
+    )
+

--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -1,4 +1,5 @@
 load("//bazel/utils:files.bzl", "write_to_file")
+load("//bazel/dive:dive.bzl", "oci_dive")
 load("@enkit//bazel/utils:merge_kwargs.bzl", "merge_kwargs")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
@@ -113,6 +114,9 @@ def nonhermetic_image_builder(*args, **kwargs):
     kwargs["staging_repo"] = "{}_staging".format(name)
     kwargs["prod_repo"] = "{}_prod".format(name)
     _nonhermetic_image_builder(*args, **kwargs)
+
+def container_dive(*args, **kwargs):
+    oci_dive(*args, **kwargs)
 
 def container_image(*args, **kwargs):
     name = kwargs.get("name")


### PR DESCRIPTION
Integrates [dive](https://github.com/wagoodman/dive) with bazel.

The rule takes an `oci_tarball` as input and will output a shell script that loads the tarball into a hermetic dive binary that you can `bazel run`.

See companion PR: https://github.com/enfabrica/internal/pull/44482/files