### PR TITLE
gee: add copy command

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5156,7 +5156,6 @@ function gee__copy() {
   local DEST="${@: -1}"
   local -a SRCS=( "$@" )
   unset SRCS[-1]  # remove last element from list
-  printf "srcs: %q\n" "${SRCS}"
 
   local DEST_IS="dir"
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -5168,6 +5168,7 @@ function gee__copy() {
     _die "You must commit these changes before using the copy operation."
   fi
 
+  # Determine if we are copying to a file or a directory.
   if [[ "${#SRCS[@]}" -gt 1 ]]; then
     if [[ -f "${DEST}" ]]; then
       DEST_IS="file"
@@ -5188,6 +5189,7 @@ function gee__copy() {
     fi
   fi
 
+  # Make the destination directory, if necessary.
   if [[ "${DEST_IS}" == "dir" ]] && [[ ! -d "${DEST}" ]]; then
     _cmd mkdir -p "${DEST}"
   fi
@@ -5197,10 +5199,7 @@ function gee__copy() {
   COPY_BRANCH="_GEE_TEMP_${CURRENT_BRANCH}"
   _git checkout -b "${COPY_BRANCH}"
 
-  local SRC
-  for SRC in "${SRCS[@]}"; do
-    _git mv -f "${SRC}" "${DEST}"
-  done
+  _git mv -v -f "${SRCS[@]}" "${DEST}"
   _git commit -m "gee: Moved to ${DEST}: ${SRCS[*]}"
 
   _git checkout HEAD~ "${SRCS[@]}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -5126,6 +5126,86 @@ function gee__create_ssh_key() {
 }
 
 ##########################################################################
+# copy command
+##########################################################################
+
+_register_help "copy" "Copy files (preserving history)." "cp" <<'EOT'
+Usage: gee copy <files...> <destination>
+
+Creates a copy of one or more files, preserving git history.  (Just
+copying a file using cp will cause git to assume a new file, and
+not preserve history.)
+
+This operation will create a new commit containing the copy operation.
+All files being copied should be "clean" (committed, not staged) for
+this to work correctly.
+
+Destination may either be a filename or a directory.  When copying
+more than one file, destination must be a directory.
+
+Examples:
+
+    gee copy foo.txt bar.txt
+    mkdir bardir
+    gee copy foo.txt bar.txt bardir/
+EOT
+function gee__cp() { gee__copy "$@"; }
+function gee__copy() {
+  _startup_checks "copy"
+
+  local DEST="${@: -1}"
+  local -a SRCS=( "$@" )
+  unset SRCS[-1]  # remove last element from list
+  printf "srcs: %q\n" "${SRCS}"
+
+  local DEST_IS="dir"
+
+  # TODO(jonathan): check that all source files are clean.
+
+  if [[ "${#SRCS[@]}" -gt 1 ]]; then
+    if [[ -f "${DEST}" ]]; then
+      DEST_IS="file"
+      _die "Multiple sources defined, but destination is a file."
+    else
+      DEST_IS="dir"
+    fi
+  else
+    if [[ -f "${DEST}" ]]; then
+      DEST_IS="file"
+    elif [[ -d "${DEST}" ]]; then
+      DEST_IS="dir"
+    elif [[ "${DEST}" == */ ]]; then
+      DEST_IS="dir"
+    else
+      DEST_IS="file"
+    fi
+  fi
+
+  if [[ "${DEST_IS}" == "dir" ]] && [[ ! -d "${DEST}" ]]; then
+    _cmd mkdir -p "${DEST}"
+  fi
+
+  local CURRENT_BRANCH COPY_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  COPY_BRANCH="_GEE_TEMP_${CURRENT_BRANCH}"
+  _git checkout -b "${COPY_BRANCH}"
+
+  local SRC
+  for SRC in "${SRCS[@]}"; do
+    _git mv "${SRC}" "${DEST}"
+  done
+  _git commit -m "gee: Moved to ${DEST}: ${SRCS[*]}"
+
+  _git checkout HEAD~ "${SRCS[@]}"
+  _git commit -m "gee: Restored ${SRCS[*]}"
+
+  _git checkout "${CURRENT_BRANCH}"
+  _git merge --no-ff "${COPY_BRANCH}" -m "gee: Copy to ${DEST}: ${SRCS[*]}"
+
+  _info "Copied ${SRCS[*]} to ${DEST}"
+}
+
+##########################################################################
 # share command
 ##########################################################################
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -5202,6 +5202,8 @@ function gee__copy() {
   _git checkout "${CURRENT_BRANCH}"
   _git merge --no-ff "${COPY_BRANCH}" -m "gee: Copy to ${DEST}: ${SRCS[*]}"
 
+  _git branch -d "${COPY_BRANCH}"
+
   _info "Copied ${SRCS[*]} to ${DEST}"
 }
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -5160,7 +5160,13 @@ function gee__copy() {
 
   local DEST_IS="dir"
 
-  # TODO(jonathan): check that all source files are clean.
+  # Check that all source files are clean.
+  local STATUS
+  STATUS="$(git status --porcelain "${SRCS[@]}")"
+  if [[ "${STATUS}" ]]; then
+    _warn "The following files have uncommitted changes:" "${STATUS}"
+    _die "You must commit these changes before using the copy operation."
+  fi
 
   if [[ "${#SRCS[@]}" -gt 1 ]]; then
     if [[ -f "${DEST}" ]]; then

--- a/scripts/gee
+++ b/scripts/gee
@@ -5153,9 +5153,10 @@ function gee__cp() { gee__copy "$@"; }
 function gee__copy() {
   _startup_checks "copy"
 
-  local DEST="${@: -1}"
+  local -a DESTS=( "${@: -1}" )
+  local DEST="${DESTS[0]}"
   local -a SRCS=( "$@" )
-  unset SRCS[-1]  # remove last element from list
+  unset "SRCS[-1]"  # remove last element from list
 
   local DEST_IS="dir"
 
@@ -5171,6 +5172,7 @@ function gee__copy() {
   else
     if [[ -f "${DEST}" ]]; then
       DEST_IS="file"
+      _warn "Destination exists: ${DEST}"
     elif [[ -d "${DEST}" ]]; then
       DEST_IS="dir"
     elif [[ "${DEST}" == */ ]]; then
@@ -5191,7 +5193,7 @@ function gee__copy() {
 
   local SRC
   for SRC in "${SRCS[@]}"; do
-    _git mv "${SRC}" "${DEST}"
+    _git mv -f "${SRC}" "${DEST}"
   done
   _git commit -m "gee: Moved to ${DEST}: ${SRCS[*]}"
 
@@ -5201,7 +5203,7 @@ function gee__copy() {
   _git checkout "${CURRENT_BRANCH}"
   _git merge --no-ff "${COPY_BRANCH}" -m "gee: Copy to ${DEST}: ${SRCS[*]}"
 
-  _git branch -d "${COPY_BRANCH}"
+  _git branch -d -f "${COPY_BRANCH}"
 
   _info "Copied ${SRCS[*]} to ${DEST}"
 }

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -159,6 +159,7 @@ prompt that `gee bash_setup` makes available.
 | <a href="#codeowners">`codeowners`</a> | Provide detailed information about required approvals for this PR. |
 | <a href="#commit">`commit`</a> | Commit all changes in this branch |
 | <a href="#config">`config`</a> | Set various configuration options. |
+| <a href="#copy">`copy`</a> | Copy files (preserving history). |
 | <a href="#create_ssh_key">`create_ssh_key`</a> | Create and enroll an ssh key. |
 | <a href="#diagnose">`diagnose`</a> | Capture diagnostics about your repository. |
 | <a href="#diff">`diff`</a> | Differences in this branch. |
@@ -784,6 +785,29 @@ This command will attempt to re-enroll you for ssh access to github.
 Normally, "gee init" will ensure that you have ssh access.  This command
 is only available if something else has gone wrong requiring that keys
 be updated.
+
+### copy
+
+Aliases: cp
+
+Usage: `gee copy <files...> <destination>`
+
+Creates a copy of one or more files, preserving git history.  (Just
+copying a file using cp will cause git to assume a new file, and
+not preserve history.)
+
+This operation will create a new commit containing the copy operation.
+All files being copied should be "clean" (committed, not staged) for
+this to work correctly.
+
+Destination may either be a filename or a directory.  When copying
+more than one file, destination must be a directory.
+
+Examples:
+
+    gee copy foo.txt bar.txt
+    mkdir bardir
+    gee copy foo.txt bar.txt bardir/
 
 ### share
 


### PR DESCRIPTION
This adds a copy command that attempts to preserve git history.

Tested:

```
$ gee copy ./CODEOWNERS{,.backup}
srcs: ./CODEOWNERS
Current branch: copytest
Copy branch: _copytest_copying
CMD: /usr/bin/git checkout -b _copytest_copying
Switched to a new branch '_copytest_copying'
CMD: /usr/bin/git mv ./CODEOWNERS ./CODEOWNERS.backup
CMD: /usr/bin/git commit -m gee:\ Moved\ to\ ./CODEOWNERS.backup:\ ./CODEOWNERS
[_copytest_copying a40199902f] gee: Moved to ./CODEOWNERS.backup: ./CODEOWNERS
 1 file changed, 0 insertions(+), 0 deletions(-)
 rename CODEOWNERS => CODEOWNERS.backup (100%)
CMD: /usr/bin/git checkout HEAD~ ./CODEOWNERS
Updated 1 path from 11a0fe3528
CMD: /usr/bin/git commit -m gee:\ Restored\ ./CODEOWNERS
[_copytest_copying 185cc474e5] gee: Restored ./CODEOWNERS
 1 file changed, 286 insertions(+)
 create mode 100644 CODEOWNERS
CMD: /usr/bin/git checkout copytest
Switched to branch 'copytest'
CMD: /usr/bin/git merge --no-ff _copytest_copying -m gee:\ Copy\ to\ ./CODEOWNERS.backup:\ ./CODEOWNERS
Merge made by the 'ort' strategy.
 CODEOWNERS.backup | 286 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 286 insertions(+)
 create mode 100644 CODEOWNERS.backup
Copied ./CODEOWNERS to ./CODEOWNERS.backup

$ git logp -- CODEOWNERS | head -n 10
* eaae76e8e0 - CODEOWNERS: add ib/libenf entry (19 hours ago) <Vitaly Mayatskikh>
* 71e6ba6a7c - systest: SWT-4415: Increase timeout of e2e nightly regressions to 4 hours (#45778) (26 hours ago) <Moksh Jain>
* 7ae8daa399 - CODEOWNERS: STF-67: Add Kevin and Roman as appropriate codeowners  (#45625) (2 days ago) <Moksh Jain>

$ git logp --follow -- CODEOWNERS.backup | head -n 10
...
| * 6c09085594 - gee: Moved to ./CODEOWNERS.backup: ./CODEOWNERS (6 minutes ago) <Jonathan Mayer>
|/
...
* eaae76e8e0 - CODEOWNERS: add ib/libenf entry (19 hours ago) <Vitaly Mayatskikh>
...
* 71e6ba6a7c - systest: SWT-4415: Increase timeout of e2e nightly regressions to 4 hours (#45778) (26 hours ago) <Moksh Jain>
...
* 7ae8daa399 - CODEOWNERS: STF-67: Add Kevin and Roman as appropriate codeowners  (#45625) (2 days ago) <Moksh Jain>
...

$ git blame CODEOWNERS | grep /fei/
41bb2401878 (Salil Pant            2024-05-20 09:59:39 -0400 104) /systest/src/fei/ @chaitanyavella-enf @giribabu-enf @gpaussaenf @jacob-adelmann @kalaivanan-enf @keshav-enf @kvedula-enf @moksh-enf @msgoldflam @naveen-enf @naveenaketi-enf @sgajendr-enf @sgajendr-enf @shashankp-enf @vinit-desai

$ git blame CODEOWNERS.backup | grep /fei/
41bb2401878 CODEOWNERS (Salil Pant            2024-05-20 09:59:39 -0400 104) /systest/src/fei/ @chaitanyavella-enf @giribabu-enf @gpaussaenf @jacob-adelmann @kalaivanan-enf @keshav-enf @kvedula-enf @moksh-enf @msgoldflam @naveen-enf @naveenaketi-enf @sgajendr-enf @sgajendr-enf @shashankp-enf @vinit-desai

```


