### PR TITLE
Attribute generator_location had full path in it

### DIFF
--- a/lib/bazel/target.go
+++ b/lib/bazel/target.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"io"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -102,7 +103,13 @@ func shallowHash(w *Workspace, t *bpb.Target) (uint32, error) {
 		// order
 		sort.Slice(attrList, func(i, j int) bool { return attrList[i].GetName() < attrList[j].GetName() })
 		for _, attr := range attrList {
-			fmt.Fprintf(h, "%s=%s", attr.GetName(), attrValue(attr))
+			if attr.GetName() != "generator_location" {
+				fmt.Fprintf(h, "%s=%s", attr.GetName(), attrValue(attr))
+			} else {
+				// Ignore the path prefix of the generator location.
+				re := regexp.MustCompile(`^.*/`)
+				fmt.Fprintf(h, "%s=%s", attr.GetName(), re.ReplaceAllString(attrValue(attr), ""))
+			}
 		}
 	case bpb.Target_SOURCE_FILE:
 		lbl, err := labelFromString(t.GetSourceFile().GetName())

--- a/lib/bazel/target.go
+++ b/lib/bazel/target.go
@@ -13,7 +13,10 @@ import (
 	bpb "github.com/enfabrica/enkit/lib/bazel/proto"
 )
 
-var pseudoTargetAttributeName = "workspace_download_checksums"
+var (
+	pseudoTargetAttributeName = "workspace_download_checksums"
+	reIgnoreFilePath          = regexp.MustCompile(`^.*/`)
+)
 
 // Target wraps a build.proto Target message with some lazily computed
 // properties.
@@ -107,8 +110,7 @@ func shallowHash(w *Workspace, t *bpb.Target) (uint32, error) {
 				fmt.Fprintf(h, "%s=%s", attr.GetName(), attrValue(attr))
 			} else {
 				// Ignore the path prefix of the generator location.
-				re := regexp.MustCompile(`^.*/`)
-				fmt.Fprintf(h, "%s=%s", attr.GetName(), re.ReplaceAllString(attrValue(attr), ""))
+				fmt.Fprintf(h, "%s=%s", attr.GetName(), reIgnoreFilePath.ReplaceAllString(attrValue(attr), ""))
 			}
 		}
 	case bpb.Target_SOURCE_FILE:


### PR DESCRIPTION
For some rules, the attribute generator_location had the full path to the temporary worktree, thus having a different hash between the two worktrees.

We ignore the path for this case.

Jira: ENGPROD-1034

Tested: run on same commit returns zero results, run on small commit returns small number of results