### PR TITLE
gee bugfix: pulling new commits from origin

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ This directory contains:
 
 * [gee](gee.md): a git/gh wrapper than implements a specific workflow.
   (see also: gee's [changelog](gee.changelog.md)).
-* [bkup]: an rclone+gcp wrapper for quick and easy backup and restore.
+* [bkup](bkup): an rclone+gcp wrapper for quick and easy backup and restore.
 
 ## Regenerating the documentation
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -3294,7 +3294,7 @@ function _get_parent_head_commit() {
   if [[ "${PARENT}" == */* ]]; then
     # make sure remote is up to date:
     _git fetch "${PARENT%%/*}"
-    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" ls-remote "${PARENT%%/*}" "${PARENT#upstream/}"
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" ls-remote "${PARENT%%/*}" "${PARENT#*/}"
     read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   else


### PR DESCRIPTION
While using my unreleased test version of gee, I see that my previous change
introduced a new bug into gee.  When another user pushed a commit into my PR,
`gee up` did not properly pull this new commit from origin into my local
branch.

The fault turned out to be my implementation of `_get_parent_head_commit`,
where I had hardcoded the remote name "upstream" instead of parsing the remote
specification correctly. This is now fixed.

Tested: I used the web interface to add a documentation-only commit to this
branch in origin, and ran `gee up`.  I watched gee pull the commit from origin
as expected.


