### PR TITLE
gee pick: improve docs, handle empty commits

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -5920,10 +5920,17 @@ function gee__restore_all_branches() {
 
 _register_help "pick" "Cherry-pick in commits from another branch." "cherrypick" \
 <<'EOT'
-Usage: pick <commit>...<commit>
+Usage: pick <commit>...
 
 The gee wrapper around the git `cherry-pick` command that adds extra
 book-keeping in the `metadata` directory.
+
+The arguments to the pick command are supplied to `git rev-list --reverse` to
+produce a list of commits to integrate.  See `git help rev-list` for proper
+usage, but here are some examples of simple use cases:
+
+* `ABCD1234^..ABCD1234`: specify a single commit
+* `ABCD1234..master_b0`: specify all commits in master_b0 after ABCD1234.
 
 EOT
 
@@ -5954,6 +5961,10 @@ function gee__pick() {
   local -a COMMITS=()
   readarray -t COMMITS < <(_git rev-list --reverse "$@")
   echo "Picking: ${COMMITS[*]}"
+  if ! _confirm_default_yes "Do you want to proceed? (Y/n)  "; then
+    _info "Canceled."
+    exit 1
+  fi
   (
     printf "\n"
     printf "# Cherry-picking %s\n" "$*"

--- a/scripts/gee
+++ b/scripts/gee
@@ -5988,11 +5988,14 @@ function gee__pick() {
       fi
       _warn "Cherry-pick operation had merge conflicts, entering subshell."
       # TODO(jonathan): adapt _interactive_conflict_resolution for this.
-      _git status
       _git mergetool
       local -a STATUS=()
-      mapfile -t STATUS < <( _git status );
-      _git cherry-pick --continue # This should complete, we're just doing one commit at a time.
+      mapfile -t STATUS < <( _git status -s );
+      if [[ -z "${STATUS[*]}" ]]; then
+        _git commit --allow-empty  # This should complete the cherry-pick operation.
+      else
+        _git cherry-pick --continue # This should complete, we're just doing one commit at a time.
+      fi
       if _is_cherry_pick_in_progress; then
         echo "# FAILED: ${DESC}" >> "${METADATA_FILE}"
         _fatal "cherry-pick ${COMMIT} operation did not succeed, aborting."

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -886,10 +886,17 @@ sure to invoke `gee set_parent` in branches that benefit from this.
 
 Aliases: cherrypick
 
-Usage: `pick <commit>...<commit>`
+Usage: `pick <commit>...`
 
 The gee wrapper around the git `cherry-pick` command that adds extra
 book-keeping in the `metadata` directory.
+
+The arguments to the pick command are supplied to `git rev-list --reverse` to
+produce a list of commits to integrate.  See `git help rev-list` for proper
+usage, but here are some examples of simple use cases:
+
+* `ABCD1234^..ABCD1234`: specify a single commit
+* `ABCD1234..master_b0`: specify all commits in master_b0 after ABCD1234.
 
 ### recover_stashes
 


### PR DESCRIPTION
Some cherry-picked commits turn into empty commits when merged, if the same
change was made separately to the local branch.  This causes `git mergetool` to
exit instantly, but the subsequent `git cherry-pick --continue` operation to
fail.  This version of gee detects and handles that condition.

Also, improved documentation.

Tested: manually tested.


