### PR TITLE
gee rmbr: improvements

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4817,44 +4817,63 @@ EOT
 
 function _remove_a_branch() {
   local BR="$1"
+  local STATE
 
   _banner "Deleting ${BR}"
-  _checkout_or_die "${BR}"
-  _set_main
-  local -a  counts=()
-  read -r -a counts < <("${GIT}" rev-list --left-right --count "${MAIN}...${BR}")
-  if (( counts[1] != 0 )); then
-    _warn "Branch \"${BR}\" is ${counts[1]} commit(s) ahead of ${MAIN}."
-    _confirm_or_exit "Are you sure you want to force-remove branch ${BR}? (y/N) "
-    _info "As you wish."
-  fi
-  if [[ -n "$("${GIT}" status --porcelain)" ]]; then
-    _warn "Branch \"${BR}\" contains uncommitted changes."
-    _confirm_or_exit "Are you sure you want to force-remove branch ${BR}? (y/N) "
-    _info "Whatever you say, boss."
+  # if a local branch exists, or if the worktree directory exists:
+  if "${GIT}" show-ref --quiet "refs/heads/${BR}" || [[ -d "${GEE_REPO_DIR}/${BR}" ]]; then
+    _checkout_or_die "${BR}"
+    _set_main
+
+    # Check if branch is clean
+    STATE=CLEAN
+    local -a  counts=()
+    read -r -a counts < <("${GIT}" rev-list --left-right --count "${MAIN}...${BR}")
+    if (( counts[1] != 0 )); then
+      _warn "Branch \"${BR}\" is ${counts[1]} commit(s) ahead of ${MAIN}."
+      STATE=UNCLEAN
+    fi
+    if [[ -n "$("${GIT}" status --porcelain)" ]]; then
+      _warn "Branch \"${BR}\" contains uncommitted changes."
+      STATE=UNCLEAN
+    fi
+    if [[ "${STATE}" != "CLEAN" ]]; then
+      if _confirm_default_no "Are you sure you want to force-remove branch ${BR}? (y/N) "; then
+        _info "By your command."
+      else
+        _info "Skipping."
+        return 0
+      fi
+    fi
+
+    local SHA
+    SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
+
+    # delete the bazel cache associated with this worktree
+    if [[ -h ./bazel-out ]] && readlink -qf ./bazel-out; then
+      local BAZELCACHE
+      BAZELCACHE="$(readlink -f ./bazel-out)"
+      BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"
+      _info "Removing linked bazel cache directory \"${BAZELCACHE}\""
+      chmod -R u+w "${BAZELCACHE}"
+      rm -rf "${BAZELCACHE}"
+    fi
+
+    _checkout_or_die "${MAIN}"
+    # --force is required for git v2.17.1, or the remove operation will always fail.
+    _git worktree remove --force "${BR}"
+    _git branch -D "${BR}"
+
+    _info "Deleted local branch ${BR}.  To undo: gee make_branch ${BR} ${SHA}"
+  else
+    _warn "Local branch \"${BR}\" not found: skipped."
   fi
 
-  local SHA
-  SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
-
-  # delete the bazel cache associated with this worktree
-  if [[ -h ./bazel-out ]] && readlink -qf ./bazel-out; then
-    local BAZELCACHE
-    BAZELCACHE="$(readlink -f ./bazel-out)"
-    BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"
-    _info "Removing linked bazel cache directory \"${BAZELCACHE}\""
-    chmod -R u+w "${BAZELCACHE}"
-    rm -rf "${BAZELCACHE}"
-  fi
-
-  _checkout_or_die "${MAIN}"
-  # --force is required for git v2.17.1, or the remove operation will always fail.
-  _git worktree remove --force "${BR}"
-  _git branch -D "${BR}"
   if _remote_branch_exists origin "${BR}"; then
     _git_can_fail push --quiet origin --delete "${BR}" | cat
+    _info "Deleted remote branch origin/${BR}"
   else
-    _info "Not deleting remote branch ${BR}: was never created."
+    _info "Remote branch origin/${BR} not found: skipped."
   fi
 
   # Remove branch from parents file, and fix up children's parents.
@@ -4870,8 +4889,6 @@ function _remove_a_branch() {
     fi
   done
   _write_parents_file
-
-  _info "Deleted ${BR}.  To undo: gee make_branch ${BR} ${SHA}"
 }
 
 function gee__rmbr() { gee__remove_branch "$@"; }


### PR DESCRIPTION
The `rmbr` and `cleanup` commands are now improved:

* detects if a branch exists before attempting to delete it, avoiding the extra
  "create a branch then delete it" steps.

* when deleting a list of branches, choosing not to delete a single branch doesn't
  cause the entire command to immediately abort (subsequent branches will still
  be deleted).

* improved messages.

Tested:

```
    $ gee rmbr nem_406 nem_406_2 nem_406_3 new nightly1 our_cdc_tool our_cdc_tool2 \
      pkgdef_elab pkgdef_elab_backup pr_38545 pr_40659 pr_40659_part_two pr_41554 \
      pr_44633 rollback_--help rtl_4311 rtl_4540 rtl_4641 rtl_4751 rtl_4815 \
      rtl_4848_limit_to_hbt rtl_4857 struct_to_pd_name synchk_codeowners \
      synreport_ics synth_check_import synth_check_update testbranch vxe_covergroup \
      xprop2

    ####################
    # Deleting nem_406 #
    ####################
    WARNING: Local branch "nem_406" not found: skipped.
    Remote branch origin/nem_406 not found: skipped.

    ######################
    # Deleting nem_406_2 #
    ######################
    WARNING: Local branch "nem_406_2" not found: skipped.
    Remote branch origin/nem_406_2 not found: skipped.

    [...]

    #####################
    # Deleting pr_38545 #
    #####################
    WARNING: Branch "pr_38545" is 3 commit(s) ahead of master.
    Are you sure you want to force-remove branch pr_38545? (y/N) n
    Skipping.

    #####################
    # Deleting pr_40659 #
    #####################
    CMD: /usr/bin/git worktree remove --force pr_40659
    CMD: /usr/bin/git branch -D pr_40659
    Deleted branch pr_40659 (was cc4dea3701).
    Deleted local branch pr_40659.  To undo: gee make_branch pr_40659 cc4dea3701
    CMD: /usr/bin/git push --quiet origin --delete pr_40659
    Deleted remote branch origin/pr_40659

    [...]

    #####################
    # Deleting pr_44633 #
    #####################
    WARNING: Branch "pr_44633" is 3 commit(s) ahead of master.
    Are you sure you want to force-remove branch pr_44633? (y/N) y
    By your command.
    /home/jonathan/.cache/bazel/_bazel_jonathan/aae32719d0bd8c6288b201224d81d88c/execroot/enfabrica/bazel-out
    Removing linked bazel cache directory "/home/jonathan/.cache/bazel/_bazel_jonathan/aae32719d0bd8c6288b201224d81d88c"
    CMD: /usr/bin/git worktree remove --force pr_44633
    CMD: /usr/bin/git branch -D pr_44633
    Deleted branch pr_44633 (was cb100af2ba).
    Deleted local branch pr_44633.  To undo: gee make_branch pr_44633 cb100af2ba
    CMD: /usr/bin/git push --quiet origin --delete pr_44633
    Deleted remote branch origin/pr_44633

    ############################
    # Deleting rollback_--help #
    ############################
    CMD: /usr/bin/git worktree remove --force rollback_--help
    CMD: /usr/bin/git branch -D rollback_--help
    Deleted branch rollback_--help (was bef6350d00).
    Deleted local branch rollback_--help.  To undo: gee make_branch rollback_--help bef6350d00
    Remote branch origin/rollback_--help not found: skipped.

    #####################
    # Deleting rtl_4311 #
    #####################
    CMD: /usr/bin/git worktree remove --force rtl_4311
    CMD: /usr/bin/git branch -D rtl_4311
    Deleted branch rtl_4311 (was d537d2a23e).
    Deleted local branch rtl_4311.  To undo: gee make_branch rtl_4311 d537d2a23e
    CMD: /usr/bin/git push --quiet origin --delete rtl_4311
    Deleted remote branch origin/rtl_4311

    [...]

```


