### PR TITLE
Added external dependency to boringssl repository and added patch to fix compilations errors observed on ARM64 architecture.

### DIFF
--- a/bazel/dependencies/boringssl/0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch
+++ b/bazel/dependencies/boringssl/0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch
@@ -1,0 +1,29 @@
+diff --git a/BUILD b/BUILD
+index 65e0cdc2e..0d0593b50 100644
+--- a/BUILD
++++ b/BUILD
+@@ -101,6 +101,10 @@ posix_copts = [
+     "-Wwrite-strings",
+     "-Wshadow",
+     "-fno-common",
++    # no-pedanitc was added to fix below compilation errors.
++    # "ISO C does not support '__int128' types [-Werror=pedantic]"
++    # "ISO C does not allow extra ';' outside of a function [-Werror=pedantic]"
++    "-Wno-pedantic",
+ 
+     # Modern build environments should be able to set this to use atomic
+     # operations for reference counting rather than locks. However, it's
+diff --git a/src/crypto/hrss/asm/poly_rq_mul.S b/src/crypto/hrss/asm/poly_rq_mul.S
+index c37d7d0b4..59acffd89 100644
+--- a/src/crypto/hrss/asm/poly_rq_mul.S
++++ b/src/crypto/hrss/asm/poly_rq_mul.S
+@@ -12,7 +12,8 @@
+ // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ 
+-#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && defined(__linux__)
++// Code change to move the declarations under defined(OPENSSL_X86_64) was picked up from origin/master-with-bazel branch.
++#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && defined(__linux__) && defined(OPENSSL_X86_64)
+ 
+ #if defined(BORINGSSL_PREFIX)
+ #include <boringssl_prefix_symbols_asm.h>

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -183,12 +183,12 @@ def stage_1():
         patches = [
             "@enkit//bazel/dependencies/boringssl:0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch",
         ],
-	sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
-	strip_prefix = "boringssl-b9232f9e27e5668bc0414879dcdedb2a59ea75f2",
-	urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
-                "https://github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
-            ],
+        sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
+        strip_prefix = "boringssl-b9232f9e27e5668bc0414879dcdedb2a59ea75f2",
+        urls = [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
+            "https://github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
+        ],
     )
 
     maybe(

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -177,6 +177,21 @@ def stage_1():
     )
 
     maybe(
+        name = "boringssl",
+        repo_rule = http_archive,
+        patch_args = ["-p1"],
+        patches = [
+            "@enkit//bazel/dependencies/boringssl:0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch",
+        ],
+	sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
+	strip_prefix = "boringssl-b9232f9e27e5668bc0414879dcdedb2a59ea75f2",
+	urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
+                "https://github.com/google/boringssl/archive/b9232f9e27e5668bc0414879dcdedb2a59ea75f2.tar.gz",
+            ],
+    )
+
+    maybe(
         name = "com_github_grpc_grpc",
         repo_rule = http_archive,
         patch_args = ["-p1"],

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -84,6 +84,11 @@ def stage_2():
     rules_pkg_dependencies()
     multirun_dependencies()
 
+    # IMPORTANT: grpc_deps() pulls in boringssl as a WORKSPACE dependency. In order to apply patches
+    # to boringssl, we define boringssl BEFORE grpc_deps is invoked - that way, our version will be picked
+    # over the default one.
+    # You must manually update boringssl when grpc is updated. If ARM support is added upstream, we may
+    # be able to remove the patches and the work here.
     grpc_deps()
 
     rules_docker_dependencies()


### PR DESCRIPTION
Tested the boringssl repo changes for ARM64 and X86 based compilation and no issues were observed.

Verified that the enkit repo changes were picked up and the boringssl related patch got applied successfully.

Testing commands:

- clear && BAZEL_PROFILE=local bazel build
--override_repository=enkit=/home/naketi/gitrepos/enkit
//model/functional/model_test:model-grpc-e1
- clear && BAZEL_PROFILE=local bazel build
--override_repository=enkit=/home/naketi/gitrepos/enkit
//model/functional/model_test:model-grpc