### PR TITLE
[SF-1038] Add support for zlib dependency

### DIFF
--- a/bazel/dependencies/dropbear.BUILD.bazel
+++ b/bazel/dependencies/dropbear.BUILD.bazel
@@ -31,6 +31,13 @@ configure_make(
         "dropbearkey",
     ],
     visibility = ["//visibility:public"],
+    deps = select({
+        "@//bazel/platforms:e1_gnu_build": [
+            "@libz//:libz",
+        ],
+        # Use the system libz on other platforms.
+        "//conditions:default": [],
+    }),
 )
 
 

--- a/bazel/dependencies/libz.BUILD.bazel
+++ b/bazel/dependencies/libz.BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+filegroup(
+    name = "libz_all",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "libz_headers",
+    srcs = glob(["**/*.h"]),
+    visibility = ["//visibility:public"],
+)
+
+
+# zlib
+# The name of this rule is libz to avoid conflicts with the system `@zlib//:zlib`.
+# We cannot use @zlib//:zlib because the libraries that are generated are named
+# libzlib.(a|so), which is incompatible with other foreign_cc builds.
+cmake(
+    name = "libz", 
+    env = select({
+        "@//bazel/platforms:e1_gnu_build" : {
+            "CHOST": "arm",
+            "LDFLAGS": "-fuse-ld=gold",
+        },
+        "//conditions:default" : {}
+    }),
+    cache_entries = {
+        "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",
+        "CMAKE_CXX_FLAGS": "${CMAKE_CXX_FLAGS:-} -fPIC",
+    },
+    lib_source = ":libz_all",
+    generate_args = [],
+    targets = ["", "install"],
+    build_args = ["--parallel $$(nproc)"],
+    out_static_libs = ["libz.a"],
+    out_shared_libs = ["libz.so"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/dependencies/libz.BUILD.bazel
+++ b/bazel/dependencies/libz.BUILD.bazel
@@ -19,13 +19,7 @@ filegroup(
 # libzlib.(a|so), which is incompatible with other foreign_cc builds.
 cmake(
     name = "libz", 
-    env = select({
-        "@//bazel/platforms:e1_gnu_build" : {
-            "CHOST": "arm",
-            "LDFLAGS": "-fuse-ld=gold",
-        },
-        "//conditions:default" : {}
-    }),
+    env = {},
     cache_entries = {
         "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",
         "CMAKE_CXX_FLAGS": "${CMAKE_CXX_FLAGS:-} -fPIC",

--- a/bazel/dependencies/libz.BUILD.bazel
+++ b/bazel/dependencies/libz.BUILD.bazel
@@ -27,7 +27,6 @@ cmake(
     lib_source = ":libz_all",
     generate_args = [],
     targets = ["", "install"],
-    build_args = ["--parallel $$(nproc)"],
     out_static_libs = ["libz.a"],
     out_shared_libs = ["libz.so"],
     includes = ["."],

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -308,6 +308,16 @@ filegroup(
     )
 
     maybe(
+        name = "libz",
+        repo_rule = http_archive,
+        build_file = "@enkit//bazel/dependencies:libz.BUILD.bazel",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        # Original file: https://zlib.net/fossils/zlib-1.2.11.tar.gz
+        urls = ["https://astore.corp.enfabrica.net/d/mirror/zlib/zlib-1.2.11.tar.gz?u=giqzp6y6me76syf7jrgwtevqxgdhswdu"]
+    )
+
+    maybe(
         name = "dropbear",
         repo_rule = http_archive,
         build_file = "@enkit//bazel/dependencies:dropbear.BUILD.bazel",


### PR DESCRIPTION
This PR adds zlib as a dependency. The default behavior is to use the zlib installed on the system. However, we may need to build zlib when cross compiling.