### PR TITLE
debootstrap: Do not install recommended packages

### DIFF
--- a/bazel/utils/container/ubuntu_base.sh
+++ b/bazel/utils/container/ubuntu_base.sh
@@ -31,7 +31,7 @@ sudo debootstrap \
     $distro $tmp_root $mirror
 
 sudo chroot $tmp_root /usr/bin/apt-get update
-sudo chroot $tmp_root /usr/bin/apt-get install --yes $pkgs
+sudo chroot $tmp_root /usr/bin/apt-get install --yes --quiet --no-install-recommends $pkgs
 
 echo "Packaging bootstrap directory $tmp_root to $outfile"
 echo ""


### PR DESCRIPTION
Recommended packages are generally too heavy for containers.  We lost this flag when transitioning to the debootstrap build.