### PR TITLE
dropbear: add an option to ignore the user's shell

### DIFF
--- a/bazel/dependencies/dropbear/0001-allow-blank-password.patch
+++ b/bazel/dependencies/dropbear/0001-allow-blank-password.patch
@@ -1,33 +1,44 @@
-diff --git runopts.h runopts.h
-index 1675836..a42e99b 100644
---- runopts.h
-+++ runopts.h
+From 7f56b2c67e20bf7b70b1cdee5b42236a65652a19 Mon Sep 17 00:00:00 2001
+From: Carlo Contavalli <carlo@enfabrica.net>
+Date: Thu, 14 Nov 2024 18:00:51 +0000
+Subject: [PATCH 1/3] allow blank password
+
+---
+ src/runopts.h     | 1 +
+ src/svr-auth.c    | 2 +-
+ src/svr-runopts.c | 7 ++++++-
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/runopts.h b/src/runopts.h
+index 1c88b5c..a79e022 100644
+--- a/src/runopts.h
++++ b/src/runopts.h
 @@ -107,6 +107,7 @@ typedef struct svr_runopts {
  	int noauthpass;
  	int norootpass;
  	int allowblankpass;
-+ 	int forceblankpass;
++	int forceblankpass;
  	int multiauthmethod;
  	unsigned int maxauthtries;
  
-diff --git svr-auth.c svr-auth.c
-index 05ac6a9..738975a 100644
---- svr-auth.c
-+++ svr-auth.c
+diff --git a/src/svr-auth.c b/src/svr-auth.c
+index 98cc518..3f91f9c 100644
+--- a/src/svr-auth.c
++++ b/src/svr-auth.c
 @@ -127,7 +127,7 @@ void recv_msg_userauth_request() {
  				&& svr_opts.allowblankpass
  				&& !svr_opts.noauthpass
  				&& !(svr_opts.norootpass && ses.authstate.pw_uid == 0) 
 -				&& ses.authstate.pw_passwd[0] == '\0') 
-+				&& (ses.authstate.pw_passwd[0] == '\0' || svr_opts.forceblankpass)) 
++				&& (ses.authstate.pw_passwd[0] == '\0' || svr_opts.forceblankpass))
  		{
  			dropbear_log(LOG_NOTICE, 
  					"Auth succeeded with blank password for '%s' from %s",
-diff --git svr-runopts.c svr-runopts.c
-index cb92595..d30b8ac 100644
---- svr-runopts.c
-+++ svr-runopts.c
-@@ -80,7 +80,8 @@ static void printhelp(const char * progname) {
+diff --git a/src/svr-runopts.c b/src/svr-runopts.c
+index c4f83c1..aaf199c 100644
+--- a/src/svr-runopts.c
++++ b/src/svr-runopts.c
+@@ -81,7 +81,8 @@ static void printhelp(const char * progname) {
  #if DROPBEAR_SVR_PASSWORD_AUTH || DROPBEAR_SVR_PAM_AUTH
  					"-s		Disable password logins\n"
  					"-g		Disable password logins for root\n"
@@ -37,7 +48,7 @@ index cb92595..d30b8ac 100644
  					"-t		Enable two-factor authentication (both password and public key required)\n"
  #endif
  					"-T		Maximum authentication tries (default %d)\n"
-@@ -161,6 +162,7 @@ void svr_getopts(int argc, char ** argv) {
+@@ -166,6 +167,7 @@ void svr_getopts(int argc, char ** argv) {
  	svr_opts.noauthpass = 0;
  	svr_opts.norootpass = 0;
  	svr_opts.allowblankpass = 0;
@@ -45,7 +56,7 @@ index cb92595..d30b8ac 100644
  	svr_opts.multiauthmethod = 0;
  	svr_opts.maxauthtries = MAX_AUTH_TRIES;
  	svr_opts.inetdmode = 0;
-@@ -298,6 +300,9 @@ void svr_getopts(int argc, char ** argv) {
+@@ -308,6 +310,9 @@ void svr_getopts(int argc, char ** argv) {
  				case 'g':
  					svr_opts.norootpass = 1;
  					break;
@@ -55,3 +66,6 @@ index cb92595..d30b8ac 100644
  				case 'B':
  					svr_opts.allowblankpass = 1;
  					break;
+-- 
+2.47.0
+

--- a/bazel/dependencies/dropbear/0002-override-authorized-keys.patch
+++ b/bazel/dependencies/dropbear/0002-override-authorized-keys.patch
@@ -1,8 +1,19 @@
-diff --git runopts.h runopts.h
-index a42e99b..925e409 100644
---- runopts.h
-+++ runopts.h
-@@ -137,6 +137,9 @@ typedef struct svr_runopts {
+From 664e175ae076757246ede342a264e91e348fecd8 Mon Sep 17 00:00:00 2001
+From: Carlo Contavalli <carlo@enfabrica.net>
+Date: Thu, 14 Nov 2024 18:02:44 +0000
+Subject: [PATCH 2/3] override authorized keys
+
+---
+ src/runopts.h        |  3 +++
+ src/svr-authpubkey.c | 38 +++++++++++++++++++++++---------------
+ src/svr-runopts.c    | 10 ++++++++++
+ 3 files changed, 36 insertions(+), 15 deletions(-)
+
+diff --git a/src/runopts.h b/src/runopts.h
+index a79e022..317d540 100644
+--- a/src/runopts.h
++++ b/src/runopts.h
+@@ -138,6 +138,9 @@ typedef struct svr_runopts {
  	char *pubkey_plugin_options;
  #endif
  
@@ -12,10 +23,10 @@ index a42e99b..925e409 100644
  	int pass_on_env;
  
  } svr_runopts;
-diff --git svr-authpubkey.c svr-authpubkey.c
+diff --git a/src/svr-authpubkey.c b/src/svr-authpubkey.c
 index 5d298cb..64723df 100644
---- svr-authpubkey.c
-+++ svr-authpubkey.c
+--- a/src/svr-authpubkey.c
++++ b/src/svr-authpubkey.c
 @@ -458,22 +458,30 @@ static int checkpubkey(const char* keyalgo, unsigned int keyalgolen,
  		dropbear_exit("Failed to set euid");
  	}
@@ -62,11 +73,11 @@ index 5d298cb..64723df 100644
  		}
  	}
  #if DROPBEAR_SVR_MULTIUSER
-diff --git svr-runopts.c svr-runopts.c
-index 6870f62..ff105dd 100644
---- svr-runopts.c
-+++ svr-runopts.c
-@@ -110,6 +110,8 @@ static void printhelp(const char * progname) {
+diff --git a/src/svr-runopts.c b/src/svr-runopts.c
+index aaf199c..2540e8f 100644
+--- a/src/svr-runopts.c
++++ b/src/svr-runopts.c
+@@ -115,6 +115,8 @@ static void printhelp(const char * progname) {
                                          "-A <authplugin>[,<options>]\n"
                                          "               Enable external public key auth through <authplugin>\n"
  #endif
@@ -75,7 +86,7 @@ index 6870f62..ff105dd 100644
  					"-V    Version\n"
  #if DEBUG_TRACE
  					"-v    verbose (repeat for more verbose)\n"
-@@ -147,6 +149,7 @@ void svr_getopts(int argc, char ** argv) {
+@@ -152,6 +154,7 @@ void svr_getopts(int argc, char ** argv) {
  #if DROPBEAR_PLUGIN
          char* pubkey_plugin = NULL;
  #endif
@@ -83,15 +94,15 @@ index 6870f62..ff105dd 100644
  
  
  	/* see printhelp() for options */
-@@ -180,6 +183,7 @@ void svr_getopts(int argc, char ** argv) {
+@@ -185,6 +188,7 @@ void svr_getopts(int argc, char ** argv) {
          svr_opts.pubkey_plugin = NULL;
          svr_opts.pubkey_plugin_options = NULL;
  #endif
-+ 	svr_opts.authorized_keys_file = NULL;
++	svr_opts.authorized_keys_file = NULL;
  	svr_opts.pass_on_env = 0;
  	svr_opts.reexec_childpipe = -1;
  
-@@ -322,6 +326,9 @@ void svr_getopts(int argc, char ** argv) {
+@@ -332,6 +336,9 @@ void svr_getopts(int argc, char ** argv) {
                                          next = &pubkey_plugin;
                                          break;
  #endif
@@ -101,13 +112,16 @@ index 6870f62..ff105dd 100644
  #if DEBUG_TRACE
  				case 'v':
  					debug_trace++;
-@@ -477,6 +484,9 @@ void svr_getopts(int argc, char ** argv) {
+@@ -463,6 +470,9 @@ void svr_getopts(int argc, char ** argv) {
  		svr_opts.pubkey_plugin_options = args;
  	}
  #endif
 +	if (authorized_keys_file) {
-+ 		svr_opts.authorized_keys_file = m_strdup(authorized_keys_file);
++		svr_opts.authorized_keys_file = m_strdup(authorized_keys_file);
 +	}
  }
  
  static void addportandaddress(const char* spec) {
+-- 
+2.47.0
+

--- a/bazel/dependencies/dropbear/0003-ignore-user-s-shell.patch
+++ b/bazel/dependencies/dropbear/0003-ignore-user-s-shell.patch
@@ -1,0 +1,70 @@
+From 5f1f84301d82f08b7cd7b280422aebb4586df4da Mon Sep 17 00:00:00 2001
+From: Greg Inozemtsev <greg@enfabrica.net>
+Date: Thu, 14 Nov 2024 18:12:10 +0000
+Subject: [PATCH 3/3] ignore user's shell
+
+---
+ src/runopts.h     | 1 +
+ src/svr-auth.c    | 3 +++
+ src/svr-runopts.c | 5 +++++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/src/runopts.h b/src/runopts.h
+index 317d540..f128682 100644
+--- a/src/runopts.h
++++ b/src/runopts.h
+@@ -95,6 +95,7 @@ typedef struct svr_runopts {
+ 	int domotd;
+ #endif
+ 	int norootlogin;
++	int ignoreshell;
+ 
+ #ifdef HAVE_GETGROUPLIST
+ 	/* restrict_group is the group name if group restriction was enabled,
+diff --git a/src/svr-auth.c b/src/svr-auth.c
+index 3f91f9c..ba83f38 100644
+--- a/src/svr-auth.c
++++ b/src/svr-auth.c
+@@ -246,6 +246,9 @@ static int checkusername(const char *username, unsigned int userlen) {
+ 	if (ses.authstate.username == NULL) {
+ 		/* first request */
+ 		fill_passwd(username);
++		if (svr_opts.ignoreshell) {
++			ses.authstate.pw_shell[0] = '\0';
++		}
+ 		ses.authstate.username = m_strdup(username);
+ 	} else {
+ 		/* check username hasn't changed */
+diff --git a/src/svr-runopts.c b/src/svr-runopts.c
+index 2540e8f..6e17084 100644
+--- a/src/svr-runopts.c
++++ b/src/svr-runopts.c
+@@ -100,6 +100,7 @@ static void printhelp(const char * progname) {
+ 					"		(default port is %s if none specified)\n"
+ 					"-P PidFile	Create pid file PidFile\n"
+ 					"		(default %s)\n"
++					"-S        	Ignore user's shell and use /bin/sh\n"
+ #ifdef SO_BINDTODEVICE
+ 					"-l <interface>\n"
+ 					"		interface to bind on\n"
+@@ -163,6 +164,7 @@ void svr_getopts(int argc, char ** argv) {
+ 	svr_opts.forced_command = NULL;
+ 	svr_opts.forkbg = 1;
+ 	svr_opts.norootlogin = 0;
++	svr_opts.ignoreshell = 0;
+ #ifdef HAVE_GETGROUPLIST
+ 	svr_opts.restrict_group = NULL;
+ 	svr_opts.restrict_group_gid = 0;
+@@ -276,6 +278,9 @@ void svr_getopts(int argc, char ** argv) {
+ 				case 'P':
+ 					next = &svr_opts.pidfile;
+ 					break;
++				case 'S':
++					svr_opts.ignoreshell = 1;
++					break;
+ #ifdef SO_BINDTODEVICE
+ 				case 'l':
+ 					next = &svr_opts.interface;
+-- 
+2.47.0
+

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -327,6 +327,7 @@ filegroup(
         patches = [
             "@enkit//bazel/dependencies/dropbear:0001-allow-blank-password.patch",
             "@enkit//bazel/dependencies/dropbear:0002-override-authorized-keys.patch",
+            "@enkit//bazel/dependencies/dropbear:0003-ignore-user-s-shell.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -321,13 +321,14 @@ filegroup(
         name = "dropbear",
         repo_rule = http_archive,
         build_file = "@enkit//bazel/dependencies:dropbear.BUILD.bazel",
-        sha256 = "e02c5c36eb53bfcd3f417c6e40703a50ec790a1a772269ea156a2ccef14998d2",
-        urls = ["https://github.com/mkj/dropbear/archive/refs/tags/DROPBEAR_2022.83.tar.gz"],
-        strip_prefix = "dropbear-DROPBEAR_2022.83",
+        sha256 = "d16285f0233a2400a84affa0235e34a71c660908079c639fdef889c2e90c9f5f",
+        urls = ["https://github.com/mkj/dropbear/archive/refs/tags/DROPBEAR_2024.86.tar.gz"],
+        strip_prefix = "dropbear-DROPBEAR_2024.86",
         patches = [
-            "@enkit//bazel/dependencies/dropbear:0000-allow-blank-password.patch",
-            "@enkit//bazel/dependencies/dropbear:0001-override-authorized-keys.patch",
+            "@enkit//bazel/dependencies/dropbear:0001-allow-blank-password.patch",
+            "@enkit//bazel/dependencies/dropbear:0002-override-authorized-keys.patch",
         ],
+        patch_args = ["-p1"],
     )
 
     maybe(


### PR DESCRIPTION
In the spirit of adding options to ignore passwords, etc also ignore the shell (useful in case it is set to `nologin`).

Update Dropbear while I'm looking at it anyway.