### PR TITLE
Commented out AARCH64 related AES symbols to resolve boringssl->crypto->fipsmodule related linking errors.

### DIFF
--- a/bazel/dependencies/boringssl/0002-commentout-fips-module-AARCH64-declarations.patch
+++ b/bazel/dependencies/boringssl/0002-commentout-fips-module-AARCH64-declarations.patch
@@ -1,0 +1,108 @@
+diff --git a/src/crypto/chacha/internal.h b/src/crypto/chacha/internal.h
+index 1435e3b01..e8e95d7c9 100644
+--- a/src/crypto/chacha/internal.h
++++ b/src/crypto/chacha/internal.h
+@@ -28,8 +28,8 @@ void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
+                       const uint8_t nonce[16]);
+ 
+ #if !defined(OPENSSL_NO_ASM) &&                         \
+-    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
+-     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
++//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
+ #define CHACHA20_ASM
+ 
+ // ChaCha20_ctr32 is defined in asm/chacha-*.pl.
+diff --git a/src/crypto/fipsmodule/aes/internal.h b/src/crypto/fipsmodule/aes/internal.h
+index 5b8069550..a251085c0 100644
+--- a/src/crypto/fipsmodule/aes/internal.h
++++ b/src/crypto/fipsmodule/aes/internal.h
+@@ -44,9 +44,9 @@ OPENSSL_INLINE int vpaes_capable(void) {
+ }
+ 
+ #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+-#define HWAES
++//#define HWAES
+ 
+-OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_ARMv8_AES_capable(); }
++//OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_ARMv8_AES_capable(); }
+ 
+ #if defined(OPENSSL_ARM)
+ #define BSAES
+@@ -57,10 +57,10 @@ OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
+ #endif
+ 
+ #if defined(OPENSSL_AARCH64)
+-#define VPAES
+-#define VPAES_CBC
+-#define VPAES_CTR32
+-OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
++//#define VPAES
++//#define VPAES_CBC
++//#define VPAES_CTR32
++//OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
+ #endif
+ 
+ #elif defined(OPENSSL_PPC64LE)
+diff --git a/src/crypto/fipsmodule/bn/internal.h b/src/crypto/fipsmodule/bn/internal.h
+index cab9a81f9..188ca6f0e 100644
+--- a/src/crypto/fipsmodule/bn/internal.h
++++ b/src/crypto/fipsmodule/bn/internal.h
+@@ -345,8 +345,8 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
+                          const BIGNUM *max_exclusive);
+ 
+ #if !defined(OPENSSL_NO_ASM) &&                         \
+-    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
+-     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
++//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
+ #define OPENSSL_BN_ASM_MONT
+ // bn_mul_mont writes |ap| * |bp| mod |np| to |rp|, each |num| words
+ // long. Inputs and outputs are in Montgomery form. |n0| is a pointer to the
+diff --git a/src/crypto/fipsmodule/modes/internal.h b/src/crypto/fipsmodule/modes/internal.h
+index 2fea5585f..7de4e0f93 100644
+--- a/src/crypto/fipsmodule/modes/internal.h
++++ b/src/crypto/fipsmodule/modes/internal.h
+@@ -284,6 +284,7 @@ size_t aesni_gcm_decrypt(const uint8_t *in, uint8_t *out, size_t len,
+ #endif  // OPENSSL_X86
+ 
+ #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
++#if 0
+ #define GHASH_ASM_ARM
+ #define GCM_FUNCREF
+ 
+@@ -302,7 +303,7 @@ void gcm_init_neon(u128 Htable[16], const uint64_t Xi[2]);
+ void gcm_gmult_neon(uint64_t Xi[2], const u128 Htable[16]);
+ void gcm_ghash_neon(uint64_t Xi[2], const u128 Htable[16], const uint8_t *inp,
+                     size_t len);
+-
++#endif
+ #elif defined(OPENSSL_PPC64LE)
+ #define GHASH_ASM_PPC64LE
+ #define GCM_FUNCREF
+diff --git a/src/crypto/fipsmodule/sha/internal.h b/src/crypto/fipsmodule/sha/internal.h
+index cc9091495..360481397 100644
+--- a/src/crypto/fipsmodule/sha/internal.h
++++ b/src/crypto/fipsmodule/sha/internal.h
+@@ -24,8 +24,8 @@ extern "C" {
+ 
+ #if defined(OPENSSL_PPC64LE) ||                          \
+     (!defined(OPENSSL_NO_ASM) &&                         \
+-     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
+-      defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)))
++     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64)))
++//      defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)))
+ // POWER has an intrinsics-based implementation of SHA-1 and thus the functions
+ // normally defined in assembly are available even with |OPENSSL_NO_ASM| in
+ // this case.
+@@ -35,8 +35,8 @@ void sha1_block_data_order(uint32_t *state, const uint8_t *in,
+ #endif
+ 
+ #if !defined(OPENSSL_NO_ASM) &&                         \
+-    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
+-     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
++//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
+ #define SHA256_ASM
+ #define SHA512_ASM
+ void sha256_block_data_order(uint32_t *state, const uint8_t *in,

--- a/bazel/dependencies/boringssl/0002-commentout-fips-module-AARCH64-declarations.patch
+++ b/bazel/dependencies/boringssl/0002-commentout-fips-module-AARCH64-declarations.patch
@@ -1,108 +1,130 @@
 diff --git a/src/crypto/chacha/internal.h b/src/crypto/chacha/internal.h
-index 1435e3b01..e8e95d7c9 100644
+index 1435e3b01..dd4fd9f0f 100644
 --- a/src/crypto/chacha/internal.h
 +++ b/src/crypto/chacha/internal.h
-@@ -28,8 +28,8 @@ void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
+@@ -28,8 +28,12 @@ void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
                        const uint8_t nonce[16]);
  
  #if !defined(OPENSSL_NO_ASM) &&                         \
 -    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
 -     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
 +    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
-+//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
++ * defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++ */
  #define CHACHA20_ASM
  
  // ChaCha20_ctr32 is defined in asm/chacha-*.pl.
 diff --git a/src/crypto/fipsmodule/aes/internal.h b/src/crypto/fipsmodule/aes/internal.h
-index 5b8069550..a251085c0 100644
+index 5b8069550..673949dc9 100644
 --- a/src/crypto/fipsmodule/aes/internal.h
 +++ b/src/crypto/fipsmodule/aes/internal.h
-@@ -44,9 +44,9 @@ OPENSSL_INLINE int vpaes_capable(void) {
+@@ -44,9 +44,14 @@ OPENSSL_INLINE int vpaes_capable(void) {
  }
  
  #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
--#define HWAES
-+//#define HWAES
++
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
+ #define HWAES
  
--OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_ARMv8_AES_capable(); }
-+//OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_ARMv8_AES_capable(); }
+ OPENSSL_INLINE int hwaes_capable(void) { return CRYPTO_is_ARMv8_AES_capable(); }
++*/
  
  #if defined(OPENSSL_ARM)
  #define BSAES
-@@ -57,10 +57,10 @@ OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
+@@ -56,12 +61,16 @@ OPENSSL_INLINE int bsaes_capable(void) { return CRYPTO_is_NEON_capable(); }
+ OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
  #endif
  
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
  #if defined(OPENSSL_AARCH64)
--#define VPAES
--#define VPAES_CBC
--#define VPAES_CTR32
--OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
-+//#define VPAES
-+//#define VPAES_CBC
-+//#define VPAES_CTR32
-+//OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
+ #define VPAES
+ #define VPAES_CBC
+ #define VPAES_CTR32
+ OPENSSL_INLINE int vpaes_capable(void) { return CRYPTO_is_NEON_capable(); }
  #endif
++*/
  
  #elif defined(OPENSSL_PPC64LE)
+ #define HWAES
 diff --git a/src/crypto/fipsmodule/bn/internal.h b/src/crypto/fipsmodule/bn/internal.h
-index cab9a81f9..188ca6f0e 100644
+index cab9a81f9..bb57cf481 100644
 --- a/src/crypto/fipsmodule/bn/internal.h
 +++ b/src/crypto/fipsmodule/bn/internal.h
-@@ -345,8 +345,8 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
+@@ -345,8 +345,12 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
                           const BIGNUM *max_exclusive);
  
  #if !defined(OPENSSL_NO_ASM) &&                         \
 -    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
 -     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
 +    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
