### PR TITLE
bazel: Force `container_image` targets to be tagged as `manual`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # see https://docs.bazel.build/versions/master/guide.html#bazelrc
 #
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
-common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
+#common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
 build --cxxopt="-std=c++20"  --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS=-std=c++20
 
 build --workspace_status_command "/bin/bash bazel/workspace_status.sh"

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # see https://docs.bazel.build/versions/master/guide.html#bazelrc
 #
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
-#common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
+common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
 build --cxxopt="-std=c++20"  --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS=-std=c++20
 
 build --workspace_status_command "/bin/bash bazel/workspace_status.sh"


### PR DESCRIPTION
As per [this comment](https://github.com/enfabrica/enkit/pull/1138#pullrequestreview-2446816475), base images in private registries are going away soon. In the meantime, `bazel test //...` when the user cannot pull images from these registries causes build failures; while `--keep_going` can be used to get some test results, it can be hard to spot real build failures among the expected ones.

This change modifies the `container_image` and `container_push` macros to add the `manual` tag to all generated targets, so that they aren't built unless specified by their specific label on the command line. This should fix the `bazel build //...` case for external users, while still allowing container images to be built and pushed as normal (since container image pushes are typically done via `bazel run`, the full specific label must be used anyway; `bazel run //...` doesn't work, and therefore can't be broken by this change).

Tested: `bazel test //...` doesn't fail due to container image pull auth errors on my machine