### PR TITLE
Update protobuf version

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -39,8 +39,8 @@ def stage_1():
     maybe(
         name = "com_google_protobuf",
         repo_rule = http_archive,
-        strip_prefix = "protobuf-27.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v27.0.tar.gz"],
+        strip_prefix = "protobuf-29.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v29.0.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
This change updates the protobuf version so that test targets under the systest and ib directory can run without crashing. This is required for https://github.com/enfabrica/internal/pull/51203

Tested:
- `bazel test --override_repository=enkit=$HOME/enkit //systest/... //ib/... --test_tag_filters=-broken,-no-presubmit,-flaky`

JIRA: ENGPROD-987