### PR TITLE
Dropbear fixes

### DIFF
--- a/bazel/dependencies/dropbear.BUILD.bazel
+++ b/bazel/dependencies/dropbear.BUILD.bazel
@@ -6,7 +6,7 @@ configure_make(
     name = "binaries",
     lib_source = ":all",
     configure_options = [
-        "--enable-static",
+        "--disable-static",
         "--enable-bundled-libtom",
     ] + select({
         "@//bazel/platforms:e1_gnu_build": [

--- a/bazel/dependencies/dropbear.BUILD.bazel
+++ b/bazel/dependencies/dropbear.BUILD.bazel
@@ -6,6 +6,12 @@ configure_make(
     name = "binaries",
     lib_source = ":all",
     configure_options = [
+        "--disable-lastlog",
+        "--disable-utmp",
+        "--disable-utmpx",
+        "--disable-wtmp",
+        "--disable-wtmpx",
+        "--disable-loginfunc",
         "--disable-static",
         "--enable-bundled-libtom",
     ] + select({


### PR DESCRIPTION
Linking dropbear statically doesn't work well because libnss (which we depend on via glibc) uses dynamic modules.  Dropbear authors recommend an alternative libc for static linking.

While at it, make some error messages go away.  These:
```
2024-11-12 20:01:35.241 SERR [qemu-acf01-host01-dropbear-215]:  [248] Nov 12 20:01:35 lastlog_openseek: Couldn't open /var/log/lastlog: Permission denied
2024-11-12 20:01:36.842 SERR [qemu-acf01-host01-dropbear-215]:  [247] Nov 12 20:01:36 syslogin_perform_logout: logout(pts/2) returned an error: No such file or directory
```