### PR TITLE
fix: make grpc use hermetic python headers

### DIFF
--- a/bazel/dependencies/grpc/use_hermetic_py_headers.patch
+++ b/bazel/dependencies/grpc/use_hermetic_py_headers.patch
@@ -1,0 +1,13 @@
+diff --git a/bazel/cython_library.bzl b/bazel/cython_library.bzl
+index 8e003c2246..2b121a33f0 100644
+--- a/bazel/cython_library.bzl
++++ b/bazel/cython_library.bzl
+@@ -71,7 +71,7 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
+         native.cc_binary(
+             name = shared_object_name,
+             srcs = [stem + ".cpp"],
+-            deps = deps + ["@local_config_python//:python_headers"],
++            deps = deps + ["@rules_python//python/cc:current_py_cc_headers"],
+             linkshared = 1,
+         )
+         shared_objects.append(shared_object_name)

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -197,6 +197,7 @@ def stage_1():
         patch_args = ["-p1"],
         patches = [
             "@enkit//bazel/dependencies/grpc:no_remote_tag.patch",
+            "@enkit//bazel/dependencies/grpc:use_hermetic_py_headers.patch",
         ],
         sha256 = "e18b16f7976aab9a36c14c38180f042bb0fd196b75c9fd6a20a2b5f934876ad6",
         strip_prefix = "grpc-1.45.2",

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -52,6 +52,12 @@ def stage_2():
         ignore_root_user_error = True,
     )
 
+    # Workaround for a bug where rules_python doesn't register
+    # the python c toolchain ("py cc").
+    # see https://github.com/bazelbuild/rules_python/issues/1669
+    # and https://rules-python.readthedocs.io/en/latest/toolchains.html#python-c-toolchain-type
+    native.register_toolchains("@python3_8_toolchains//:all")
+
     # SDKs that can be used to build Go code. We need:
     # * the most recent version we can support
     # * the most recent version AppEngine can support (currently 1.16)


### PR DESCRIPTION
TL;DR - This patch should fix the issue that pops up from time to time where grpc's python stuff breaks due to having python 3.12 installed on the system.

Going forward we should try to stamp out our usage of `python_configure` and `local_config_python`. This is a step in that direction.

### Technical details

After filling up my disk I had to `bazel clean --expunge` and started noticing some interesting side effects -

My builds started failing with a familiar error where grpc picks up python 3.12 headers which have an API break:
```sh
bazel-out/k8-fastbuild/bin/external/com_github_grpc_grpc/src/python/grpcio/grpc/_cython/cygrpc.cpp: In function 'size_t __Pyx_PyInt_As_size_t(PyObject*)':
bazel-out/k8-fastbuild/bin/external/com_github_grpc_grpc/src/python/grpcio/grpc/_cython/cygrpc.cpp:132754:55: error: 'PyLongObject' {aka 'struct _longobject'} has no member named 'ob_digit'
132754 |             const digit* digits = ((PyLongObject*)x)->ob_digit;
```

Sure enough running `python --version` on my system indicated that I was running `3.12`. I uninstalled this python - but that made bazel *very* unhappy:
```sh
ERROR: /bazel/paths/to/external/local_config_python/_python/BUILD:75:8 declares output /some/path/Python.h is a dangling symbolic link
```

So it appears that although we have a hermetic python toolchain setup - `local_config_python` is still configuring targets based on the python headers it's able to find on the system. In my case I installed python 3.12 sometime before I `clean --expunged` and this time around it picked up the headers that make grpc break.

I found at least two different dependencies of ours that try to create this dependency:
- https://github.com/pybind/pybind11_bazel/blob/fd7d88857cca3d7435b06f3ac6abab77cd9983b2/python_configure.bzl#L431
- https://github.com/grpc/grpc/blob/b39ffcc425ea990a537f98ec6fe6a1dcb90470d7/third_party/py/python_configure.bzl#L379

luckily `rules_python` provides equivalents for the targets contained in `local_config_python` - so fixing this is a matter of making our builds use those instead.

I tried to globally shadow the `local_config_python` targets with the `rules_python` versions but ran into a lot of friction. In the end I just patched the specific usage in `grpc` that was causing the failures.

For pybind11 - we just need to upgrade: https://github.com/pybind/pybind11_bazel/pull/72

grpc is also trying to get a fix landed it looks like: https://github.com/grpc/grpc/pull/35666