### PR TITLE
Update import path of the kunit_parser

### DIFF
--- a/bazel/linux/kunit/kunit_json.py
+++ b/bazel/linux/kunit/kunit_json.py
@@ -9,9 +9,7 @@
 import json
 import os
 
-import kunit_parser
-
-from bazel.linux.kunit.kunit_parser import TestStatus
+import bazel.linux.kunit.kunit_parser
 
 def get_json_result(test_result, def_config, build_dir, json_path) -> str:
 	sub_groups = []
@@ -34,9 +32,9 @@ def get_json_result(test_result, def_config, build_dir, json_path) -> str:
 		#  failure message, see https://api.kernelci.org/schema-test-case.html#get
 		for case in test_suite.cases:
 			test_case = {"name": case.name, "status": "FAIL"}
-			if case.status == TestStatus.SUCCESS:
+			if case.status == kunit_parser.TestStatus.SUCCESS:
 				test_case["status"] = "PASS"
-			elif case.status == TestStatus.TEST_CRASHED:
+			elif case.status == kunit_parser.TestStatus.TEST_CRASHED:
 				test_case["status"] = "ERROR"
 			test_cases.append(test_case)
 		sub_group["test_cases"] = test_cases


### PR DESCRIPTION
This change updates the import path to the kunit_parser as a result of the python 3.12 upgrade.

Tested:
- `bazel test //...`
- `bazel build //...`


JIRA: ENGPROD-987