### PR TITLE
try to auth to bb_clientd on login

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,31 +31,3 @@ load("//bazel/init:stage_4.bzl", "stage_4")
 
 stage_4()
 
-#load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-#
-#http_archive(
-#    name = "remote-apis",
-#    strip_prefix = "remote-apis-2.3.0-rc2",
-#    url = "https://github.com/bazelbuild/remote-apis/archive/refs/tags/v2.3.0-rc2.tar.gz",
-#)
-#
-#load("@remote-apis//:repository_rules.bzl", "switched_rules_by_language")
-#
-#switched_rules_by_language(
-#    name = "bazel_remote_apis_imports",
-#    go = True,
-#)
-#
-#http_archive(
-#    name = "googleapis",
-#    sha256 = "361e26593b881e70286a28065859c941e25b96f9c48ba91127293d0a881152d6",
-#    strip_prefix = "googleapis-a3770599794a8d319286df96f03343b6cd0e7f4f",
-#    urls = ["https://github.com/googleapis/googleapis/archive/a3770599794a8d319286df96f03343b6cd0e7f4f.zip"],
-#)
-#
-#load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
-#
-#switched_rules_by_language(
-#    name = "com_google_googleapis_imports",
-#    go = True,
-#)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,4 +30,3 @@ stage_3()
 load("//bazel/init:stage_4.bzl", "stage_4")
 
 stage_4()
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,3 +30,32 @@ stage_3()
 load("//bazel/init:stage_4.bzl", "stage_4")
 
 stage_4()
+
+#load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+#
+#http_archive(
+#    name = "remote-apis",
+#    strip_prefix = "remote-apis-2.3.0-rc2",
+#    url = "https://github.com/bazelbuild/remote-apis/archive/refs/tags/v2.3.0-rc2.tar.gz",
+#)
+#
+#load("@remote-apis//:repository_rules.bzl", "switched_rules_by_language")
+#
+#switched_rules_by_language(
+#    name = "bazel_remote_apis_imports",
+#    go = True,
+#)
+#
+#http_archive(
+#    name = "googleapis",
+#    sha256 = "361e26593b881e70286a28065859c941e25b96f9c48ba91127293d0a881152d6",
+#    strip_prefix = "googleapis-a3770599794a8d319286df96f03343b6cd0e7f4f",
+#    urls = ["https://github.com/googleapis/googleapis/archive/a3770599794a8d319286df96f03343b6cd0e7f4f.zip"],
+#)
+#
+#load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
+#
+#switched_rules_by_language(
+#    name = "com_google_googleapis_imports",
+#    go = True,
+#)

--- a/lib/client/commands/BUILD.bazel
+++ b/lib/client/commands/BUILD.bazel
@@ -1,11 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
+    name = "go_rbe",
+    embed = ["@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto"],
+    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
+)
+
+go_library(
     name = "commands",
     srcs = ["login.go"],
     importpath = "github.com/enfabrica/enkit/lib/client/commands",
     visibility = ["//visibility:public"],
     deps = [
+        ":go_rbe",
         "//auth/proto",
         "//lib/client",
         "//lib/config/identity",
@@ -15,6 +22,9 @@ go_library(
         "//lib/kflags/kcobra",
         "//lib/retry",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//grpclog",
+        "@org_golang_google_grpc//metadata",
     ],
 )
 

--- a/lib/client/commands/login.go
+++ b/lib/client/commands/login.go
@@ -115,7 +115,7 @@ func AuthenticateBbclientd(token string) error {
         var err error
 
         bbclientd_address := "localhost:8981"
-        conn, err = grpc.Dial(bbclientd_address, grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)), grpc.WithTimeout(5 * time.Second))
+        conn, err = grpc.Dial(bbclientd_address, grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)), grpc.WithTimeout(2 * time.Second))
         if err != nil {
             return fmt.Errorf("fail to dial: %w", err)
         }

--- a/lib/client/commands/login.go
+++ b/lib/client/commands/login.go
@@ -72,6 +72,8 @@ func TokenAuthInterceptor(token string) grpc.UnaryClientInterceptor {
         invoker grpc.UnaryInvoker,
         opts ...grpc.CallOption,
     ) error {
+        // TODO(isaac): This is a little non-standard - perhaps we should make these
+        // constants somewhere in the enkit codebase?
         md := metadata.Pairs("cookie", "Creds="+token)
         ctxWithToken := metadata.NewOutgoingContext(ctx, md)
 
@@ -113,7 +115,7 @@ func AuthenticateBbclientd(token string) error {
         var err error
 
         bbclientd_address := "localhost:8981"
-        conn, err = grpc.Dial(bbclientd_address, grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)))
+        conn, err = grpc.Dial(bbclientd_address, grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)), grpc.WithTimeout(5 * time.Second))
         if err != nil {
             return fmt.Errorf("fail to dial: %w", err)
         }

--- a/lib/client/commands/login.go
+++ b/lib/client/commands/login.go
@@ -156,7 +156,7 @@ func (l *Login) Run(cmd *cobra.Command, args []string) error {
         }
 
         client := remoteexecution.NewContentAddressableStorageClient(conn)
-        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{InstanceName: "buildbarn_prod", BlobDigests: digests})
+        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{BlobDigests: digests})
 //        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{})
 
         if err != nil {

--- a/lib/client/commands/login.go
+++ b/lib/client/commands/login.go
@@ -150,8 +150,14 @@ func (l *Login) Run(cmd *cobra.Command, args []string) error {
         }
         //defer conn.Close()
 
+        digests := []*remoteexecution.Digest{
+            {Hash: "013ad2661e3240ec6e0c8f79eb14944f599e04aeffa78d90873a6d679297746c", SizeBytes: 22733},
+//            {Hash: "abcdef12345", SizeBytes: 12345},
+        }
+
         client := remoteexecution.NewContentAddressableStorageClient(conn)
-        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{})
+        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{InstanceName: "buildbarn_prod", BlobDigests: digests})
+//        resp, err := client.FindMissingBlobs(context.Background(), &remoteexecution.FindMissingBlobsRequest{})
 
         if err != nil {
             return fmt.Errorf("failed :(: %w", err)

--- a/lib/client/commands/login.go
+++ b/lib/client/commands/login.go
@@ -111,7 +111,9 @@ func AuthenticateBbclientd(token string) error {
 //        grpc.EnableTracing = true
         var conn *grpc.ClientConn
         var err error
-        conn, err = grpc.Dial("localhost:8981", grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)))
+
+        bbclientd_address := "localhost:8981"
+        conn, err = grpc.Dial(bbclientd_address, grpc.WithInsecure(), grpc.WithUnaryInterceptor(TokenAuthInterceptor(token)))
         if err != nil {
             return fmt.Errorf("fail to dial: %w", err)
         }


### PR DESCRIPTION
Makes it so that `enkit login` also tries to authenticate our bbclientd CAS mounts.