### PR TITLE
gee: improve prls, git-aware prompt

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3970,7 +3970,7 @@ function _new_pr_list() {
   TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
   TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
   TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
-  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|autocolor $color) (.author.login|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.author.login|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
   TEMPLATE+='{{end}}'
   gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
 }
@@ -3990,7 +3990,7 @@ function _new_pr_list_with_merging_info() {
   TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
   TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
   TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
-  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|autocolor $color) (.headRefName|autocolor $color) (.baseRefName|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.headRefName|autocolor $color) (.baseRefName|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
   TEMPLATE+='{{end}}'
   gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
 }

--- a/scripts/gee
+++ b/scripts/gee
@@ -3913,6 +3913,7 @@ _register_help "pr_list" \
   "lspr" "list_pr" "prls" <<'EOT'
 Usage: gee pr_list [--text] [<user>]
 
+
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
 
@@ -3922,9 +3923,6 @@ suitable for pasting into an email.
 Example:
 
     $ gee lspr jonathan-enf
-    PRs associated with this branch:
-    OPEN 1181 codegen tool
-
     Open PRs authored by jonathan-enf:
     #1205   REVIEW_REQUIRED Fix libsystemc build file error.
     #1181   REVIEW_REQUIRED codegen tool
@@ -3957,6 +3955,24 @@ An example of using the "--text" option:
       https://github.com/enfabrica/internal/pull/29625
 
 EOT
+function _new_pr_list() {
+  local SEARCH="$1"; shift
+  local JSON TEMPLATE
+  JSON="url,author,reviewDecision,title,state,createdAt,statusCheckRollup"
+  # golang templates are complex but useful:
+  TEMPLATE=''
+  TEMPLATE+='{{tablerow "URL" "Title" "Author" "Created" "Status" }}'
+  TEMPLATE+='{{tablerow "---" "-----" "------" "-------" "------" }}'
+  TEMPLATE+='{{range .}}'
+  TEMPLATE+='{{ $status := "" }}'
+  TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{end}}{{end}}'
+  TEMPLATE+='{{tablerow .url .title .author.login (timeago .createdAt) $status}}'
+  TEMPLATE+='{{end}}'
+  gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
+}
+
 function gee__lspr() { gee__pr_list "$@"; }
 function gee__list_pr() { gee__pr_list "$@"; }
 function gee__prls() { gee__pr_list "$@"; }
@@ -4034,53 +4050,13 @@ function gee__pr_list() {
     return
   fi
 
-  if _in_gee_branch; then
-    _info "PRs associated with this branch:"
-    _get_pull_requests
-    echo ""
-  fi
-
   _info "Open PRs authored by ${WHO_3RD_PERSON}:"
-  ( printf "PR\tbranch\treview\ttitle\n" ; \
-    printf "==\t======\t======\t=====\n" ; \
-   "${GH}" --repo "${UPSTREAM}/${REPO}" pr list \
-    -L "${PR_LIST_MAX_FETCH}" \
-    --author "${WHO}" \
-    --state open \
-    --json number,reviewDecision,headRefName,title \
-    --jq '.[] | "#\(.number)\t\(.headRefName)\t\(.reviewDecision)\t\(.title)"' \
-    ) | column -t -s $'\t'
+  _new_pr_list "author:@me"
   echo ""
 
   _info "PRs assigned to ${WHO_3RD_PERSON}:"
-  local -a JQSCRIPT=(
-    '.[]'
-    ' | "#\(.number)\t\(.author.login)\t\(.createdAt)\t\(.title)"'
-  )
-  ( printf "PR\tauthor\tcreated\ttitle\n" ; \
-    printf "==\t======\t=======\t=====\n" ; \
-   "${GH}" --repo "${UPSTREAM}/${REPO}" pr list \
-    -L "${PR_LIST_MAX_FETCH}" \
-    --assignee "@me" \
-    --json number,author,headRefName,createdAt,state,title,reviewDecision,reviewRequests \
-    --jq "${JQSCRIPT[*]}" \
-    ) | column -t -s $'\t'
+  _new_pr_list "assignee:@me"
   echo ""
-
-  _info "PRs pending ${YOUR} review:"
-  local -a JQSCRIPT=(
-    '.[]'
-    ' | select( .reviewDecision == "REVIEW_REQUIRED" )'
-    ' | select( .reviewRequests[]? | contains({"login":"'"${USER}"'"}))'
-    ' | "#\(.number)\t\(.author.login)\t\(.createdAt)\t\(.title)"'
-  )
-  ( printf "PR\tauthor\tcreated\ttitle\n" ; \
-    printf "==\t======\t=======\t=====\n" ; \
-   "${GH}" --repo "${UPSTREAM}/${REPO}" pr list \
-    -L "${PR_LIST_MAX_FETCH}" \
-    --json number,author,headRefName,createdAt,state,title,reviewDecision,reviewRequests \
-    --jq "${JQSCRIPT[*]}" \
-    ) | column -t -s $'\t'
 }
 
 ##########################################################################
