### PR TITLE
bazel: Patch rules_go to allow embedding generated files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 # see https://docs.bazel.build/versions/master/guide.html#bazelrc
 #
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
-common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
+#common --repo_env=CC=gcc-10 --repo_env=CPP=g++-10 --repo_env=CXX=g++-10
 build --cxxopt="-std=c++20"  --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS=-std=c++20
 
 build --workspace_status_command "/bin/bash bazel/workspace_status.sh"

--- a/bazel/dependencies/io_bazel_rules_go/embedsrcs_generated_files.patch
+++ b/bazel/dependencies/io_bazel_rules_go/embedsrcs_generated_files.patch
@@ -1,0 +1,33 @@
+diff --git go/private/actions/compilepkg.bzl go/private/actions/compilepkg.bzl
+index fff807fa..efb0d051 100644
+--- go/private/actions/compilepkg.bzl
++++ go/private/actions/compilepkg.bzl
+@@ -36,6 +36,10 @@ def _embedlookupdir_arg(src):
+         root_relative = root_relative[len("/"):]
+     return root_relative
+ 
++def _embedlookupdir_root(src):
++    if src.root.path:
++        return src.root.path
++
+ def emit_compilepkg(
+         go,
+         sources = None,
+@@ -87,6 +91,17 @@ def emit_compilepkg(
+         uniquify = True,
+         expand_directories = False,
+     )
++
++    # HACK: Add (deduplicated) root dir as an embed lookup dir, so that
++    # //go:embed directives can use workspace-relative paths to embed generated
++    # files
++    args.add_all(
++        sources + [out_lib],
++        map_each = _embedlookupdir_root,
++        before_each = "-embedlookupdir",
++        uniquify = True,
++        expand_directories = False,
++    )
+     if cover and go.coverdata:
+         inputs.append(go.coverdata.data.export_file)
+         args.add("-arc", _archive(go.coverdata))

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -36,7 +36,10 @@ def stage_1():
     maybe(
         name = "io_bazel_rules_go",
         repo_rule = http_archive,
-        patches = ["@enkit//bazel/dependencies/io_bazel_rules_go:tags_manual.patch"],
+        patches = [
+            "@enkit//bazel/dependencies/io_bazel_rules_go:tags_manual.patch",
+            "@enkit//bazel/dependencies/io_bazel_rules_go:embedsrcs_generated_files.patch",
+        ],
         sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
@@ -132,13 +135,14 @@ def stage_1():
     maybe(
         name = "com_google_absl",
         repo_rule = http_archive,
-        sha256 = "7c11539617af1f332f0854a6fb21e296a1b29c27d03f23c7b49d4adefcd102cc",
-        strip_prefix = "abseil-cpp-20230802.2",
+        sha256 = "51d676b6846440210da48899e4df618a357e6e44ecde7106f1e44ea16ae8adc7",
+        strip_prefix = "abseil-cpp-20230125.3",
         patch_args = ["-p1"],
         patches = [
-            "@enkit//bazel/dependencies/abseil:0001-remove-maes-and-msse4.1-option-from-cross-compilation.patch",
+            "@enkit//bazel/dependencies/abseil:0001-absl-flags-parse.cc-provide-a-mechanism-to-let-other.patch",
+            "@enkit//bazel/dependencies/abseil:0002-remove-maes-and-msse4.1-option-from-cross-compilation.patch",
         ],
-        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.2.tar.gz"],
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.zip"],
     )
 
     maybe(
@@ -305,7 +309,7 @@ filegroup(
         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         strip_prefix = "zlib-1.2.11",
         # Original file: https://zlib.net/fossils/zlib-1.2.11.tar.gz
-        urls = ["https://astore.corp.enfabrica.net/d/mirror/zlib/zlib-1.2.11.tar.gz?u=giqzp6y6me76syf7jrgwtevqxgdhswdu"]
+        urls = ["https://astore.corp.enfabrica.net/d/mirror/zlib/zlib-1.2.11.tar.gz?u=giqzp6y6me76syf7jrgwtevqxgdhswdu"],
     )
 
     maybe(


### PR DESCRIPTION
This change adds a patch to `rules_go` that will be necessary for using the `embedsrcs` attribute of `go_library` rules to embed generated files; this in turn is necessary to remove uses of `go_embed_data` rules in favor of `embedsrcs`.

The current `rules_go` version has a `go_embed_data` rule that is used to embed files (source files or generated files) into a Go library/binary. This is used by enkit to embed static web assets, as well as some generated assets (e.g. machinist client embeds a built shared library, that it copies to the host system when provisioning).

The `go_embed_data` rule is deprecated in favor of native Go embedding. Outside of bazel, this is controlled by `//go:embed` directives in the source files (see [embed package docs](https://pkg.go.dev/embed) for more info). This rule is removed in future versions of rules_go, so use of the rule in enkit is preventing rules_go upgrades (which in turn blocks a migration to bzlmod and later versions of bazel).

The `embedsrcs` attribute does work for embedding static files, and gazelle will even generate BUILD files correctly based on `//go:embed` directives in the source for static files.

For generated files, there are two problems:
1. gazelle will not generate the necessary `embedsrcs` attribute values
1. even if targets are added to `embedsrcs` for generated files, the logic in rules_go won't allow the files to be found and used during the build.

This change fixes the second problem listed above by adding effectively `bazel-bin` as an extra `-embedlookupdir` arg to the `rules_go` builder,
 which will allow generated files to be referenced by `//go:embed`
 directives by their full repo-relative path.

 This should be a relatively safe patch to make; adding extra lookup
 directories can only have a few possible negative effects:

 1. increased build time/resources due to path combinatorial explosion (unlikely given the current usage pattern)
 1. picking up the wrong file due to ambiguity (e.g. conflict between source and generated files with the same name/path) which is also currently unlikely

Tested: Allows portions of future PRs to build (TODO: list PRs here after they are put up)