### PR TITLE
kernel_module - add paths to extra flags

### DIFF
--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -94,6 +94,9 @@ def _kernel_modules(ctx):
     if extra_symbols:
         extra.append("KBUILD_EXTRA_SYMBOLS=\"%s\"" % (extra_symbols))
 
+    extra.append('BAZEL_BIN_DIR="%s"' % ctx.bin_dir.path)
+    extra.append('BAZEL_GEN_DIR="%s"' % ctx.genfiles_dir.path)
+
     if ctx.attr.silent:
         silent = "-s"
     else:


### PR DESCRIPTION
Currently, the Makefiles for kernel modules infer the bin directory from the include flags, or set it to be `bazel-out/k8-fastbuild/bin`. Both methods are brittle and the second one is incorrect if more than one platform is targeted.

This change will allow kernel modules to point to the right directories during compilation without having to resort to such brittle methods.