### PR TITLE
Add rules_distroless to enkit to be imported by internal

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -18,6 +18,22 @@ def stage_1():
     way of forcing a dependency upgrade underneath e.g. io_bazel_rules_go.
     """
     maybe(
+        name = "aspect_bazel_lib",
+        repo_rule = http_archive,
+        sha256 = "688354ee6beeba7194243d73eb0992b9a12e8edeeeec5b6544f4b531a3112237",
+        strip_prefix = "bazel-lib-2.8.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz",
+    )
+
+    maybe(
+        name = "rules_distroless",
+        repo_rule = http_archive,
+        sha256 = "8a3440067453ad211f3b34d4a8f68f65663dc5fd6d7834bf81eecf0526785381",
+        strip_prefix = "rules_distroless-0.3.6",
+        url = "https://github.com/GoogleContainerTools/rules_distroless/releases/download/v0.3.6/rules_distroless-v0.3.6.tar.gz",
+    )
+
+    maybe(
         name = "io_bazel_rules_go",
         repo_rule = http_archive,
         patches = ["@enkit//bazel/dependencies/io_bazel_rules_go:tags_manual.patch"],

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -4,6 +4,8 @@ See README.md for more information.
 """
 
 load("//bazel/meson:meson.bzl", "meson_register_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+load("@rules_distroless//distroless:dependencies.bzl", "distroless_dependencies")
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
@@ -36,6 +38,11 @@ def stage_2():
       dependencies are in stage 2 because they depend on the existence of
       rules_python in a load statement, which is instantiated in stage 1.
     """
+
+    aspect_bazel_lib_dependencies()
+    aspect_bazel_lib_register_toolchains()
+
+    distroless_dependencies()
 
     py_repositories()
 

--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -3,6 +3,7 @@
 See README.md for more information.
 """
 
+load("@rules_distroless//distroless:toolchains.bzl", "distroless_register_toolchains")
 load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 load("@com_github_bazelbuild_remote_apis//:repository_rules.bzl", "switched_rules_by_language")
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
@@ -24,6 +25,8 @@ def stage_3():
     * A transitive load statement that references a repository that doesn't
       exist until stage 2 completes
     """
+
+    distroless_register_toolchains()
 
     pip_parse(
         name = "enkit_pip_deps",

--- a/bazel/init/stage_4.bzl
+++ b/bazel/init/stage_4.bzl
@@ -34,3 +34,4 @@ def stage_4():
         registry = "us-docker.pkg.dev",
         repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
     )
+

--- a/bazel/init/stage_4.bzl
+++ b/bazel/init/stage_4.bzl
@@ -34,4 +34,3 @@ def stage_4():
         registry = "us-docker.pkg.dev",
         repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
     )
-


### PR DESCRIPTION
This change adds the `rules_distroless` repo to `enkit` to be eventually imported by the `internal` repo.

Tested:
- `bazel test //...`

JIRA: ENGPROD-351