### PR TITLE
faketree: Fix exec_test failure outside dev container

### DIFF
--- a/faketree/exec/BUILD.bazel
+++ b/faketree/exec/BUILD.bazel
@@ -10,12 +10,17 @@ go_library(
 go_test(
     name = "exec_test",
     srcs = ["exec_test.go"],
+    data = ["//faketree"],
     embed = [":exec"],
     tags = [
         # Cloud Build cannot run privileged containers
         "no-cloudbuild",
     ],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
+    ],
 )
 
 alias(

--- a/faketree/exec/exec_test.go
+++ b/faketree/exec/exec_test.go
@@ -5,12 +5,20 @@ import (
 	"os"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {
 	ctx := context.Background()
-	faketreeBin = "/opt/enfabrica/bin/faketree"
+
+	faketreeRunfilesPath, err := runfiles.Rlocation("enkit/faketree/faketree_/faketree")
+	require.NoError(t, err)
+	defer func(oldPath string) {
+		faketreeBin = oldPath
+	}(faketreeBin)
+	faketreeBin = faketreeRunfilesPath
 
 	gotErr := Run(
 		ctx,
@@ -21,7 +29,7 @@ func TestRun(t *testing.T) {
 		os.Getenv("TEST_TMPDIR"),
 		[]string{"/bin/true"},
 	)
-	assert.Nilf(t, gotErr, "got error: %v; want no error", gotErr)
+	assert.NoError(t, gotErr)
 
 	gotErr = Run(
 		ctx,
@@ -32,5 +40,5 @@ func TestRun(t *testing.T) {
 		os.Getenv("TEST_TMPDIR"),
 		[]string{"/bin/false"},
 	)
-	assert.NotNil(t, gotErr)
+	assert.ErrorContains(t, gotErr, "exit status 1")
 }


### PR DESCRIPTION
Prior to this change, `exec_test` was testing the version of `faketree` baked into the dev container, rather than a version built from the current source. Not only is this surprising, it doesn't work outside the dev container.

This change adds the from-source `faketree` binary as a data dependency, so that the test can find it using the `runfiles` library and run it directly. Additionally, some of the usages of the `assert` library are cleaned up to make the test easier to read.

Tested: test passes outside dev container