-+//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
++ * defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++ */
  #define OPENSSL_BN_ASM_MONT
  // bn_mul_mont writes |ap| * |bp| mod |np| to |rp|, each |num| words
  // long. Inputs and outputs are in Montgomery form. |n0| is a pointer to the
 diff --git a/src/crypto/fipsmodule/modes/internal.h b/src/crypto/fipsmodule/modes/internal.h
-index 2fea5585f..7de4e0f93 100644
+index 2fea5585f..f06cbff9e 100644
 --- a/src/crypto/fipsmodule/modes/internal.h
 +++ b/src/crypto/fipsmodule/modes/internal.h
-@@ -284,6 +284,7 @@ size_t aesni_gcm_decrypt(const uint8_t *in, uint8_t *out, size_t len,
+@@ -283,6 +283,9 @@ size_t aesni_gcm_decrypt(const uint8_t *in, uint8_t *out, size_t len,
+ #define GHASH_ASM_X86
  #endif  // OPENSSL_X86
  
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
  #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
-+#if 0
  #define GHASH_ASM_ARM
  #define GCM_FUNCREF
- 
-@@ -302,7 +303,7 @@ void gcm_init_neon(u128 Htable[16], const uint64_t Xi[2]);
- void gcm_gmult_neon(uint64_t Xi[2], const u128 Htable[16]);
+@@ -303,6 +306,7 @@ void gcm_gmult_neon(uint64_t Xi[2], const u128 Htable[16]);
  void gcm_ghash_neon(uint64_t Xi[2], const u128 Htable[16], const uint8_t *inp,
                      size_t len);
--
-+#endif
+ 
++*/
  #elif defined(OPENSSL_PPC64LE)
  #define GHASH_ASM_PPC64LE
  #define GCM_FUNCREF
 diff --git a/src/crypto/fipsmodule/sha/internal.h b/src/crypto/fipsmodule/sha/internal.h
-index cc9091495..360481397 100644
+index cc9091495..3d7b297f7 100644
 --- a/src/crypto/fipsmodule/sha/internal.h
 +++ b/src/crypto/fipsmodule/sha/internal.h
-@@ -24,8 +24,8 @@ extern "C" {
+@@ -24,8 +24,12 @@ extern "C" {
  
  #if defined(OPENSSL_PPC64LE) ||                          \
      (!defined(OPENSSL_NO_ASM) &&                         \
 -     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
 -      defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)))
 +     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64)))
