### PR TITLE
Add the command rules for multirun

### DIFF
--- a/bazel/enkit/defs.bzl
+++ b/bazel/enkit/defs.bzl
@@ -1,5 +1,5 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@com_github_atlassian_bazel_tools//multirun:def.bzl", _multirun = "multirun")
+load("@com_github_atlassian_bazel_tools//multirun:def.bzl", _multirun = "multirun", _command = "command")
 load("@bazel_tools//tools/build_defs/hash:hash.bzl", "sha256", "tools")
 load("//bazel/utils:template.bzl", "template_expand", "template_tool")
 load("//bazel/utils:validate.bzl", "validate_format", "validate_tool")
@@ -121,3 +121,4 @@ def enkit_package(name, srcs, image = "", override = "", manifest = "maninfest.y
 
 # Expose the multirun target, for convenience.
 multirun = _multirun
+command = _command


### PR DESCRIPTION
This change imports the `command` rules from the `multirun` external repo so that multiple bazel run targets can be executed with command line arguments.

Tested:
- `bazel run //infra/dev_container/hw_dev_v3/tests:update_all`

JIRA: ENGPROD-809