### PR TITLE
`diff_test.bzl`: add `md5sum_diff_test`

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//bazel/utils:diff_test.bzl", "diff_test", "extract_file", "diff_test_suite")
+load("//bazel/utils:diff_test.bzl", "diff_test", "extract_file", "md5sum_diff_test", "diff_test_suite")
 load("//bazel/utils:types.bzl", "escape_and_join")
 load("//bazel/utils:merge_kwargs_test.bzl", "merge_kwargs_test_suite")
 load("//bazel/utils:files.bzl", "write_to_file")
@@ -123,6 +123,16 @@ diff_test_suite(
     files = [
       "escape_and_join1.actual",
       ":a",
+    ],
+)
+
+# Exercise the md5sum_diff_test rule:
+md5sum_diff_test(
+    name = "md5sum_diff_test_test",
+    srcs = [
+      "escape_and_join1.actual",
+      ":a",
+      "testdata/a.expected.txt",
     ],
 )
 

--- a/bazel/utils/diff_test.bzl
+++ b/bazel/utils/diff_test.bzl
@@ -186,19 +186,26 @@ diff_test = rule(
 )
 
 def md5sum_diff_test(name, srcs, expected = None, **kwargs):
-    """md5sum_diff_test is a diff_test that diffs the md5 checksums
-    of a set of files.  This is useful in situations where the files
-    themselves are too large to keep in source control.
+    """A difference-test of a set of files, using a checksum.
+
+    md5sum_diff_test is a diff_test that diffs the md5 checksums of a set of
+    files.  This is useful in situations where the files themselves are too
+    large to keep in source control.
 
     The md5sum value can be updated by the "update_golden" tool, just like
-    ordinary `diff_test`s.  Just like `diff_test`, the expected data
-    file must exist.
+    ordinary `diff_test`s.  Just like `diff_test`, the expected data file must
+    exist.
 
-    Arguments:
-    * name: The name of the diff_test to generate.
-    * srcs: The generated source files to check (the "actual" files).
-    * expected: The file containing the md5 checksum(s).  If omitted, the
-          default filename (name + ".md5sum") will be used instead.
+    Internally, this macro produces two rules.  "<name>-gen" is the rule
+    to calculate the md5 checksums of the set of files.  "<name>" is the
+    `diff_test` rule that compares the calculated checksums against a file
+    containing the expected checksums.
+
+    Args:
+        name: The name of the diff_test to generate.
+        srcs: The generated source files to check (the "actual" files).
+        expected: The file containing the md5 checksum(s).  If omitted, the
+            default filename ("<name>.md5sum") will be used instead.
     """
     if not expected:
         expected = name + ".md5sum"
@@ -217,7 +224,6 @@ def md5sum_diff_test(name, srcs, expected = None, **kwargs):
         expected = expected,
         **kwargs,
     )
-
 
 def diff_test_suite(name, files, subdir = "expected", **kwargs):
     """diff_test_suite is a macro for quickly instantiating multiple diff_test rules.

--- a/bazel/utils/diff_test.bzl
+++ b/bazel/utils/diff_test.bzl
@@ -185,6 +185,40 @@ diff_test = rule(
     test = True,
 )
 
+def md5sum_diff_test(name, srcs, expected = None, **kwargs):
+    """md5sum_diff_test is a diff_test that diffs the md5 checksums
+    of a set of files.  This is useful in situations where the files
+    themselves are too large to keep in source control.
+
+    The md5sum value can be updated by the "update_golden" tool, just like
+    ordinary `diff_test`s.  Just like `diff_test`, the expected data
+    file must exist.
+
+    Arguments:
+    * name: The name of the diff_test to generate.
+    * srcs: The generated source files to check (the "actual" files).
+    * expected: The file containing the md5 checksum(s).  If omitted, the
+          default filename (name + ".md5sum") will be used instead.
+    """
+    if not expected:
+        expected = name + ".md5sum"
+    out = expected + "-out"
+    cmd = "/usr/bin/md5sum $(SRCS) > $@"
+    native.genrule(
+        name = name + "-gen",
+        srcs = srcs,
+        outs = [out],
+        cmd = cmd,
+        tools = [],
+    )
+    diff_test(
+        name = name,
+        actual = out,
+        expected = expected,
+        **kwargs,
+    )
+
+
 def diff_test_suite(name, files, subdir = "expected", **kwargs):
     """diff_test_suite is a macro for quickly instantiating multiple diff_test rules.
 

--- a/bazel/utils/md5sum_diff_test_test.md5sum
+++ b/bazel/utils/md5sum_diff_test_test.md5sum
@@ -1,0 +1,3 @@
+2ebec47b84f22f0acc2812627aec97b0  bazel-out/k8-fastbuild/bin/bazel/utils/escape_and_join1.actual
+60b725f10c9c85c70d97880dfe8191b3  bazel/utils/testdata/a.txt
+60b725f10c9c85c70d97880dfe8191b3  bazel/utils/testdata/a.expected.txt


### PR DESCRIPTION
From the docstring:

    """md5sum_diff_test is a diff_test that diffs the md5 checksums
    of a set of files.  This is useful in situations where the files
    themselves are too large to keep in source control.

    The md5sum value can be updated by the "update_golden" tool, just like
    ordinary `diff_test`s.  Just like `diff_test`, the expected data
    file must exist.

    Arguments:
    * name: The name of the diff_test to generate.
    * srcs: The generated source files to check (the "actual" files).
    * expected: The file containing the md5 checksum(s).  If omitted, the
          default filename (name + ".md5sum") will be used instead.
    """

Tested: Adds an example md5sum_diff_test.