-+//      defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)))
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
++ * defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)))
++ */
  // POWER has an intrinsics-based implementation of SHA-1 and thus the functions
  // normally defined in assembly are available even with |OPENSSL_NO_ASM| in
  // this case.
-@@ -35,8 +35,8 @@ void sha1_block_data_order(uint32_t *state, const uint8_t *in,
+@@ -35,8 +39,12 @@ void sha1_block_data_order(uint32_t *state, const uint8_t *in,
  #endif
  
  #if !defined(OPENSSL_NO_ASM) &&                         \
 -    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
 -     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
 +    (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
-+//     defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++/*
++ * TODO(naketi): Commenting out ARM and AARCH64 condition,
++ * will enable if needed
++ * defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
++ */
  #define SHA256_ASM
  #define SHA512_ASM
  void sha256_block_data_order(uint32_t *state, const uint8_t *in,

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -182,6 +182,7 @@ def stage_1():
         patch_args = ["-p1"],
         patches = [
             "@enkit//bazel/dependencies/boringssl:0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch",
+            "@enkit//bazel/dependencies/boringssl:0002-commentout-fips-module-AARCH64-declarations.patch",
         ],
         sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
         strip_prefix = "boringssl-b9232f9e27e5668bc0414879dcdedb2a59ea75f2",


### PR DESCRIPTION
**Unit Testing:**

**Command:** `BAZEL_PROFILE=local bazel build --config=gcc-13-aarch64 --override_repository=enkit=/home/naketi/gitrepos/enkit //model/functional/model_test:model-grpc-agent-aarch64`

**Binary:** `bazel-bin/model/functional/model_test/model-grpc-agent-aarch64`

(default-dev-env)naketi@penguin:~/gitrepos/E1$ file bazel-bin/model/functional/model_test/model-grpc-agent-aarch64
bazel-bin/model/functional/model_test/model-grpc-agent-aarch64: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, not stripped

**Regression Testing:**

**Command:** `BAZEL_PROFILE=local bazel build --override_repository=enkit=/home/naketi/gitrepos/enkit //model/functional/model_test:model-grpc-agent`

**Binary:** `bazel-bin/model/functional/model_test/model-grpc-agent`

(default-dev-env)naketi@penguin:~/gitrepos/E1$ file bazel-bin/model/functional/model_test/model-grpc-agent
bazel-bin/model/functional/model_test/model-grpc-agent: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=65db6691d180754a36be803f7c49dd688e196284, not stripped
