### PR TITLE
auth/server: introduce more verbose logging (... for counters).

### DIFF
--- a/auth/proto/auth.proto
+++ b/auth/proto/auth.proto
@@ -36,11 +36,47 @@ message HostCertificateResponse {
   bytes signedhostcert = 2; // The signed host certificate passed in the request.
 }
 
+// The Auth service provides tokens or host certificates to use for authentication.
+//
+// Tokens identify users (or agents in general) typically performing API calls or
+// accessing web based resources.
+//
+// Host certificates identify machines or API endpoints in general so users/agents
+// can be certain of the identity of the endpoint.
+//
+// For a token to be issued to a CLI tool:
+// 1. Invoke the Authenticate() method. This will return an URL for the
+//    user to visit with his own browser.
+// 2. Invoke the Token() method, repeatedly, with a pause in between attempts
+//    and a timeout. Once the user completes the browser based authentication,
+//    the Token() method will succeed and return a token.
+//
+// This works as visiting the URL returned by Authenticate() with a browser
+// kicks off some sort of web based authentication (oauth, saml, or ... - the auth
+// server gRPC endpoint is really agnostic to it), and at the end of the process,
+// out of band, the web server responsible for the authentication will confirm
+// the identity of the user to the auth server which will then issue a token.
+//
+// In the current (Jan/25) simple auth server implementation, the web server
+// performing the authentication is in the same binary as the gRPC auth
+// endpoint. The out of band step to confirm the identity of the user is
+// performed by invoking the `FeedToken` method.
+//
+// This simple implementation also mandates that the CLI tool and web based
+// authentication must be served by the same backend. Which means there's
+// either a single backend, or the load balancer is capable of guaranteeing
+// that a given IP is always sent to the same backend, or there's some other
+// form of "session stickyness".
+//
+// The HostCertificate issuing mechanism implementation is currently incomplete.
+// A certificate is always returned, with no real checking mechanism.
+// TODO: complete the HostCertificate implementation.
 service Auth {
   // Use to retrieve the url to visit to create an authentication token.
   rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse) {}
   // Use to retrieve an authentication token.
   rpc Token(TokenRequest) returns (TokenResponse) {}
+
   // Used to retrieve an SSH certificate for a host.
   rpc HostCertificate(HostCertificateRequest) returns (HostCertificateResponse) {}
 }

--- a/auth/server/auth/auth.go
+++ b/auth/server/auth/auth.go
@@ -64,7 +64,7 @@ type Jar struct {
 	cancel  context.CancelFunc
 }
 
-func (s *Server) GetChannel(cancel context.CancelFunc, pub common.Key) chan oauth.AuthData {
+func (s *Server) getChannel(cancel context.CancelFunc, pub common.Key) chan oauth.AuthData {
 	s.jarlock.Lock()
 	defer s.jarlock.Unlock()
 
@@ -103,7 +103,7 @@ func (s *Server) Authenticate(ctx context.Context, req *apb.AuthenticateRequest)
 }
 
 func (s *Server) FeedToken(key common.Key, cookie oauth.AuthData) {
-	channel := s.GetChannel(nil, key)
+	channel := s.getChannel(nil, key)
 	channel <- cookie
 }
 
@@ -113,7 +113,7 @@ func (s *Server) Token(ctx context.Context, req *apb.TokenRequest) (*apb.TokenRe
 		return nil, err
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	channel := s.GetChannel(cancel, *clientPub)
+	channel := s.getChannel(cancel, *clientPub)
 	select {
 	case <-ctx.Done():
 		return nil, status.Errorf(codes.Canceled, "context canceled while waiting for authentication")

--- a/auth/server/auth/auth.go
+++ b/auth/server/auth/auth.go
@@ -21,6 +21,14 @@ import (
 	"time"
 )
 
+// Implements the Auth service defined in auth/proto/auth.proto file.
+//
+// Use the New() method to instantiate it. Invoke `Authenticate` to start
+// the authentication process, and `Token` to retrieve the generated token
+// at the end of it - which will not complete until `FeedToken` is
+// asynchronously invoked to confirm the identity of the user.
+//
+// See the definition of the protocol in the auth.proto file for more details.
 type Server struct {
 	rng                   *rand.Rand
 	serverPub, serverPriv *common.Key

--- a/auth/server/auth/auth_test.go
+++ b/auth/server/auth/auth_test.go
@@ -85,6 +85,29 @@ func TestBasicAuth(t *testing.T) {
 	assert.Equal(t, 0, len(tresp.Capublickey), "%v", tresp.Capublickey)
 }
 
+func TestLogging(t *testing.T) {
+	rng := rand.New(srand.Source)
+	log := logger.NewAccumulator()
+
+	server, err := New(rng, WithAuthURL("static-prefix"), WithLogger(log))
+	assert.Nil(t, err, err)
+	assert.NotNil(t, server)
+
+	Authenticate(t, rng, server, nil)
+
+	events := log.Retrieve()
+
+	expected := []string{
+		`authenticate - id ........ user emma.goldman@writers.org - started`,
+		`token feed - id ........ user emma.goldman@writers.org groups \[\]`,
+		`token request - id ........`,
+		`token issued - id ........ user emma.goldman@writers.org groups \[\]`,
+	}
+	for ix, match := range expected {
+		assert.Regexp(t, match, events[ix].Message)
+	}
+}
+
 // Just in case your security scanner goes crazy on this:
 // This is a test key, it is actually not used anywehere, at all.
 // Yes, it has no passphrase.

--- a/auth/server/auth/factory.go
+++ b/auth/server/auth/factory.go
@@ -165,6 +165,7 @@ func New(rng *rand.Rand, mods ...Modifier) (*Server, error) {
 		useGroups:  true,
 		jars:       map[common.Key]*Jar{},
 		limit:      30 * time.Minute,
+		log:        &logger.NilLogger{},
 	}
 
 	for _, m := range mods {

--- a/auth/server/auth/factory.go
+++ b/auth/server/auth/factory.go
@@ -21,7 +21,7 @@ type Flags struct {
 	TimeLimit         time.Duration
 	AuthURL           string
 	Principals        string
-	UseGroups	  bool
+	UseGroups         bool
 	CA                []byte
 	UserCertTimeLimit time.Duration
 }


### PR DESCRIPTION
Look at the individual commits, especially at the last one.

Tl;Dr: once the PR is merged, the auth server will start logging authentication
related events in a format suitable to define log based metrics on gcp and
app engine.

This is in preparation for the next PR, that will improve the logic in auth.go
to make it more resilient to misbehaving clients/applications, and less susceptible
to connection exhaustion by avoiding long lasting connections.

- astore, auth: consistently propagate and use logger.
- auth/server/auth/factory.go: run of go fmt.
- auth/server/auth/auth.go: make GetChannel private.
- auth: add minimal documentation on auth.proto and server/auth/auth.go.
- auth/server: start logging authentication requests and events.
