### PR TITLE
codegen: add `tostderr` filter

### DIFF
--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -104,8 +104,10 @@ def _merge(a, b, path=None):
         raise TypeError(f"Could not merge type {type(a)!r} with type {type(b)!r}.")
     return a
 
-def tostderr_filter(text):
-    sys.stderr.write(f"{text}\n")
+def log_filter(text):
+    # TODO(jonathan): find a way to annotate this log message with the template
+    # file and line number.
+    logging.info(f"LOGGED: {text}")
     return ''
 
 class Template(data_loader.DataLoader):
@@ -136,7 +138,7 @@ class Template(data_loader.DataLoader):
         )
         self.env.filters.update({
             "re_sub": re_sub_function,
-            "tostderr": tostderr_filter,
+            "log": log_filter,
         })
         self.context = {"_DATA": [], "_TEMPLATE": ""}
         self.template = None

--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -12,6 +12,7 @@
 #  https://jinja.palletsprojects.com/en/3.1.x/
 
 # standard libraries
+import inspect
 import json
 import os
 import re
@@ -105,9 +106,18 @@ def _merge(a, b, path=None):
     return a
 
 def log_filter(text):
-    # TODO(jonathan): find a way to annotate this log message with the template
-    # file and line number.
-    logging.info(f"LOGGED: {text}")
+    for frameinfo in inspect.stack():
+        template = frameinfo.frame.f_globals.get("__jinja_template__")
+        if template is not None:
+            break
+    lineno = 0
+    filename = "?"
+    if template is not None:
+        filename = template.filename
+        lineno = template.get_corresponding_lineno(inspect.currentframe().f_back.f_lineno)
+        logging.info(f"{filename}:{lineno}: {text}")
+    else:
+        logging.info(f"unknown source: {text}")
     return ''
 
 class Template(data_loader.DataLoader):

--- a/tools/codegen/codegen.py
+++ b/tools/codegen/codegen.py
@@ -104,6 +104,9 @@ def _merge(a, b, path=None):
         raise TypeError(f"Could not merge type {type(a)!r} with type {type(b)!r}.")
     return a
 
+def tostderr_filter(text):
+    sys.stderr.write(f"{text}\n")
+    return ''
 
 class Template(data_loader.DataLoader):
     def __init__(self, other=None):
@@ -131,7 +134,10 @@ class Template(data_loader.DataLoader):
                 "re_sub": re_sub_function,
             }
         )
-        self.env.filters.update({"re_sub": re_sub_function})
+        self.env.filters.update({
+            "re_sub": re_sub_function,
+            "tostderr": tostderr_filter,
+        })
         self.context = {"_DATA": [], "_TEMPLATE": ""}
         self.template = None
         self.template_path = None

--- a/tools/codegen/tests/test.template
+++ b/tools/codegen/tests/test.template
@@ -2,6 +2,7 @@ over={{over}}
 zoo={{zoo}}
 foo={{foo}}
 camel={{foo|to_screaming_snake}}
+{{-foo|tostderr}}
 tooth={{"tooth"|re_sub("o", "a")}}
 tooth={{re_sub("foo", "o", "a")}}
 {%- for t in bum %}

--- a/tools/codegen/tests/test.template
+++ b/tools/codegen/tests/test.template
@@ -2,7 +2,7 @@ over={{over}}
 zoo={{zoo}}
 foo={{foo}}
 camel={{foo|to_screaming_snake}}
-{{-foo|tostderr}}
+{{-foo|log}}
 tooth={{"tooth"|re_sub("o", "a")}}
 tooth={{re_sub("foo", "o", "a")}}
 {%- for t in bum %}


### PR DESCRIPTION
This extension allows jinja2 scripts to emit text to standard logging during
code generation. This feature will ease the debugging of jinja2 templates.

Tested:

```
$ bazel build :gen-test-actual-gen
INFO: Analyzed target //tools/codegen/tests:gen-test-actual-gen (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: From Generating "tools/codegen/tests/gen-test.actual":
I0924 17:26:28.055019 140036723234624 codegen.py:118] tools/codegen/tests/test.template:5: bar
Target //tools/codegen/tests:gen-test-actual-gen up-to-date:
  bazel-bin/tools/codegen/tests/gen-test.actual
INFO: Elapsed time: 0.725s, Critical Path: 0.63s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

```