@@ -6199,9 +6175,16 @@ function gee_prompt_update_git_info() {
     stash_depth=" S=${stash_depth}"
   fi
 
-  GEE_PROMPT_INFO="$(printf "(%s%s%s%s%s%s)" \
+  local assigned=""
+  local assigned_count
+  assigned_count="$(gh pr list --search "assignee:@me" 2>/dev/null | wc -l)"
+  if [[ "${assigned_count}" > 0 ]]; then
+    assigned=", ASSIGNED_PRs=${assigned_count}"
+  fi
+
+  GEE_PROMPT_INFO="$(printf "(%s%s%s%s%s%s%s)" \
     "${repo}" "${branch}" "${complete_mode}" \
-    "${changes}" "${cached}" "${stash_depth}")"
+    "${changes}" "${cached}" "${stash_depth}" "${assigned}" )"
 }
 
 function gee_prompt_git_info() {

--- a/scripts/gee
+++ b/scripts/gee
@@ -6177,7 +6177,7 @@ function gee_prompt_update_git_info() {
 
   local assigned=""
   local assigned_count
-  assigned_count="$(gh pr list --search "assignee:@me" 2>/dev/null | wc -l)"
+  assigned_count="$(gh pr list --search "assignee:@me" 2>/dev/null | grep -v "^no pull requests" | wc -l)"
   if [[ "${assigned_count}" > 0 ]]; then
     assigned=", ASSIGNED_PRs=${assigned_count}"
   fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.51"
+readonly VERSION="0.2.52"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee
+++ b/scripts/gee
@@ -3920,40 +3920,6 @@ no user is specified).
 The `--text` option provides an alternative formatting for a list of open PRs, more
 suitable for pasting into an email.
 
-Example:
-
-    $ gee lspr jonathan-enf
-    Open PRs authored by jonathan-enf:
-    #1205   REVIEW_REQUIRED Fix libsystemc build file error.
-    #1181   REVIEW_REQUIRED codegen tool
-    #1158   REVIEW_REQUIRED Added @gmp//:libgmpxx
-    #1148   REVIEW_REQUIRED Added gee to enkit.config.yaml.
-    #1136   REVIEW_REQUIRED Unified PtrQueue and Queue implementations.
-    #1130   REVIEW_REQUIRED Owners of /poc/{sim,models}
-    #1059   REVIEW_REQUIRED CSV file helper library
-
-    PRs pending their review:
-    #1200  taoliu0  2021-08-12T15:26:03Z  Added an example integrating SC
-
-An example of using the "--text" option:
-
-    $ /home/jonathan/gee/enkit/gee_lspr_format/scripts/gee lspr --text
-    * #29644: Lorem ipsum dolor sit amet
-      2023-12-30 APPROVED Checks passed.
-      https://github.com/enfabrica/internal/pull/29644
-
-    * #29641: consectetur adipiscing elit
-      2023-12-30 REVIEW_REQUIRED DRAFT Checks passed.
-      https://github.com/enfabrica/internal/pull/29641
-
-    * #29640: sed do eiusmod tempor incididunt
-      2023-12-30 APPROVED Checks passed.
-      https://github.com/enfabrica/internal/pull/29640
-
-    * #29625: ut labore et dolor magna aliqua
-      2023-12-29 REVIEW_REQUIRED Checks passed.
-      https://github.com/enfabrica/internal/pull/29625
-
 EOT
 function _new_pr_list() {
   local SEARCH="$1"; shift

--- a/scripts/gee
+++ b/scripts/gee
@@ -3964,12 +3964,19 @@ function _new_pr_list() {
   TEMPLATE+='{{tablerow "URL" "Title" "Author" "Created" "Status" }}'
   TEMPLATE+='{{tablerow "---" "-----" "------" "-------" "------" }}'
   TEMPLATE+='{{range .}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ $status := "" }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ $color := "reset" }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.author.login|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
   TEMPLATE+='{{end}}'
   gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
@@ -3981,15 +3988,23 @@ function _new_pr_list_with_merging_info() {
   JSON="number,url,author,reviewDecision,title,state,baseRefName,headRefName,createdAt,statusCheckRollup"
   # golang templates are complex but useful:
   TEMPLATE=''
+  # shellcheck disable=SC2016
   TEMPLATE+='{{tablerow "URL" "Title" "From Branch" "To" "Created" "Status" }}'
   TEMPLATE+='{{tablerow "---" "-----" "-----------" "--" "-------" "------" }}'
   TEMPLATE+='{{range .}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ $status := "" }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ $color := "reset" }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  # shellcheck disable=SC2016
   TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.headRefName|autocolor $color) (.baseRefName|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
   TEMPLATE+='{{end}}'
   gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"

--- a/scripts/gee
+++ b/scripts/gee
@@ -3958,17 +3958,39 @@ EOT
 function _new_pr_list() {
   local SEARCH="$1"; shift
   local JSON TEMPLATE
-  JSON="url,author,reviewDecision,title,state,createdAt,statusCheckRollup"
+  JSON="number,url,author,reviewDecision,title,state,baseRefName,headRefName,createdAt,statusCheckRollup"
   # golang templates are complex but useful:
   TEMPLATE=''
   TEMPLATE+='{{tablerow "URL" "Title" "Author" "Created" "Status" }}'
   TEMPLATE+='{{tablerow "---" "-----" "------" "-------" "------" }}'
   TEMPLATE+='{{range .}}'
   TEMPLATE+='{{ $status := "" }}'
+  TEMPLATE+='{{ $color := "reset" }}'
   TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
   TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
-  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{end}}{{end}}'
-  TEMPLATE+='{{tablerow .url .title .author.login (timeago .createdAt) $status}}'
+  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|autocolor $color) (.author.login|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
+  TEMPLATE+='{{end}}'
+  gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
+}
+
+function _new_pr_list_with_merging_info() {
+  local SEARCH="$1"; shift
+  local JSON TEMPLATE
+  JSON="number,url,author,reviewDecision,title,state,baseRefName,headRefName,createdAt,statusCheckRollup"
+  # golang templates are complex but useful:
+  TEMPLATE=''
+  TEMPLATE+='{{tablerow "URL" "Title" "From Branch" "To" "Created" "Status" }}'
+  TEMPLATE+='{{tablerow "---" "-----" "-----------" "--" "-------" "------" }}'
+  TEMPLATE+='{{range .}}'
+  TEMPLATE+='{{ $status := "" }}'
+  TEMPLATE+='{{ $color := "reset" }}'
+  TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|autocolor $color) (.headRefName|autocolor $color) (.baseRefName|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
   TEMPLATE+='{{end}}'
   gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
 }
@@ -4051,7 +4073,7 @@ function gee__pr_list() {
   fi
 
   _info "Open PRs authored by ${WHO_3RD_PERSON}:"
-  _new_pr_list "author:@me"
+  _new_pr_list_with_merging_info "author:@me"
   echo ""
 
   _info "PRs assigned to ${WHO_3RD_PERSON}:"

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,14 @@
 
 ## Releases
 
+### 0.2.52
+* `gee lspr`: Improve lspr output, improve bash prompt to report number of assigned PRs.  (#1148)
+* `gee pr_submit`: Fix automatic rebasing of child branches.  This broke in 0.2.51.  (#1147)
+* `gee up`: Fix bug introduced in 0.2.51: Correctly pulls new commits from origin.  (#1146)
+* `gee whatsout`: Fix bug if running in a branch created by `gee pr_checkout`.  (#1145)
+* `gee gcd`: Fail correctly if target branch isn't specified.  (#1144)
+* `gee vimdiff`: Now uses `git difftool` (#1125)
+
 ### 0.2.51
 * `gee pr_make`: Darn, fixed a typo that I missed before.  (#1118)
 * `gee codeowners`: Fix codeowners to work with non-standard base branches.  (#1116)

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.51
+gee version: 0.2.52
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -587,48 +587,12 @@ Aliases: lspr list_pr prls
 
 Usage: `gee pr_list [--text] [<user>]`
 
+
 Lists information about PRs associated with the specified user (or yourself, if
 no user is specified).
 
 The `--text` option provides an alternative formatting for a list of open PRs, more
 suitable for pasting into an email.
-
-Example:
-
-    $ gee lspr jonathan-enf
-    PRs associated with this branch:
-    OPEN 1181 codegen tool
-
-    Open PRs authored by jonathan-enf:
-    #1205   REVIEW_REQUIRED Fix libsystemc build file error.
-    #1181   REVIEW_REQUIRED codegen tool
-    #1158   REVIEW_REQUIRED Added @gmp//:libgmpxx
-    #1148   REVIEW_REQUIRED Added gee to enkit.config.yaml.
-    #1136   REVIEW_REQUIRED Unified PtrQueue and Queue implementations.
-    #1130   REVIEW_REQUIRED Owners of /poc/{sim,models}
-    #1059   REVIEW_REQUIRED CSV file helper library
-
-    PRs pending their review:
-    #1200  taoliu0  2021-08-12T15:26:03Z  Added an example integrating SC
-
-An example of using the "--text" option:
-
-    $ /home/jonathan/gee/enkit/gee_lspr_format/scripts/gee lspr --text
-    * #29644: Lorem ipsum dolor sit amet
-      2023-12-30 APPROVED Checks passed.
-      https://github.com/enfabrica/internal/pull/29644
-
-    * #29641: consectetur adipiscing elit
-      2023-12-30 REVIEW_REQUIRED DRAFT Checks passed.
-      https://github.com/enfabrica/internal/pull/29641
-
-    * #29640: sed do eiusmod tempor incididunt
-      2023-12-30 APPROVED Checks passed.
-      https://github.com/enfabrica/internal/pull/29640
-
-    * #29625: ut labore et dolor magna aliqua
-      2023-12-29 REVIEW_REQUIRED Checks passed.
-      https://github.com/enfabrica/internal/pull/29625
 
 ### pr_edit
 


### PR DESCRIPTION
Github Badger stopped working for me, and I can't seem to fix it, so I decided to replicate
that functionality in gee's git-aware bash prompt.

gee's prompt now adds an "ASSIGNED_PRs" count to the prompt if that count is non-zero.

```
(int:python_and_rust_migration S=84, ASSIGNED_PRs=6)[1518] ~/gee/internal/python_and_rust_migration
$
```

If the count is zero, the prompt remains uncluttered:

```
(enk:gee_assigned_prs S=2)[1152] ~/gee/enkit/gee_assigned_prs
$
```

While I was here, I also improved the way that "gee lspr" reports PRs.  In
particular, it now lists PRs using the full URL instead of just the PR number,
making the URL clickable in the standard terminal. Additionally, PRs that fail
presubmit checks are now annotated appropriately.

```
(int:python_and_rust_migration S=84, ASSIGNED_PRs=6)[1518] ~/gee/internal/python_and_rust_migration
$ /home/jonathan/gee/enkit/gee_assigned_prs/scripts/gee lspr
Open PRs authored by you:
URL                                               Title                                                                         From Branch                To         Created       Status
---                                               -----                                                                         -----------                --         -------       ------
https://github.com/enfabrica/internal/pull/50096  A0 migration: rewrite rust rules.                                             rust_migration             master     11 days ago   check failed
https://github.com/enfabrica/internal/pull/50094  A0 release: migrate all python dependencies.                                  python_and_rust_migration  master     11 days ago
https://github.com/enfabrica/internal/pull/50015  cowners: add more reporting                                                   cowners                    master     13 days ago
https://github.com/enfabrica/internal/pull/49928  A0 release: migrate the SystemVerilog RAL packages                            first_sv_migraiton         master     17 days ago
https://github.com/enfabrica/internal/pull/49784  rtl_release: release chip_top                                                 rtl_release                master     20 days ago
https://github.com/enfabrica/internal/pull/49750  MERGE master_b0 into master (a0)                                              master_with_b0_changes     master     21 days ago   check failed
https://github.com/enfabrica/internal/pull/49749  pkgdef/csr: add identifying comments to all templates                         template_names             master     21 days ago
https://github.com/enfabrica/internal/pull/49696  gdma: comment-only test change to master_b0-based branch.                     testing_b0                 master_b0  24 days ago   check failed
https://github.com/enfabrica/internal/pull/49571  merge all recent a0 changes into master_b0                                    master_b0_with_a0_changes  master_b0  28 days ago   check failed
https://github.com/enfabrica/internal/pull/49187  AscentLint test wrapper                                                       ascentlint1                master     1 month ago   check failed
https://github.com/enfabrica/internal/pull/48727  csr.py: For fields: make num_bits optional if type is specified.              external_type              master     1 month ago
https://github.com/enfabrica/internal/pull/48511  WIP: creating stitcher config files for the swc block.                        swc_pd0                    master     2 months ago
https://github.com/enfabrica/internal/pull/48266  license_env.sh                                                                envvars                    master     2 months ago
https://github.com/enfabrica/internal/pull/46816  An example release //api/test/...                                             release_api_test           master     3 months ago  check failed
https://github.com/enfabrica/internal/pull/46183  github_badger: update UI when PRs are unassigned                              github_badger              master     3 months ago
https://github.com/enfabrica/internal/pull/46083  DEFINES.md: starting to document all +define switches in our codebase.        defines                    master     3 months ago
https://github.com/enfabrica/internal/pull/45615  reformat BUILD files                                                          build_reformatting         master     4 months ago  check failed
https://github.com/enfabrica/internal/pull/45208  mlm_b0 GDMA: whitespace only change                                           long_lines                 master     4 months ago
https://github.com/enfabrica/internal/pull/45181  verilog_test: add support for rootseed                                        montes_seed_idea           master     4 months ago  check failed
https://github.com/enfabrica/internal/pull/45134  ib/util/tests: Add no-presubmit tags to broken tests                          test_times_out             master     4 months ago
https://github.com/enfabrica/internal/pull/45075  mrng_gen documentation, schema checks, a little cleanup                       mrnggen                    master     4 months ago  check failed
https://github.com/enfabrica/internal/pull/45073  testing specs preview                                                         specs_test                 master     4 months ago  check failed
https://github.com/enfabrica/internal/pull/43992  DV events generation: add elab tests                                          pr_433329_clone            master     5 months ago  APPROVED
https://github.com/enfabrica/internal/pull/43990  pkgdef: add support for tagging of structs                                    pkgdef_tags                master     5 months ago  check failed
https://github.com/enfabrica/internal/pull/43398  mcu_pcie_erp_top: insert apb4_flow_reg to break combinational i/o path        mcu_pcie_erp_top_flow_reg  master     5 months ago
https://github.com/enfabrica/internal/pull/42780  Demo: how to use assert_off to disable an immediate assertion in a function?  assertoff                  master     5 months ago
https://github.com/enfabrica/internal/pull/41672  MRNG: annotate mrng stops with associated counter collections                 mrng_to_collection_map     master     6 months ago
https://github.com/enfabrica/internal/pull/41121  mcu_aps_clus_wrap.sv: instrument with cover points                            mcu_cover_points           master     6 months ago  check failed
https://github.com/enfabrica/internal/pull/40854  he_pd0.chksyn: checking he_pd0 synthesis reports                              synth_check_he             master     6 months ago
https://github.com/enfabrica/internal/pull/40558  codegen: starting to export counter metadata to rust                          pkgdef_counters_rust       master     6 months ago

PRs assigned to you:
URL                                               Title                                               Author         Created      Status
---                                               -----                                               ------         -------      ------
https://github.com/enfabrica/internal/pull/50096  A0 migration: rewrite rust rules.                   jonathan-enf   11 days ago  check failed
https://github.com/enfabrica/internal/pull/50094  A0 release: migrate all python dependencies.        jonathan-enf   11 days ago
https://github.com/enfabrica/internal/pull/49928  A0 release: migrate the SystemVerilog RAL packages  jonathan-enf   17 days ago
https://github.com/enfabrica/internal/pull/49794  WORKSPACE: update enkit for commit 5fd1748          enfabrica-bot  20 days ago  check failed
https://github.com/enfabrica/internal/pull/49784  rtl_release: release chip_top                       jonathan-enf   20 days ago
https://github.com/enfabrica/internal/pull/49734  WORKSPACE: update enkit for commit 5ead31d          enfabrica-bot  22 days ago

```

Tested: manual testing as shown above.


