### PR TITLE
gee: update support for bcompare

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2433,20 +2433,25 @@ function gee__config() {
         "/usr/bin/meld \"\$LOCAL\" \"\$REMOTE\""
       ;;
     enable_bcompare)
-      _info "Setting BeyondCompare as the default GUI diff and merge tool."
-      _git config --global merge.guitool bc
-      _git config --global diff.guitool bc
-      _git config --global mergetool.bc.trustExitCode true
-      _git config --global difftool.bc.trustExitCode true
       if ! command -v bcompare > /dev/null; then
-        _warn "bcompare is not currently installed."
+        _error "bcompare is not currently installed."
         _info \
           "To install BeyondCompare:" \
           "" \
-          "  wget https://www.scootersoftware.com/files/bcompare-4.4.6.27483_amd64.deb" \
+          "  wget https://www.scootersoftware.com/files/bcompare-5.0.2.30045_amd64.deb" \
           "  sudo apt install poppler-utils" \
-          "  sudo dpkg -i ./bcompare-4.4.6.27483_amd64.deb" \
-          "  which bcompare  # ensure tool is installed"
+          "  sudo dpkg -i ./bcompare-5.0.2.30045_amd64.deb" \
+          "  which bcompare  # ensure tool is installed" \
+          "" \
+          "Install bcompare and try again."
+        _fatal "bcompare not installed."
+      else
+        _info "Setting BeyondCompare as the default GUI diff and merge tool."
+        # Note "bc" selects a wrapper for beyondcompare that is distributed with git.
+        _git config --global merge.guitool bc
+        _git config --global diff.guitool bc
+        _git config --global mergetool.bc.trustExitCode true
+        _git config --global difftool.bc.trustExitCode true
       fi
       ;;
     enable_emacs)

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -4,7 +4,8 @@
 
 ### 0.2.51
 
-* `gee pr_make`: Allow branches to be created from arbitrary upstream base branches.
+* `gee pr_make`: Allow branches to be created from arbitrary upstream base branches. (#1088)
+* `gee config`: Update to bcompare5.  (#1102)
 * `gee copy`: Added "copy" command to facilitate copying files while preserving history. (#1093)
 * `gee rmbr`: When removing multiple branches, remove remaining branches even if one branch removal fails. (#1087)
 * `gee`: Allow explicit paths for enkit (#358)


### PR DESCRIPTION
A user had an issue where they ran `gee config enable_bcompare` but didn't
notice the warning message and instructions indicating that `bcompare` still
needed to be installed in their container. This PR fixes that issue by failing
to enable bcompare if bcompare is not installed (an error instead of a
warning).

While we're here, let's update to bcompare5 anyway.  Dark mode!

Tested: manually tested by creating a merge conflict and invoking the gui
mergetool to resolve it.


