### PR TITLE
fix(bazel): make kernel module builds use gcc-13

### DIFF
--- a/bazel/linux/platforms/BUILD.bazel
+++ b/bazel/linux/platforms/BUILD.bazel
@@ -1,5 +1,17 @@
 load("//bazel/linux/platforms:defs.bzl", "kernel_aarch64_constraints")
 
+# Constraint setting based on GCC version
+constraint_setting(name = "gcc_version")
+
+# A specific constraint value, limiting GCC to version 13
+constraint_value(
+    name = "gcc_13",
+    constraint_setting = ":gcc_version",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
 platform(
     name = "kernel_aarch64",
     constraint_values = kernel_aarch64_constraints,

--- a/bazel/linux/platforms/defs.bzl
+++ b/bazel/linux/platforms/defs.bzl
@@ -5,6 +5,7 @@ load("//bazel/linux:providers.bzl", "KernelBundleInfo")
 kernel_aarch64_constraints = [
     "@platforms//cpu:aarch64",
     "@platforms//os:linux",
+    Label("//bazel/linux/platforms:gcc_13"),
 ]
 
 def _kernel_aarch64_transition_impl(settings, attr):


### PR DESCRIPTION
`kernel_module` targets were still silently building against our previous aarch64-linux cross compiler based on `bazel_embedded` instead of our new hand rolled one.

To fix this I've moved the `gcc-13` constraint into this repo so and made it a constraint of the `kernel-aarch64` platform.

This aligns the constraints setting of all the aarch64-linux platforms.