### PR TITLE
md5sum_diff_test: improve handling of archives.

### DIFF
--- a/bazel/utils/BUILD.bazel
+++ b/bazel/utils/BUILD.bazel
@@ -140,6 +140,22 @@ md5sum_diff_test(
     ],
 )
 
+genrule(
+    name = "test_archive.tgz",
+    outs = ["test_archive.tgz"],
+    srcs = [
+        "escape_and_join1.actual",
+        "testdata/a.expected.txt",
+    ],
+    cmd_bash = "tar -zcf $@ --dereference $(SRCS)",
+)
+
+md5sum_diff_test(
+    name = "md5sum_diff_test_archive_test",
+    srcs = [":test_archive.tgz"],
+)
+
+
 #### Support targets
 filegroup(
     name = "remote-deps",

--- a/bazel/utils/md5sum_diff_test_archive_test.md5sum
+++ b/bazel/utils/md5sum_diff_test_archive_test.md5sum
@@ -1,0 +1,3 @@
+bazel-out/k8-fastbuild/bin/bazel/utils/test_archive.tgz contents:
+bazel-out/k8-fastbuild/bin/bazel/utils/escape_and_join1.actual	2ebec47b84f22f0acc2812627aec97b0  -
+bazel/utils/testdata/a.expected.txt	60b725f10c9c85c70d97880dfe8191b3  -


### PR DESCRIPTION
It's better to md5 checksum the contents of archives than the archives themselves.

Tested: Added a new test for checksumming archives, it passes.


