### PR TITLE
bazel/linux/defs.bzl: better prune kernel modules dependencies.

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -23,19 +23,20 @@ def _kernel_modules(ctx):
         kdeps.extend(get_compatible(ctx, ki.arch, ki.package, d))
 
     for d in ctx.attr.deps:
-        inputs.extend(d.files.to_list())
-
         if not is_module(d):
             if CcInfo in d:
                 inputs += d[CcInfo].compilation_context.headers.to_list()
                 includes += d[CcInfo].compilation_context.includes.to_list()
                 quote_includes += d[CcInfo].compilation_context.quote_includes.to_list()
+
+            inputs.extend(d.files.to_list())
         else:
             mods = get_compatible(ctx, ki.arch, ki.package, d)
 
             kdeps.extend(mods)
             for mod in mods:
                 extra_symbols.extend([f for f in mod.files if f.extension == "symvers"])
+                inputs.extend(mod.files)
 
     outputs = []
     message = ""


### PR DESCRIPTION
Background:
A single kernel module rule can result in building multiple modules: one per
platform supported x one per kernel supported.

Before this PR:
- When a kernel module depends on another kernel module, it implicitly depends
  on ALL the artifacts produced by the other kernel module.

  So for example, if I'm building a kernel module for one kernel one platform
  only, any other module this module depends on will actually be built for ALL
  platforms and for ALL kernels the other module is DEFINED for. Even if not
  needed.

After this PR:
- The dependency graph is pruned so that only dependencies in the same platform
  and same kernel are carried on.

Tested:
bazel aquery //driver/ib:enf-ubuntu-impish-generic-enf_ib

Without --override_repository=...:
    [...]
    Inputs: [
      bazel-out/k8-fastbuild-ST-837e96fca359/bin/driver/core/enf-ubuntu-impish-emulator-aarch64/enf_core-aarch64/aarch64/enf_core.ko,
      bazel-out/k8-fastbuild-ST-837e96fca359/bin/driver/core/enf-ubuntu-impish-emulator-aarch64/enf_core-aarch64/aarch64/enf_core.ko.symvers,
      bazel-out/k8-fastbuild/bin/driver/core/enf-ubuntu-impish-generic/enf_core/host/enf_core.ko,
      bazel-out/k8-fastbuild/bin/driver/core/enf-ubuntu-impish-generic/enf_core/host/enf_core.ko.symvers,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-internal/capnp_c.h,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-list.inc,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-malloc.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-stream.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capnp_c.h,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capnp_priv.h
      [...]

With --override_repository=...:
    [...]
    Inputs: [
      bazel-out/k8-fastbuild/bin/driver/core/enf-ubuntu-impish-generic/enf_core/host/enf_core.ko,
      bazel-out/k8-fastbuild/bin/driver/core/enf-ubuntu-impish-generic/enf_core/host/enf_core.ko.symvers,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-internal/capnp_c.h,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-list.inc,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-malloc.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn-stream.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capn.c,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capnp_c.h,
      bazel-out/k8-fastbuild/bin/external/c-capnproto/_virtual_includes/c-capnproto-lib/c-capnproto/capnp_priv.h,
      bazel-out/k8-fastbuild/bin/mcu/api/all.capnp.c,
      [...]

Note the first two lines: WITHOUT this PR, it is pulling in the aarch64 dependencies.
With this PR, it is NOT pulling in the aarch64 dependencies.
