### PR TITLE
Reverted unwanted changes made to fix ARM64 based compilation errors in boringssl external repository

### DIFF
--- a/bazel/dependencies/boringssl/0001-move-hrss-polynomial-declarations-under-x64-flag.patch
+++ b/bazel/dependencies/boringssl/0001-move-hrss-polynomial-declarations-under-x64-flag.patch
@@ -1,18 +1,3 @@
-diff --git a/BUILD b/BUILD
-index 65e0cdc2e..0d0593b50 100644
---- a/BUILD
-+++ b/BUILD
-@@ -101,6 +101,10 @@ posix_copts = [
-     "-Wwrite-strings",
-     "-Wshadow",
-     "-fno-common",
-+    # no-pedanitc was added to fix below compilation errors.
-+    # "ISO C does not support '__int128' types [-Werror=pedantic]"
-+    # "ISO C does not allow extra ';' outside of a function [-Werror=pedantic]"
-+    "-Wno-pedantic",
- 
-     # Modern build environments should be able to set this to use atomic
-     # operations for reference counting rather than locks. However, it's
 diff --git a/src/crypto/hrss/asm/poly_rq_mul.S b/src/crypto/hrss/asm/poly_rq_mul.S
 index c37d7d0b4..0e2cf0620 100644
 --- a/src/crypto/hrss/asm/poly_rq_mul.S

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -181,7 +181,7 @@ def stage_1():
         repo_rule = http_archive,
         patch_args = ["-p1"],
         patches = [
-            "@enkit//bazel/dependencies/boringssl:0001-ignore-pedantic-warnings-and-move-hrss-polynomial-declarations-under-x64-flag.patch",
+            "@enkit//bazel/dependencies/boringssl:0001-move-hrss-polynomial-declarations-under-x64-flag.patch",
             "@enkit//bazel/dependencies/boringssl:0002-commentout-fips-module-AARCH64-declarations.patch",
         ],
         sha256 = "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",


### PR DESCRIPTION
Some of the changes in boringssl external repository are not needed after upgrading GCC version to GCC-13 form GCC-10. So, reverting the changes.

Tested the boringssl repo changes for ARM64 and X86 based compilation and no issues were observed.
Verified that the enkit repo changes were picked up and the boringssl related patch got applied successfully.

**Testing commands:**

```
clear && BAZEL_PROFILE=local bazel build --override_repository=enkit=/home/naketi/gitrepos/enkit //model/functional/model_test:model-grpc-agent-e1

clear && BAZEL_PROFILE=local bazel build --override_repository=enkit=/home/naketi/gitrepos/enkit //model/functional/model_test:model-grpc-agent
```