### PR TITLE
gee pr_submit: fix rebasing of child branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3283,8 +3283,13 @@ EOT
 
 # _get_parent_head_commit <varname> <parent>
 #
-# Sets the value of indirect variable <varname> to the commit associated with
-# the <parent> reference specifier.
+# git sometimes makes it hard for some commands to refer to branches in
+# remote repos.  This function takes any refspec that looks like it
+# refers to a remote repo and turns that into a commit id.  Otherwise,
+# it leaves it alone.
+#
+# Sets the value of indirect variable <varname> to a commit, local branch, or
+# local tag name associated with the <parent> reference specification.
 function _get_parent_head_commit() {
   local VARNAME="$1"; shift
   local PARENT="$1"; shift
@@ -3298,7 +3303,10 @@ function _get_parent_head_commit() {
     read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   else
-    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" show-ref "refs/heads/${PARENT}"
+    # Note: git show-ref "refs/heads/${PARENTS}" is the conventional wisdom
+    # solution, which doesn't work for tags.  Instead, git rev-list works for
+    # both branches and tags.
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" rev-list -n 1 "${PARENT}"
     read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   fi


### PR DESCRIPTION
A recent change broke rebasing of child branches:

```
CMD: /usr/bin/gh pr merge --squash --body-file /tmp/pr.message.n9uRON.txt --repo enfabrica/internal jonathan-enf:release_api_a0_rust
✓ Squashed and merged pull request enfabrica/internal#49753 (API release: enabling rust rules)
...
CMD: _gee_get_all_children_of release_api_a0_rust
WARNING: The following branches contain the commits that were just
WARNING: squash-merged, and need to be rebased to avoid future
WARNING: merge conflicts: first_recipe_migration release_api_a0_random_csr_multigen
Rebase child branches now? (Y/n)

CMD: /usr/bin/git show-ref refs/heads/release_api_a0_rust-unsquashed
WARNING: Command returned non-zero exit code: 1
```

The problem is my good friend `_get_parent_head_commit` only worked for
branches, not tags, and `release_api_a0_rust-unsquashed` is a tag.  This
PR fixes that function to work for both branches and tags.

Tested:

Manual testing of the underlying git command shows it working for
branches and tags.

`gee rup` shows the new function correctly getting branch commits.

The next time I submit a PR, I'll be able to validate the "rebase child
branches" functionality.


