### PR TITLE
fix(rules_foreign_cc): pass linker args from toolchain to module libs

### DIFF
--- a/bazel/dependencies/rules_foreign_cc_module_linker_flags.patch
+++ b/bazel/dependencies/rules_foreign_cc_module_linker_flags.patch
@@ -1,0 +1,20 @@
+diff --git a/foreign_cc/private/cmake_script.bzl b/foreign_cc/private/cmake_script.bzl
+index 7645e61..29b33b0 100644
+--- a/foreign_cc/private/cmake_script.bzl
++++ b/foreign_cc/private/cmake_script.bzl
+@@ -199,6 +199,7 @@ _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
+     "CMAKE_EXE_LINKER_FLAGS": struct(value = "CMAKE_EXE_LINKER_FLAGS_INIT", replace = False),
+     "CMAKE_RANLIB": struct(value = "CMAKE_RANLIB", replace = True),
+     "CMAKE_SHARED_LINKER_FLAGS": struct(value = "CMAKE_SHARED_LINKER_FLAGS_INIT", replace = False),
++    "CMAKE_MODULE_LINKER_FLAGS": struct(value = "CMAKE_MODULE_LINKER_FLAGS_INIT", replace = False),
+     "CMAKE_STATIC_LINKER_FLAGS": struct(value = "CMAKE_STATIC_LINKER_FLAGS_INIT", replace = False),
+ }
+ 
+@@ -354,6 +355,7 @@ def _fill_crossfile_from_toolchain(workspace_name, tools, flags):
+     #        lines += [_set_list(ctx, "CMAKE_STATIC_LINKER_FLAGS_INIT", flags.cxx_linker_static)]
+     if flags.cxx_linker_shared:
+         dict["CMAKE_SHARED_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_shared)
++        dict["CMAKE_MODULE_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_shared)
+     if flags.cxx_linker_executable:
+         dict["CMAKE_EXE_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_executable)
+ 

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -285,6 +285,7 @@ filegroup(
         url = "https://github.com/bazelbuild/rules_foreign_cc/archive/816905a078773405803e86635def78b61d2f782d.tar.gz",
         patches = [
             "@enkit//bazel/dependencies:rules_foreign_cc_export_functions.patch",
+            "@enkit//bazel/dependencies:rules_foreign_cc_module_linker_flags.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
Fixes bazel's linker flags not being passed to CMake module library targets - e.g.:

```cmake
add_library(foo MODULE)
```

This can lead to surprising behavior - see: https://github.com/enfabrica/internal/blob/5ac4068d3afad4a662962740981dde0764972c98/bazel/dependencies/rdma-core.BUILD.bazel#L47

Further we can remove the hardcoded linker flags in the above target.

We should merge this if upstream takes the fix: https://github.com/bazel-contrib/rules_foreign_cc/pull/1308.

Once we upgrade it can be removed.