### PR TITLE
gee gcd: improve gcd to fail if target branch isn't specified

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5096,6 +5096,9 @@ function gee__gcd() {
     fi
   done
   TARGET="$1"
+  if [[ "${TARGET}" == "" ]]; then
+    _fatal "gcd: target branch argument not specified."
+  fi
   _set_main
 
   if ! _in_gee_branch; then


### PR DESCRIPTION
Previously:

    gee gcd -B upstream/master

would fail with an obscure error "git worktree" generated error message.

Now, it fails with a clear error indicating that the target branch name
argument was unspecified.

Tested: manually tested.


