### PR TITLE
Update googletest to v1.15.2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,8 @@
 # see https://docs.bazel.build/versions/master/guide.html#bazelrc
 #
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
-build --cxxopt="-std=c++17"  --host_cxxopt="-std=c++17" --client_env=BAZEL_CXXOPTS=-std=c++17
+common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
+build --cxxopt="-std=c++20"  --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS=-std=c++20
 
 build --workspace_status_command "/bin/bash bazel/workspace_status.sh"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,7 @@
 # see https://docs.bazel.build/versions/master/guide.html#bazelrc
 #
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
+build --cxxopt="-std=c++17"  --host_cxxopt="-std=c++17" --client_env=BAZEL_CXXOPTS=-std=c++17
 
 build --workspace_status_command "/bin/bash bazel/workspace_status.sh"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+
+
+bazel_dep(name = "googletest", version = "1.15.2")

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -130,14 +130,6 @@ def stage_1():
     )
 
     maybe(
-        name = "com_google_googletest",
-        repo_rule = http_archive,
-        sha256 = "f179ec217f9b3b3f3c6e8b02d3e7eda997b49e4ce26d6b235c9053bec9c0bf9f",
-        strip_prefix = "googletest-1.15.2",
-        url = "https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip",
-    )
-
-    maybe(
         name = "com_google_absl",
         repo_rule = http_archive,
         sha256 = "51d676b6846440210da48899e4df618a357e6e44ecde7106f1e44ea16ae8adc7",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -132,9 +132,9 @@ def stage_1():
     maybe(
         name = "com_google_googletest",
         repo_rule = http_archive,
-        sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
-        strip_prefix = "googletest-release-1.10.0",
-        url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
+        sha256 = "f179ec217f9b3b3f3c6e8b02d3e7eda997b49e4ce26d6b235c9053bec9c0bf9f",
+        strip_prefix = "googletest-1.15.2",
+        url = "https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip",
     )
 
     maybe(

--- a/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
+++ b/bazel/utils/testdata/remote/with-all-inputs.files_to_copy.expected
@@ -283,15 +283,13 @@ enkit/tools/codegen/tests/test.template
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-actions.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-cardinalities.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-function-mocker.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-actions.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-function-mockers.h
-enkit/../com_google_googletest/googlemock/include/gmock/gmock-generated-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-more-actions.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-more-matchers.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-nice-strict.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h
 enkit/../com_google_googletest/googlemock/include/gmock/gmock.h
+enkit/../com_google_googletest/googletest/include/gtest/gtest-assertion-result.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-death-test.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-matchers.h
 enkit/../com_google_googletest/googletest/include/gtest/gtest-message.h
@@ -325,6 +323,7 @@ enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-port-arch
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-port.h
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-string.h
 enkit/../com_google_googletest/googletest/include/gtest/internal/gtest-type-util.h
+enkit/../com_google_googletest/googletest/src/gtest-assertion-result.cc
 enkit/../com_google_googletest/googletest/src/gtest-death-test.cc
 enkit/../com_google_googletest/googletest/src/gtest-filepath.cc
 enkit/../com_google_googletest/googletest/src/gtest-internal-inl.h


### PR DESCRIPTION
Despite the branch name, this does what it says in the title.

Along the way, I found that it requires an explicit specification of C++ version >= C++14, so I added that to the .bazelrc.

All tests under [internal] //ib, //driver, and //sdk perform as before this change if I incorporate it in the main repository (with one necessary change to one line of code).