### PR TITLE
auth/client and server: adjust timeout handling.

### DIFF
--- a/auth/server/auth/auth_test.go
+++ b/auth/server/auth/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -106,6 +107,122 @@ func TestLogging(t *testing.T) {
 	for ix, match := range expected {
 		assert.Regexp(t, match, events[ix].Message)
 	}
+}
+
+// Verifies incorrect behavior: user browser authenticating multiple times,
+// CLI client repeteadly trying for the same token, etc.
+func TestContrivedFuzzy(t *testing.T) {
+	rng := rand.New(srand.Source)
+	log := logger.Go // Provides visual hints that the fuzzing is working.
+
+	server, err := New(rng, WithAuthURL("static-prefix"), WithLogger(log))
+	assert.Nil(t, err, err)
+	assert.NotNil(t, server)
+
+	pub, priv, err := box.GenerateKey(rng)
+	assert.Nil(t, err, err)
+
+	areq := &apb.AuthenticateRequest{
+		Key:    (*pub)[:],
+		User:   "emma.goldman",
+		Domain: "writers.org",
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	lock := sync.RWMutex{}
+	lock.Lock()
+
+	var url string          // Protected by lock.
+	var key *common.Key     // Protected by lock.
+	var servPub *common.Key // Protected by lock.
+
+	const violence = "The most violent element in society is ignorance."
+	const kIterations = 1000
+	const kMinSleep = 0
+	const kMaxSleep = 1000
+
+	sleep := func() {
+		time.Sleep(time.Duration(rng.Intn(kMaxSleep-kMinSleep)+kMinSleep) * time.Microsecond)
+	}
+
+	go func() {
+		for ix := 0; ix < kIterations; ix++ {
+			aresp, err := server.Authenticate(context.Background(), areq)
+			assert.Nil(t, err, err)
+			assert.Equal(t, 32, len(aresp.Key), "%d", len(aresp.Key))
+			assert.True(t, strings.HasPrefix(aresp.Url, "static-prefix"), aresp.Url)
+
+			if ix != 0 {
+				lock.Lock()
+			}
+
+			url = aresp.Url
+			key, err = common.KeyFromURL(aresp.Url)
+			assert.Nil(t, err, err)
+			assert.NotNil(t, key)
+
+			servPub, err = common.KeyFromSlice(aresp.Key)
+			assert.Nil(t, err, err)
+			lock.Unlock()
+
+			sleep()
+		}
+
+		wg.Done()
+	}()
+
+	go func() {
+		for ix := 0; ix < kIterations; ix++ {
+			oa := oauth.AuthData{Creds: &oauth.CredentialsCookie{Identity: oauth.Identity{
+				Id:           "emma.goldman@writers.org",
+				Username:     "emma.goldman",
+				Organization: "writers.org",
+			}}, Cookie: violence}
+
+			lock.RLock()
+			lkey := *key
+			lock.RUnlock()
+
+			server.FeedToken(lkey, oa)
+			sleep()
+		}
+
+		wg.Done()
+	}()
+
+	go func() {
+		for ix := 0; ix < kIterations; ix++ {
+			lock.RLock()
+			treq := &apb.TokenRequest{
+				Url: url,
+			}
+			lpub := servPub.ToByte()
+			lock.RUnlock()
+
+			tresp, err := server.Token(context.Background(), treq)
+			assert.Nil(t, err, err)
+			assert.NotNil(t, tresp)
+
+			if tresp != nil {
+				assert.Equal(t, 65, len(tresp.Token), "%v", tresp.Token)
+				assert.Equal(t, 24, len(tresp.Nonce), "%v", tresp.Nonce)
+
+				nonce, err := common.NonceFromSlice(tresp.Nonce)
+				assert.Nil(t, err, err)
+
+				decrypted, ok := box.Open(nil, tresp.Token, nonce.ToByte(), lpub, priv)
+				assert.True(t, ok)
+				assert.Equal(t, violence, string(decrypted), "%v - %v", decrypted, string(decrypted))
+			}
+			sleep()
+		}
+
+		wg.Done()
+	}()
+
+	wg.Wait()
 }
 
 // Just in case your security scanner goes crazy on this:

--- a/auth/server/auth/factory.go
+++ b/auth/server/auth/factory.go
@@ -28,7 +28,7 @@ type Flags struct {
 
 func DefaultFlags() *Flags {
 	return &Flags{
-		TimeLimit: time.Minute * 30,
+		TimeLimit: time.Minute * 6,
 		UseGroups: true,
 	}
 }
@@ -164,7 +164,12 @@ func New(rng *rand.Rand, mods ...Modifier) (*Server, error) {
 		serverPriv: (*common.Key)(priv),
 		useGroups:  true,
 		jars:       map[common.Key]*Jar{},
-		limit:      30 * time.Minute,
+		// Pre-2025 clients by default try at most 5 times, with 10 seconds between attempts.
+		//      6 minutes * 5 = 30 minutes to complete login.
+		// Post-2025 clients by default try at most 1800 times, with 1 second between attempts.
+		//      Once rolled out, we can lower this time to a few seconds, and still allow the user
+		//      1800 * 1 seconds = ~30 minutes to complete login
+		limit:      6 * time.Minute,
 		log:        &logger.NilLogger{},
 	}
 


### PR DESCRIPTION
Currently, the auth server and client relies on long lived connections
(up to 30 minutes per connection).

With the default appengine connection limit of max_concurrent_requests of 10,
this means if 10 users do enkit login and walk away from the connection, the
server is hosed for ~30 minutes.

Although this limit was increased to the max a while back in our deployment,
let's start rolling out changes so we can start using short lived connections
instead (deployment requires users moving to a new client, which will take time).

Additionally, we move the client side timeout and retry handling to be
configurable with our default flag infrastructure, which will allow us
to tune those values via flag push on astore server without asking users for an
upgrade in the future.

See individual commits for the specific changes.

- lib/clients/command: run go fmt
- lib/clients/command/login.go: read retry parameters from flags.
- auth/server (and client): change default retry and sleep parameters.
