### PR TITLE
gee whatsout: fix bug in pr branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1337,6 +1337,10 @@ function _read_cmd() {
       fi
     fi
     set -e
+    if [[ "${READ_CMD_ECHO}" == 1 ]]; then
+      local VAR_ITEMS="${VAR}[@]"
+      printf >&2 "%s\n" "${!VAR_ITEMS}"
+    fi
     return "${RC}"
   else
     local C
@@ -1818,21 +1822,14 @@ function _safer_rebase() {
   CHILD_DIR="$(_get_branch_rootdir "${CHILD}")"
   cd "${CHILD_DIR}"
   local PARENT_HEAD
-  if [[ "${PARENT}" == */* ]]; then
-    # make sure remote is up to date:
-    _git fetch "${PARENT%%/*}"
-    PARENT_HEAD="$(git ls-remote "${PARENT%%/*}" "${PARENT#upstream/}" | awk '{print $1}')"
-  else
-    PARENT_HEAD="$(git show-ref "refs/heads/${PARENT}" | awk '{print $1}')"
-  fi
+  _get_parent_head_commit PARENT_HEAD "${PARENT}"
 
-  # Use rebase for local parent branches, or pull for remote parent branches.
   local -a GITCMD=()
   GITCMD+=( rebase --autostash )
   if [[ -n "${ONTO}" ]]; then
     GITCMD+=(--onto "${ONTO}")
   fi
-  GITCMD+=( "${PARENT}" "${CHILD}" )
+  GITCMD+=( "${PARENT_HEAD}" "${CHILD}" )
 
   _checkout_or_die "${CHILD}"
   if ! _git "${GITCMD[@]}"; then
@@ -3284,6 +3281,30 @@ Usage: gee whatsout
 Reports which files in this branch differ from parent branch.
 EOT
 
+# _get_parent_head_commit <varname> <parent>
+#
+# Sets the value of indirect variable <varname> to the commit associated with
+# the <parent> reference specifier.
+function _get_parent_head_commit() {
+  local VARNAME="$1"; shift
+  local PARENT="$1"; shift
+  local _PARENT_HEAD
+  local -a OUTPUT=()
+  local -a WORDS=()
+  if [[ "${PARENT}" == */* ]]; then
+    # make sure remote is up to date:
+    _git fetch "${PARENT%%/*}"
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" ls-remote "${PARENT%%/*}" "${PARENT#upstream/}"
+    WORDS=( ${OUTPUT[0]} )
+    _PARENT_HEAD="${WORDS[0]}"
+  else
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" show-ref "refs/heads/${PARENT}"
+    WORDS=( ${OUTPUT[0]} )
+    _PARENT_HEAD="${WORDS[0]}"
+  fi
+  printf -v "${VARNAME}" '%s' "${_PARENT_HEAD}"
+}
+
 function gee__whatsout() {
   _startup_checks "whatsout"
 
@@ -3292,7 +3313,9 @@ function gee__whatsout() {
   BRANCH="$(_get_current_branch)"
   _read_parents_file
   PARENT="$(_get_parent_branch "${BRANCH}")"
-  _git diff --name-only "${PARENT}...${BRANCH}"
+  local PARENT_HEAD
+  _get_parent_head_commit PARENT_HEAD "${PARENT}"
+  _git diff --name-only "${PARENT_HEAD}..${BRANCH}"
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."
   fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -3295,11 +3295,11 @@ function _get_parent_head_commit() {
     # make sure remote is up to date:
     _git fetch "${PARENT%%/*}"
     READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" ls-remote "${PARENT%%/*}" "${PARENT#upstream/}"
-    WORDS=( ${OUTPUT[0]} )
+    read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   else
     READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" show-ref "refs/heads/${PARENT}"
-    WORDS=( ${OUTPUT[0]} )
+    read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   fi
   printf -v "${VARNAME}" '%s' "${_PARENT_HEAD}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -3315,7 +3315,7 @@ function gee__whatsout() {
   PARENT="$(_get_parent_branch "${BRANCH}")"
   local PARENT_HEAD
   _get_parent_head_commit PARENT_HEAD "${PARENT}"
-  _git diff --name-only "${PARENT_HEAD}..${BRANCH}"
+  _git diff --name-only "${PARENT_HEAD}...${BRANCH}"
   if _branch_has_unstaged_changes; then
     _info "Note: This branch contains uncommitted changes."
   fi


### PR DESCRIPTION
Previously, `gee whatsout` would fail in branches created with `gee pr_checkout`.

```
$ gee whatsout
CMD: /usr/bin/git diff --name-only upstream/refs/pull/49674/head...pr_49674
fatal: ambiguous argument 'upstream/refs/pull/49674/head...pr_49674': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
WARNING: Command /usr/bin/git diff --name-only upstream/refs/pull/49674/head...pr_49674 failed with exit code 128
```

This PR creates a more consistent mapping from refspecs onto commit ids, so that commands will work consistently
regardless of whether the parent branch is local or remote.

```
$ ~/gee/enkit/fix_whatsout/scripts/gee whatsout
CMD: /usr/bin/git fetch upstream
CMD: /usr/bin/git ls-remote upstream refs/pull/49674/head
eb836a20a4863fd9e6ea14482fc1b82dec41bde9        refs/pull/49674/head
CMD: /usr/bin/git diff --name-only eb836a20a4863fd9e6ea14482fc1b82dec41bde9..pr_49674
hw/projects/mlm/csr/he/gfc/BUILD.bazel
hw/projects/mlm/csr/he/gfc/he_gfc_dpl.yaml
hw/projects/mlm/design/chip/macro_gen/BUILD
hw/projects/mlm/design/chip/pmw.yaml
hw/projects/mlm/design/he/gfc/BUILD
hw/projects/mlm/design/he/gfc/he_gfc.sv
hw/projects/mlm/design/he/gfc/he_gfc_hash_table_mem.sv
hw/projects/mlm/design/he/gfc/lmw/BUILD
hw/projects/mlm/design/he/gfc/lmw/lmw_he_gfc_hash_table_bank.yaml
```

This PR also improves the `_read_cmd` function to optionally allow the user to see what the executed command
generated, for transparency.

Tested: manually tested as shown above.  Also validated that the modified `safer_rebase` functionality works as expected:

```
$ ~/gee/enkit/fix_whatsout/scripts/gee up
CMD: /usr/bin/git fetch origin
no pull requests found for branch "jonathan-enf:pr_49674"
CMD: /usr/bin/git fetch upstream
CMD: /usr/bin/git ls-remote upstream refs/pull/49674/head
eb836a20a4863fd9e6ea14482fc1b82dec41bde9        refs/pull/49674/head
CMD: /usr/bin/git rebase --autostash eb836a20a4863fd9e6ea14482fc1b82dec41bde9 pr_49674
Current branch pr_49674 is up to date.
To undo: git checkout pr_49674; git reset --hard pr_49674.REBASE_BACKUP
CMD: /usr/bin/git push --quiet -u origin +pr_49674
Done.
```


