### PR TITLE
Fix shell interpreter for kunit tests script

### DIFF
--- a/bazel/linux/templates/kunit.template.sh
+++ b/bazel/linux/templates/kunit.template.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo ========= {message} - {target} ==========
 


### PR DESCRIPTION
With the latest upgrade in the dev container, targets that run kunit tests locally, like:

`bazel run //mcu/api:qemu_kunit_multi_gen_module`

stopped working. This patch fixes the problem.