### PR TITLE
gee 0.2.51: add support for non-standard base branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3088,7 +3088,8 @@ function _add_parent_branches_to_chain() {
   # If the current branch is upstr
   if [[ "${B}" == "upstream/"* ]]; then return; fi
 
-  local P="$(_get_parent_branch "${B}")"
+  local P
+  P="$(_get_parent_branch "${B}")"
   # if parent branch is the current branch, stop.
   if [[ "${P}" == "${B}" ]]; then return; fi
 
@@ -4116,7 +4117,7 @@ function gee__pr_make() {
 
   _check_cwd
   _check_gh_auth
-  local DEST_BRANCH CURRENT_BRANCH NUM_COMMITS
+  local DEST_BRANCH CURRENT_BRANCH NUM_COMMITS FIRST_PARENT UPSTREAM_PARENT
   _git fetch upstream
   _read_parents_file
 
@@ -4125,8 +4126,8 @@ function gee__pr_make() {
 
   local -a CHAIN=()
   _add_parent_branches_to_chain "${CURRENT_BRANCH}"
-  local FIRST_PARENT="${CHAIN[0]}"
-  local UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
+  FIRST_PARENT="${CHAIN[0]}"
+  UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
   DEST_BRANCH="${UPSTREAM_PARENT}"
   _info "Destination branch: ${DEST_BRANCH}"
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.50"
+readonly VERSION="0.2.51"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -108,6 +108,10 @@ review.
 * `GEE_BUILDLOGS_PROJECT`: If you are using gcloud to store your presubmit testing logs, you can
   override gee's default gcloud project by setting this environment variable.
 
+* `GEE_PR_BASE`: Sets the name of the default upstream branch that you want to integrate your
+  PRs to.  If unspecified, defaults to "master", but can be used to mark PRs are being
+  destined for integration into branches like "master_b0", for example.
+
 * `UPSTREAM`: The name of the github user hosting the specified repository.  By default, `enfabrica`.
 
 * `YESYESYES`: If set to a non-zero integer, will cause all yes/no prompts within `gee` to automatically
@@ -259,6 +263,7 @@ TESTMODE="${TESTMODE:-0}"
 MAIN="" # Unknown, call _set_main to set.
 REPO="${REPO:-"${GEE_REPO:-}"}"
 PAGER="${PAGER:-less}"
+GEE_PR_BASE="${GEE_PR_BASE:-""}"  # branch to merge PRs into.
 PARENTS_FILE_IS_LOADED=0
 PWD_CMD="$(command -v pwd)"  # dev: /usr/bin/pwd, fpga-dev: /bin/pwd  :-(
 declare -A FLAGS=()  # for _parse_options(), below
@@ -4076,6 +4081,16 @@ If you have any second thoughts during this process: Adding the token "DRAFT"
 to your PR description will cause the PR to be marked as a draft.  Adding the
 token "ABORT" will cause gee to abort the creation of your PR.
 
+By default, `pr_make` creates a PR that targets upstream/master as the branch
+for the PR to merge into.  However, this branch can be changed in two ways:
+
+* The `GEE_PR_BASE` environment variable can be used to specify the name of the
+  upstream branch to merge into.
+
+* The `--base <branchname>` argument can be added to the command line to
+  explicitly specify the name of the upstream branch to target.  This value
+  will override the value in `GEE_PR_BASE`, if set.
+
 Uses the same options as "gh pr create".
 EOT
 
@@ -4273,6 +4288,14 @@ EndOfPrTemplate
   for A in "${ASSIGNEES[@]}"; do
     PR_ARGS+=(--assignee "${A}")
   done
+
+  if [[ -n "${GEE_PR_BASE}" ]]; then
+    if [[ "$*" == *"--base"* ]]; then
+      _info "GEE_PR_BASE ignored due to use of --base switch on the command line."
+    else
+      PR_ARGS+=(--base "${GEE_PR_BASE}")
+    fi
+  fi
 
   PR_ARGS+=( "$@" )
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -1387,8 +1387,8 @@ function _git_rev_list_counts() {
   if [[ "${P}" == upstream/refs/pull/*/head ]]; then
     "${GIT}" fetch upstream "${P#upstream/refs/}" >/dev/null 2>&1
     P=FETCH_HEAD
-  elif [[ "${P}" == upstream/* ]]; then
-    "${GIT}" fetch upstream "${P#upstream}" >/dev/null 2>&1
+  elif [[ "${P}" == */* ]]; then
+    "${GIT}" fetch "${P%%/*}" "${P#upstream}" >/dev/null 2>&1
     P=FETCH_HEAD
   fi
   "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true
@@ -4099,8 +4099,7 @@ token "ABORT" will cause gee to abort the creation of your PR.
 
 `pr_make` will look at the recursive parentage of the current branch  until
 it finds a remote branch as a parent.  This remote branch (usually `upstream/master`)
-will be used as the "base" branch for the PR to be merged into.  This "base"
-branch can be overriden useing the "--base <branchname>" flag.
+will be used as the "base" branch for the PR to be merged into.
 
 Uses the same options as "gh pr create".
 EOT
@@ -4120,11 +4119,24 @@ function gee__pr_make() {
   local DEST_BRANCH CURRENT_BRANCH NUM_COMMITS
   _git fetch upstream
   _read_parents_file
-  _set_main
-  DEST_BRANCH="upstream/${MAIN}"
+
   CURRENT_BRANCH="$(_get_current_branch)"
   _info "Current branch: ${CURRENT_BRANCH}"
+
+  local -a CHAIN=()
+  _add_parent_branches_to_chain "${CURRENT_BRANCH}"
+  local FIRST_PARENT="${CHAIN[0]}"
+  local UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
+  DEST_BRANCH="${UPSTREAM_PARENT}"
   _info "Destination branch: ${DEST_BRANCH}"
+
+  if [[ "${DEST_BRANCH}" == */pull/* ]]; then
+    _warn "This branch was created from a pull request (${DEST_BRANCH})." \
+          "To create a pull request, you need to change the parent of this branch" \
+          "to indicate the upstream branch you want to merge into.  For example:" \
+          "    gee set_parent upstream/master"
+    _fatal "Refusing to create a PR until parent branch is updated."
+  fi
 
   local -a pr_vars
   mapfile -t pr_vars < \
@@ -4215,9 +4227,9 @@ EndOfPrTemplate
       printf "      easier to read.\n\n"
     fi
     printf "\n# The following files were modified in this PR:\n"
-    "${GIT}" diff --name-only "${PARENT}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
+    "${GIT}" diff --name-only "${DEST_BRANCH}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
     printf "#\n# Here is your commit log:\n"
-    "${GIT}" log --reverse "${PARENT}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
+    "${GIT}" log --reverse "${DEST_BRANCH}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
 
     # TODO(jonathan): add support for specifying tags and reviewers in the
     #                 PR description.
@@ -4277,6 +4289,7 @@ EndOfPrTemplate
     --title "${TITLE}"
     -H "${GHUSER}:${CURRENT_BRANCH}"
     --body-file "${TRIMMED}"
+    --base "${UPSTREAM_PARENT#*/}"
   )
   local DRAFT=0
   if grep --quiet -E "^\s*DRAFT" "${TRIMMED}"; then
@@ -4297,15 +4310,6 @@ EndOfPrTemplate
   for A in "${ASSIGNEES[@]}"; do
     PR_ARGS+=(--assignee "${A}")
   done
-
-  if [[ "$*" != *"--base"* ]]; then
-    # base was not specified, so we have to look at tree to find it.
-    local -a CHAIN=()
-    _add_parent_branches_to_chain "${CURRENT_BRANCH}"
-    local FIRST_PARENT="${CHAIN[0]}"
-    local UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
-    PR_ARGS+=(--base "${UPSTREAM_PARENT#*/}")
-  fi
 
   PR_ARGS+=( "$@" )
 
@@ -4573,10 +4577,11 @@ function gee__pr_submit() {
   # Check the status of the PR.
   local -a pr_vars=()
   mapfile -t pr_vars < \
-    <("${GH}" pr view --json number,state,isDraft --jq '.number, .state, .isDraft')
+    <("${GH}" pr view --json number,state,isDraft,baseRefName --jq '.number, .state, .isDraft, .baseRefName')
   local pr_number="${pr_vars[0]}"
   local pr_state="${pr_vars[1]}"
   local pr_is_draft="${pr_vars[2]}"
+  local pr_base="${pr_vars[3]}"
   if [[ "${pr_state}" == "MERGED" ]]; then
     _fatal "Associated PR #${pr_number} has already been merged."
   fi
@@ -4621,10 +4626,9 @@ function gee__pr_submit() {
   fi
 
   # Get some information about this PR before we merge.
-  _set_main
   local MERGEBASE
-  MERGEBASE="$( "${GIT}" merge-base "upstream/${MAIN}" "origin/${CURRENT_BRANCH}" )"
-  _info "Merge base: ${MERGEBASE}"
+  MERGEBASE="$( "${GIT}" merge-base "upstream/${pr_base}" "origin/${CURRENT_BRANCH}" )"
+  _info "Merging into ${pr_base}, Merge base: ${MERGEBASE}"
   local -a COMMITS
   mapfile -t COMMITS < <( "${GIT}" log --pretty=oneline "${MERGEBASE}"..HEAD | awk '{print $1}' )
   local -a FILES
@@ -4658,7 +4662,7 @@ function gee__pr_submit() {
     --repo "${UPSTREAM}/${REPO}" \
     "${FROM_BRANCH}"
   rm "${BODYFILE}"
-  _update_main
+  _git fetch upstream
 
   # This check is of low value (gr pr merge is reliable), and occasionally
   # reports false negatives (ie. if two PRs changed the same file, but
@@ -4676,7 +4680,7 @@ function gee__pr_submit() {
 
   # Reset this branch to now contain the squash-merged commit:
   _checkout_or_die "${CURRENT_BRANCH}"  # make sure we're in the right branch.
-  _git checkout -B "${CURRENT_BRANCH}" "upstream/${MAIN}"
+  _git checkout -B "${CURRENT_BRANCH}" "upstream/${pr_base}"
   _push_to_origin "+${CURRENT_BRANCH}"
 
   # After a squash merge, we have a potential problem for child (and
@@ -5082,6 +5086,7 @@ function gee__gcd() {
   # check whether BRANCH exists:
   if ! _local_branch_exists "${BRANCH}"; then
     if (( OPT_M == 1 )); then
+      # option -m is equivalent to "-B upstream/master"
       PARENT="upstream/${MAIN}"
       OPT_B=1
     fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,15 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
-#
-# TODO(jonathan):
-#   * allow branches to be created as clones of any upstream branch, not just master
-#   * keep track of the upstream branch in the parents file.
-#   * recursive updates always halt when either an upstream branch is reached,
-#     or a branch is marked as its own parent.
-#   * update all legacy parents files so that upstream/master is the parent of master.
-#   * support --base flag in gee mkbr
-# TODO(jonathan): allow creation of branches whose parent is a non-standard upstream branch
 
 readonly VERSION="0.2.51"
 
@@ -2478,15 +2469,32 @@ _register_help "make_branch" \
   "Create a new child branch based on the current branch." \
   "mkbr" \
   <<'EOT'
-Usage: gee make_branch <branch-name> [<commit-ish>]
+Usage: gee make_branch <branch-name> [<parent-branch>]
 Aliases: mkbr
 
-Create a new branch based on the current branch.  The new branch will be located in the
+Create a new branch based.  The new branch will be located in the
 directory:
   ~/gee/<repo>/<branch-name>
 
-If <commit-ish> is provided, sets the HEAD of the newly created branch to that
-revision.
+If the parent branch is not specified, the current branch is used as the parent
+branch.  An arbitrary upstream branch may be specified as the parent branch
+(ie. `upstream/master_a0`).
+
+Note that if the parent branch is a non-master upstream branch, any PR created
+from this branch (or a child of this branch) will use that non-master branch
+as the base branch to merge into.
+
+If a matching branch exists in origin (ie, if `origin/<branch-name>` exists),
+gee will ask the user if they want to integrate commits from origin into the
+current branch.
+
+For example:
+
+    cd $(gee gcd bar)
+    gee make_branch foo  # foo is a child branch of the current branch, bar
+    gee make_branch based_on_master upstream/master
+    gee make_branch based_on_fork_a0 upstream/fork_a0
+
 EOT
 
 function gee__mkbr() { gee__make_branch "$@"; }

--- a/scripts/gee
+++ b/scripts/gee
@@ -1,6 +1,15 @@
 #!/bin/bash
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
+#
+# TODO(jonathan):
+#   * allow branches to be created as clones of any upstream branch, not just master
+#   * keep track of the upstream branch in the parents file.
+#   * recursive updates always halt when either an upstream branch is reached,
+#     or a branch is marked as its own parent.
+#   * update all legacy parents files so that upstream/master is the parent of master.
+#   * support --base flag in gee mkbr
+# TODO(jonathan): allow creation of branches whose parent is a non-standard upstream branch
 
 readonly VERSION="0.2.51"
 
@@ -107,10 +116,6 @@ review.
 
 * `GEE_BUILDLOGS_PROJECT`: If you are using gcloud to store your presubmit testing logs, you can
   override gee's default gcloud project by setting this environment variable.
-
-* `GEE_PR_BASE`: Sets the name of the default upstream branch that you want to integrate your
-  PRs to.  If unspecified, defaults to "master", but can be used to mark PRs are being
-  destined for integration into branches like "master_b0", for example.
 
 * `UPSTREAM`: The name of the github user hosting the specified repository.  By default, `enfabrica`.
 
@@ -263,7 +268,6 @@ TESTMODE="${TESTMODE:-0}"
 MAIN="" # Unknown, call _set_main to set.
 REPO="${REPO:-"${GEE_REPO:-}"}"
 PAGER="${PAGER:-less}"
-GEE_PR_BASE="${GEE_PR_BASE:-""}"  # branch to merge PRs into.
 PARENTS_FILE_IS_LOADED=0
 PWD_CMD="$(command -v pwd)"  # dev: /usr/bin/pwd, fpga-dev: /bin/pwd  :-(
 declare -A FLAGS=()  # for _parse_options(), below
@@ -1823,34 +1827,21 @@ function _safer_rebase() {
   CHILD_DIR="$(_get_branch_rootdir "${CHILD}")"
   cd "${CHILD_DIR}"
   local PARENT_HEAD
-  if [[ "${PARENT}" == "upstream/"* ]]; then
-    PARENT_HEAD="$(git ls-remote upstream "${PARENT#upstream/}" | awk '{print $1}')"
+  if [[ "${PARENT}" == */* ]]; then
+    # make sure remote is up to date:
+    _git fetch "${PARENT%%/*}"
+    PARENT_HEAD="$(git ls-remote "${PARENT%%/*}" "${PARENT#upstream/}" | awk '{print $1}')"
   else
     PARENT_HEAD="$(git show-ref "refs/heads/${PARENT}" | awk '{print $1}')"
   fi
 
   # Use rebase for local parent branches, or pull for remote parent branches.
   local -a GITCMD=()
-  if [[ "${PARENT}" == "upstream/"* ]]; then
-    if [[ -n "${ONTO}" ]]; then
-      # TODO(jonathan): figure out the right way to split this into git
-      # fetch/rebase steps, so --onto can work -- though we are unlikely
-      # to ever need this (squash-merge from a fork of another's PR?).
-      #
-      # I wonder what I'm doing wrong?  Naively:
-      # $ git fetch upstream
-      # $ git rebase upstream/pull/1234/head
-      # fatal: invalid upstream 'upstream/pull/1234/head'
-      _die "git pull --rebase does not support --onto"
-    fi
-    GITCMD+=( pull --rebase --autostash upstream "${PARENT#upstream/}" )
-  else
-    GITCMD+=( rebase --autostash )
-    if [[ -n "${ONTO}" ]]; then
-      GITCMD+=(--onto "${ONTO}")
-    fi
-    GITCMD+=( "${PARENT}" "${CHILD}" )
+  GITCMD+=( rebase --autostash )
+  if [[ -n "${ONTO}" ]]; then
+    GITCMD+=(--onto "${ONTO}")
   fi
+  GITCMD+=( "${PARENT}" "${CHILD}" )
 
   _checkout_or_die "${CHILD}"
   if ! _git "${GITCMD[@]}"; then
@@ -2059,6 +2050,9 @@ function _read_parents_file() {
     MERGEBASES["${BRANCH}"]="${MERGEBASE}"
   done < "${PATH}" \
     || /bin/true
+  # Hack: fixup the parent for the special branch "master":
+  PARENTS["master"]="upstream/master"
+  MERGEBASES["master"]=""
   PARENTS_FILE_IS_LOADED=1
 }
 
@@ -2505,41 +2499,46 @@ function gee__make_branch() {
   SHA="$1"
 
   _set_main
-  CURRENT_BRANCH="$(_get_current_branch)"
-  if [[ -z "${CURRENT_BRANCH}" ]]; then
-    CURRENT_BRANCH="${MAIN}"
+  if [[ -z "${SHA}" ]]; then
+    SHA="$(_get_current_branch)"
+    if [[ -z "${SHA}" ]]; then
+      SHA="upstream/${MAIN}"
+    fi
   fi
-  _checkout_or_die "${CURRENT_BRANCH}"
 
-  local -a ARGS=( worktree add -f "${GEE_REPO_DIR}/${BRNAME}" )
+  if [[ "${SHA}" == "upstream/"* ]]; then
+    _git fetch upstream
+  fi
+
+  local -a ARGS=( worktree add -b "${BRNAME}" -f "${GEE_REPO_DIR}/${BRNAME}" "${SHA}")
   _git "${ARGS[@]}"
   _info "Created ${GEE_REPO_DIR}/${BRNAME}"
 
   _read_parents_file
-  PARENTS["${BRNAME}"]="${CURRENT_BRANCH}"
+  PARENTS["${BRNAME}"]="${SHA}"
   _write_parents_file
-
-  if [[ -n "${SHA}" ]]; then
-    _info "Setting HEAD of branch \"${BRNAME}\" to \"${SHA}\""
-    _checkout_or_die "${BRNAME}"
-    git reset --hard "${SHA}"
-  fi
 
   # If the user has created a branch whose name matches an
   # existing branch in their existing repo, pull those changes
   # into this branch.
+  _git fetch origin
   if _remote_branch_exists origin "${BRNAME}"; then
     _checkout_or_die "${BRNAME}"
-    _git fetch origin
     local -a COUNTS
-    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${MAIN}...origin/${CURRENT_BRANCH}")
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "HEAD...origin/${CURRENT_BRANCH}")
     if [[ "${COUNTS[1]}" -gt 0 ]]; then
-      _warn "Remote branch origin/${BRNAME} is ${COUNTS[1]} commit(s) ahead of master." \
-            "Do you want to reset your local branch to be the same as origin/${BRNAME}?"
-      if _confirm_default_yes "Reset ${BRNAME} to match origin/${BRNAME}?  (Y/n)  "; then
-        _git reset --hard "origin/${BRNAME}"
+      if [[ "${COUNTS[0]}" -eq 0 ]]; then
+        _warn "Remote branch origin/${BRNAME} is ${COUNTS[1]} commit(s) ahead of master." \
+              "Do you want to reset your local branch to be the same as origin/${BRNAME}?"
+        if _confirm_default_yes "Reset ${BRNAME} to match origin/${BRNAME}?  (Y/n)  "; then
+          _git reset --hard "origin/${BRNAME}"
+        else
+          _warn "Commits from origin/${BRNAME} were not imported." \
+                "You probably want to run \"gee update\" in branch ${BRNAME}."
+        fi
       else
-        _warn "Commits from origin/${BRNAME} were not imported." \
+        _warn "Local branch has ${COUNTS[0]} commits that are not in origin." \
+              "Origin has ${COUNTS[1]} commits that are not in the local branch." \
               "You probably want to run \"gee update\" in branch ${BRNAME}."
       fi
     else
@@ -3072,18 +3071,22 @@ function _add_parent_branches_to_chain() {
   # any parent is earlier than any child.  Recursive searching
   # for parent branches ultimately stops when we reach an
   # upstream branch.
+  #
+  # Recursive list of branches halts at:
+  # * any branch whose parent is in upstream.
   local B="$1"
   if _contains_element "${B}" "${CHAIN[@]}"; then return; fi
+
+  # If the current branch is upstr
   if [[ "${B}" == "upstream/"* ]]; then return; fi
 
-  # If we find a branch that has itself as a parent also
-  # exit the recursion
-  if [[ "${B}" == "$(_get_parent_branch "${B}")" ]]; then return; fi
+  local P="$(_get_parent_branch "${B}")"
+  # if parent branch is the current branch, stop.
+  if [[ "${P}" == "${B}" ]]; then return; fi
 
-  _add_parent_branches_to_chain "$(_get_parent_branch "${B}")"
-  if (( "${#CHAIN[@]}" > 500 )); then
-    _info "CHAIN: ${CHAIN[*]}"
-    _die "_add_parent_branches_to_chain recursed too deeply."
+  # Keep recursing until we reach a branch whose parent is remote:
+  if [[ "${P}" != */* ]]; then
+    _add_parent_branches_to_chain "${P}"
   fi
   CHAIN+=( "${B}" )
 }
@@ -3121,6 +3124,11 @@ function gee__rupdate() {
           "${UNCOMMITTED[@]}" \
           "Commit branch ${B} and try again."
       fi
+    fi
+
+    # if parent is a remote, make sure remote is up to date.
+    if [[ "${PARENT_BRANCH}" == */* ]]; then
+      _git fetch "${PARENT_BRANCH%%/*}"
     fi
 
     # Rebase from PREVIOUS_B onto B
@@ -4081,15 +4089,10 @@ If you have any second thoughts during this process: Adding the token "DRAFT"
 to your PR description will cause the PR to be marked as a draft.  Adding the
 token "ABORT" will cause gee to abort the creation of your PR.
 
-By default, `pr_make` creates a PR that targets upstream/master as the branch
-for the PR to merge into.  However, this branch can be changed in two ways:
-
-* The `GEE_PR_BASE` environment variable can be used to specify the name of the
-  upstream branch to merge into.
-
-* The `--base <branchname>` argument can be added to the command line to
-  explicitly specify the name of the upstream branch to target.  This value
-  will override the value in `GEE_PR_BASE`, if set.
+`pr_make` will look at the recursive parentage of the current branch  until
+it finds a remote branch as a parent.  This remote branch (usually `upstream/master`)
+will be used as the "base" branch for the PR to be merged into.  This "base"
+branch can be overriden useing the "--base <branchname>" flag.
 
 Uses the same options as "gh pr create".
 EOT
@@ -4106,16 +4109,14 @@ function gee__pr_make() {
 
   _check_cwd
   _check_gh_auth
-  local DEST_BRANCH CURRENT_BRANCH MERGE_BASE NUM_COMMITS
+  local DEST_BRANCH CURRENT_BRANCH NUM_COMMITS
   _git fetch upstream
   _read_parents_file
   _set_main
   DEST_BRANCH="upstream/${MAIN}"
   CURRENT_BRANCH="$(_get_current_branch)"
-  MERGE_BASE="$("${GIT}" merge-base "${DEST_BRANCH}" "${CURRENT_BRANCH}")"
   _info "Current branch: ${CURRENT_BRANCH}"
   _info "Destination branch: ${DEST_BRANCH}"
-  _info "Merge base: ${MERGE_BASE}"
 
   local -a pr_vars
   mapfile -t pr_vars < \
@@ -4289,12 +4290,13 @@ EndOfPrTemplate
     PR_ARGS+=(--assignee "${A}")
   done
 
-  if [[ -n "${GEE_PR_BASE}" ]]; then
-    if [[ "$*" == *"--base"* ]]; then
-      _info "GEE_PR_BASE ignored due to use of --base switch on the command line."
-    else
-      PR_ARGS+=(--base "${GEE_PR_BASE}")
-    fi
+  if [[ "$*" != *"--base"* ]]; then
+    # base was not specified, so we have to look at tree to find it.
+    local -a CHAIN=()
+    _add_parent_branches_to_chain "${CURRENT_BRANCH}"
+    local FIRST_PARENT="${CHAIN[0]}"
+    local UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
+    PR_ARGS+=(--base "${UPSTREAM_PARENT#*/}")
   fi
 
   PR_ARGS+=( "$@" )
@@ -4973,7 +4975,7 @@ function gee__fix() {
 # TODO(jonathan): Maybe "change_branch" (chb? cbr? chbr?) is a better name.
 
 _register_help "gcd" "Change directory to another branch." <<'EOT'
-Usage: gcd [-b] [-m] <branch>[/<path>]
+Usage: gcd [-b] [-m] [-B <parent>] <branch>[/<path>]
 
 Print the path to an equivalent directory in another worktree (branch).
 This command is meant to be invoked from the "gcd" bash function, which
@@ -4992,6 +4994,8 @@ Options:
   exist.  The new branch is a child of the current branch.
 * "-m" causes gee to create a new branch if the specified branch doesn't
   exist.  The new branch is a child of the master (or main) branch.
+* "-B <parent>" causes gee to create a new branch if the specified branch
+  doesn't exist.  The new branch is a child of the specified parent branch.
 
 If only "<branch>" is specified, "gcd" will change directory to the same
 relative directory in another branch.  If "<branch>/<path>" is specified,
@@ -5011,6 +5015,10 @@ For example:
     gcd -m new_feature
     # now in new_feature/foo, a child branch of master.
 
+To create a new branch of a non-standard upstream master:
+
+    gcd -B upstream/master_a0 my_a0_feature_branch
+
 The "gcd" function also updates the following environment variables:
 
 * BROOT always contains the path to the root directory of the current branch.
@@ -5019,12 +5027,18 @@ The "gcd" function also updates the following environment variables:
 EOT
 
 function gee__gcd() {
-  local TARGET BRANCH REL_PATH OPT_B
+  local TARGET BRANCH REL_PATH OPT_B OPT_M PARENT
   OPT_B=0
   OPT_M=0
+  PARENT=""
   while [[ "$1" == "-"* ]]; do
     if [[ "$1" == "-b" ]]; then
       OPT_B=1
+      shift
+    elif [[ "$1" == "-B" ]]; then
+      OPT_B=1
+      PARENT="$2"
+      shift
       shift
     elif [[ "$1" == "-m" ]]; then
       OPT_M=1
@@ -5038,9 +5052,6 @@ function gee__gcd() {
   done
   TARGET="$1"
   _set_main
-  if [[ -z "${TARGET}" ]]; then
-    TARGET="${MAIN}"
-  fi
 
   if ! _in_gee_branch; then
     cd "${GEE_REPO_DIR}/${MAIN}"
@@ -5063,12 +5074,14 @@ function gee__gcd() {
   # check whether BRANCH exists:
   if ! _local_branch_exists "${BRANCH}"; then
     if (( OPT_M == 1 )); then
-      # branch from the main branch
-      cd "${GEE_REPO_DIR}/${MAIN}"
+      PARENT="upstream/${MAIN}"
       OPT_B=1
     fi
     if (( OPT_B == 1 )); then
-      gee__mkbr "${BRANCH}" >&2
+      if [[ -z "${PARENT}" ]]; then
+        PARENT="$(_get_current_branch)"
+      fi
+      gee__mkbr "${BRANCH}" "${PARENT}" >&2
       if ! _local_branch_exists "${BRANCH}"; then
         _fatal "Branch \"${REPO}/${BRANCH}\" could not be created."
       fi

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,14 @@
 
 ## Releases
 
+### 0.2.51
+
+* `gee pr_make`: Add support for `--base` and `GEE_PR_BASE` options.
+* `gee rmbr`: When removing multiple branches, remove remaining branches even if one branch removal fails. (#1087)
+* `gee`: Allow explicit paths for enkit (#358)
+* `gee rupdate`: Exit recursion when a branch has itself as a parent (#1075)
+* `gee commit`: Improve output when cancelling running gcloud jobs.  #(1068)
+
 ### 0.2.50
 
 * gee commit: cancels invalidates presubmits, on by default. (#1067)

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -4,7 +4,8 @@
 
 ### 0.2.51
 
-* `gee pr_make`: Add support for `--base` and `GEE_PR_BASE` options.
+* `gee pr_make`: Allow branches to be created from arbitrary upstream base branches.
+* `gee copy`: Added "copy" command to facilitate copying files while preserving history. (#1093)
 * `gee rmbr`: When removing multiple branches, remove remaining branches even if one branch removal fails. (#1087)
 * `gee`: Allow explicit paths for enkit (#358)
 * `gee rupdate`: Exit recursion when a branch has itself as a parent (#1075)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -235,15 +235,31 @@ Valid configuration options are:
 
 Aliases: mkbr
 
-Usage: `gee make_branch <branch-name> [<commit-ish>]`
+Usage: `gee make_branch <branch-name> [<parent-branch>]`
 Aliases: mkbr
 
-Create a new branch based on the current branch.  The new branch will be located in the
+Create a new branch based.  The new branch will be located in the
 directory:
   ~/gee/<repo>/<branch-name>
 
-If <commit-ish> is provided, sets the HEAD of the newly created branch to that
-revision.
+If the parent branch is not specified, the current branch is used as the parent
+branch.  An arbitrary upstream branch may be specified as the parent branch
+(ie. `upstream/master_a0`).
+
+Note that if the parent branch is a non-master upstream branch, any PR created
+from this branch (or a child of this branch) will use that non-master branch
+as the base branch to merge into.
+
+If a matching branch exists in origin (ie, if `origin/<branch-name>` exists),
+gee will ask the user if they want to integrate commits from origin into the
+current branch.
+
+For example:
+
+    cd $(gee gcd bar)
+    gee make_branch foo  # foo is a child branch of the current branch, bar
+    gee make_branch based_on_master upstream/master
+    gee make_branch based_on_fork_a0 upstream/fork_a0
 
 ### log
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.50
+gee version: 0.2.51
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful
@@ -110,10 +110,6 @@ review.
 
 * `GEE_BUILDLOGS_PROJECT`: If you are using gcloud to store your presubmit testing logs, you can
   override gee's default gcloud project by setting this environment variable.
-
-* `GEE_PR_BASE`: Sets the name of the default upstream branch that you want to integrate your
-  PRs to.  If unspecified, defaults to "master", but can be used to mark PRs are being
-  destined for integration into branches like "master_b0", for example.
 
 * `UPSTREAM`: The name of the github user hosting the specified repository.  By default, `enfabrica`.
 
@@ -645,15 +641,10 @@ If you have any second thoughts during this process: Adding the token "DRAFT"
 to your PR description will cause the PR to be marked as a draft.  Adding the
 token "ABORT" will cause gee to abort the creation of your PR.
 
-By default, `pr_make` creates a PR that targets upstream/master as the branch
-for the PR to merge into.  However, this branch can be changed in two ways:
-
-* The `GEE_PR_BASE` environment variable can be used to specify the name of the
-  upstream branch to merge into.
-
-* The `--base <branchname>` argument can be added to the command line to
-  explicitly specify the name of the upstream branch to target.  This value
-  will override the value in `GEE_PR_BASE`, if set.
+`pr_make` will look at the recursive parentage of the current branch  until
+it finds a remote branch as a parent.  This remote branch (usually `upstream/master`)
+will be used as the "base" branch for the PR to be merged into.  This "base"
+branch can be overriden useing the "--base <branchname>" flag.
 
 Uses the same options as "gh pr create".
 
@@ -737,7 +728,7 @@ out as formatting rules are highly project specific.
 
 ### gcd
 
-Usage: `gcd [-b] [-m] <branch>[/<path>]`
+Usage: `gcd [-b] [-m] [-B <parent>] <branch>[/<path>]`
 
 Print the path to an equivalent directory in another worktree (branch).
 This command is meant to be invoked from the "gcd" bash function, which
@@ -756,6 +747,8 @@ Options:
   exist.  The new branch is a child of the current branch.
 * "-m" causes gee to create a new branch if the specified branch doesn't
   exist.  The new branch is a child of the master (or main) branch.
+* "-B <parent>" causes gee to create a new branch if the specified branch
+  doesn't exist.  The new branch is a child of the specified parent branch.
 
 If only "<branch>" is specified, "gcd" will change directory to the same
 relative directory in another branch.  If "<branch>/<path>" is specified,
@@ -774,6 +767,10 @@ For example:
     # now in branch4/foo, a child branch of branch3.
     gcd -m new_feature
     # now in new_feature/foo, a child branch of master.
+
+To create a new branch of a non-standard upstream master:
+
+    gcd -B upstream/master_a0 my_a0_feature_branch
 
 The "gcd" function also updates the following environment variables:
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -111,6 +111,10 @@ review.
 * `GEE_BUILDLOGS_PROJECT`: If you are using gcloud to store your presubmit testing logs, you can
   override gee's default gcloud project by setting this environment variable.
 
+* `GEE_PR_BASE`: Sets the name of the default upstream branch that you want to integrate your
+  PRs to.  If unspecified, defaults to "master", but can be used to mark PRs are being
+  destined for integration into branches like "master_b0", for example.
+
 * `UPSTREAM`: The name of the github user hosting the specified repository.  By default, `enfabrica`.
 
 * `YESYESYES`: If set to a non-zero integer, will cause all yes/no prompts within `gee` to automatically
@@ -640,6 +644,16 @@ edit a PR description file before the PR is created.
 If you have any second thoughts during this process: Adding the token "DRAFT"
 to your PR description will cause the PR to be marked as a draft.  Adding the
 token "ABORT" will cause gee to abort the creation of your PR.
+
+By default, `pr_make` creates a PR that targets upstream/master as the branch
+for the PR to merge into.  However, this branch can be changed in two ways:
+
+* The `GEE_PR_BASE` environment variable can be used to specify the name of the
+  upstream branch to merge into.
+
+* The `--base <branchname>` argument can be added to the command line to
+  explicitly specify the name of the upstream branch to target.  This value
+  will override the value in `GEE_PR_BASE`, if set.
 
 Uses the same options as "gh pr create".
 

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -659,8 +659,7 @@ token "ABORT" will cause gee to abort the creation of your PR.
 
 `pr_make` will look at the recursive parentage of the current branch  until
 it finds a remote branch as a parent.  This remote branch (usually `upstream/master`)
-will be used as the "base" branch for the PR to be merged into.  This "base"
-branch can be overriden useing the "--base <branchname>" flag.
+will be used as the "base" branch for the PR to be merged into.
 
 Uses the same options as "gh pr create".
 


### PR DESCRIPTION
Previously, `gee` based all branches on `master`, which in turn was a local
clone of `upstream/master`.

Now, branches may be created with arbitrary upstream parents.  This allows
creating a branch based on, say, `master_a0` instead of `master`.  Further,
`gee` will now look at the parentage of the current branch when creating a
PR, and will use the upstream parent of the earlier branch as the "base"
branch to target for any newly created PR.

Make it easier for gee to use an upstream master other than "master".


Tested:

The following copy-pasta illustrates manually creating a local clone of upstream/glog, and then creating
a child branch of that branch, and then finally making a small change and creating a PR.  The generated PR
uses "enkit/glog" as the base branch for merging the PR.

```
$ gcd -B upstream/glog my_local_glog_clone
CMD: /usr/bin/git fetch upstream
CMD: /usr/bin/git worktree add -b my_local_glog_clone -f /home/jonathan/gee/enkit/my_local_glog_clone upstream/glog
Preparing worktree (new branch 'my_local_glog_clone')
branch 'my_local_glog_clone' set up to track 'upstream/glog'.
HEAD is now at fc031b6 Added gflags and glog libraries.
Created /home/jonathan/gee/enkit/my_local_glog_clone
CMD: /usr/bin/git fetch origin

$ gcd -b my_local_glog_clone2
CMD: /usr/bin/git worktree add -b my_local_glog_clone2 -f /home/jonathan/gee/enkit/my_local_glog_clone2 my_local_glog_clone
Preparing worktree (new branch 'my_local_glog_clone2')
HEAD is now at fc031b6 Added gflags and glog libraries.
Created /home/jonathan/gee/enkit/my_local_glog_clone2
CMD: /usr/bin/git fetch origin

$ touch foobar; gee commit -a -m "created foobar"
CMD: /usr/bin/git add --all
CMD: /usr/bin/git commit -a -m created\ foobar
[my_local_glog_clone2 29ca9f1] created foobar
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 foobar
Killing any previous presubmit jobs.
CMD: gcloud --project=cloud-build-290921 builds list --format=yaml --filter=substitutions.BRANCH_NAME=my_local_glog_clone2\ AND\ substitutions._HEAD_REPO_URL:jonathan-enf\ AND\ substitutions.TRIGGER_NAME:presubmit\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
Killed 0 job(s).
CMD: /usr/bin/git push --quiet -u origin my_local_glog_clone2
gremote:
remote: Create a pull request for 'my_local_glog_clone2' on GitHub by visiting:
remote:      https://github.com/jonathan-enf/enkit/pull/new/my_local_glog_clone2
remote:

$ gee pr_make
CMD: /usr/bin/git fetch upstream
Current branch: my_local_glog_clone2
Destination branch: upstream/master
no pull requests found for branch "jonathan-enf:my_local_glog_clone2"
no pull requests found for branch "jonathan-enf:my_local_glog_clone"
fatal: master...HEAD: no merge base
WARNING: There are no tracked, modified files in this client.
How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  v
CMD: /usr/bin/git push --quiet -u origin my_local_glog_clone2
CMD: /usr/bin/gh pr create --repo enfabrica/enkit --title A\ test\ PR\ for\ gee -H jonathan-enf:my_local_glog_clone2 --body-file /tmp/prbody.wGJIbg.txt.trimmed --draft --base glog

Creating draft pull request for jonathan-enf:my_local_glog_clone2 into glog in enfabrica/enkit

https://github.com/enfabrica/enkit/pull/1108
CMD: /usr/bin/gh pr view --repo enfabrica/enkit jonathan-enf:my_local_glog_clone2
A test PR for gee enfabrica/enkit#1108
Draft • jonathan-enf wants to merge 1 commit into glog from my_local_glog_clone2 • less than a minute ago
+0 -0 • No checks


  This PR should target enkit/glog as it's "base" branch.

  Tested: n/a


View this pull request on GitHub: https://github.com/enfabrica/enkit/pull/1108

```


