### PR TITLE
gee: fix "gee init" bug, improve "mkbr" handling.

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2414,6 +2414,8 @@ function gee__init() {
   _git remote add upstream "${UPSTREAM_URL}"
   _git fetch upstream
   _git remote -v
+  _gh repo set-default "${UPSTREAM}/${REPO}"
+  _gh repo set-default --view
 
   # Fix the name of the main branch to match the actual branch name:
   local OLD_MAIN="${MAIN}"
@@ -2598,31 +2600,19 @@ function gee__make_branch() {
   _write_parents_file
 
   # If the user has created a branch whose name matches an
-  # existing branch in their existing repo, pull those changes
-  # into this branch.
+  # existing branch in their existing repo, reset this branch
+  # to match what is in origin.
   _git fetch origin
   if _remote_branch_exists origin "${BRNAME}"; then
+    _warn "Found existing \"origin/${BRNAME}\" branch: resetting local \"${BRNAME}\" to match."
     _checkout_or_die "${BRNAME}"
+    # always make our local branch the same as what's in origin.
+    _git reset --hard "origin/${BRNAME}"
     local -a COUNTS
-    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "HEAD...origin/${CURRENT_BRANCH}")
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "HEAD...${SHA}")
     if [[ "${COUNTS[1]}" -gt 0 ]]; then
-      if [[ "${COUNTS[0]}" -eq 0 ]]; then
-        _warn "Remote branch origin/${BRNAME} is ${COUNTS[1]} commit(s) ahead of master." \
-              "Do you want to reset your local branch to be the same as origin/${BRNAME}?"
-        if _confirm_default_yes "Reset ${BRNAME} to match origin/${BRNAME}?  (Y/n)  "; then
-          _git reset --hard "origin/${BRNAME}"
-        else
-          _warn "Commits from origin/${BRNAME} were not imported." \
-                "You probably want to run \"gee update\" in branch ${BRNAME}."
-        fi
-      else
-        _warn "Local branch has ${COUNTS[0]} commits that are not in origin." \
-              "Origin has ${COUNTS[1]} commits that are not in the local branch." \
-              "You probably want to run \"gee update\" in branch ${BRNAME}."
-      fi
-    else
-      _warn "Remote branch origin/${BRNAME} exists but was not ahead of master." \
-            "No commits were imported from origin/${BRNAME}."
+      _warn "Parent branch ${SHA} is ${COUNTS[1]} commits ahead of this branch." \
+            "You probably want to do a \"gee update\" operation in branch ${BRNAME}."
     fi
   fi
 }


### PR DESCRIPTION
Udi recently gave gee a try and found a bug I introduced recently that was breaking
the comparison of local and origin branches.  While fixing that, I decided that the
whole "rebase from origin" approach was too clever, and I simplified it so that now:

* If branch "foo" is created and "origin/foo" already exists, the new "foo" branch
  is always reset to match exactly what is in "origin/foo".  No more rebasing or
  asking the user questions.

* Gee checks to see how many commits "foo" is behind the parent branch, and reports
  the difference so the user knows there is a "gee up" operation in their future.

Along the way, I also found a bug where `gh repo set-default` wasn't always
being called before branch creation.  This PR fixes `gee init` so that `gh pr
repo set-default` is always performed when the repo is created.

Tested:

I created a new gee repo:

    export GEE_DIR=/home/jonathan/geeclone
    gee init

I then attempt to recreate existing branches in that new client, which I knew
would already have branches existing in origin.

    $ gee mkbr verilog_rules_transition
    CMD: /usr/bin/git worktree add -b verilog_rules_transition -f /home/jonathan/geeclone/internal/verilog_rules_transition master
    Preparing worktree (new branch 'verilog_rules_transition')
    Updating files: 100% (24493/24493), done.
    HEAD is now at aca840b119 mcu: ethd: Remove force pll
    Created /home/jonathan/geeclone/internal/verilog_rules_transition
    CMD: /usr/bin/git fetch origin
    WARNING: Found existing "origin/verilog_rules_transition" branch: resetting local "verilog_rules_transition" to match.
    CMD: /usr/bin/git reset --hard origin/verilog_rules_transition
    HEAD is now at f12334f426 support MSIE builds, log the two lines after any warning or errors.
    WARNING: Parent branch master is 559 commits ahead of this branch.
    WARNING: You probably want to do a "gee update" operation in branch verilog_rules_transition.


