### PR TITLE
bazel: kernel: enable using local builds of the linux kernel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,8 @@ load("//bazel/enkit:defs.bzl", "multirun")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
 
 # To update and generate the BUILD.bazel files, run:
 #     bazelisk run //:gazelle
@@ -104,3 +106,16 @@ compile_pip_requirements(
     requirements_in = "requirements.in",
     requirements_txt = "requirements.txt",
 )
+
+string_flag(
+    name = "kernel_dir",
+    build_setting_default = "placeholder",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "kernel_dir_placeholder",
+    flag_values = {":kernel_dir": "placeholder"},
+    visibility = ["//visibility:public"],
+)
+

--- a/bazel/linux/BUILD.bazel.tpl
+++ b/bazel/linux/BUILD.bazel.tpl
@@ -1,0 +1,22 @@
+load("@enkit//bazel/linux:defs.bzl", "kernel_image")
+
+kernel_image(
+    name = "image",
+    package = "{version}",
+    arch = "host",
+    image = "boot/vmlinuz-{version}",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+filegroup(
+    name = "modules",
+    srcs = glob(["lib/modules/**"],
+    exclude = [
+        "**/add-ons/**",
+    ]),
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -110,16 +110,11 @@ def _kernel_modules(ctx):
 
     kernel_build_dir = ctx.attr.local_kernel[BuildSettingInfo].value if ctx.attr.local_kernel and ki.arch == "host" else kernel_build_dir
 
-    print(ctx.attr.local_kernel)
-    print(kernel_build_dir)
-
     make_args = ctx.attr.make_format_str.format(
         src_dir = srcdir,
         kernel_build_dir = kernel_build_dir,
         modules = " ".join(modules),
     )
-
-    #print(make_args)
 
     compilation_mode = ctx.var["COMPILATION_MODE"]
     if compilation_mode == "fastbuild":
@@ -147,7 +142,6 @@ def _kernel_modules(ctx):
     # equivalent to tags = ["no-remote"], but tags are not configurable attributes -
     # https://github.com/bazelbuild/bazel/issues/2971
     execution_requirements = None if ctx.attr.remote else {"no-remote": "foo"}
-    print(execution_requirements)
 
     ctx.actions.run_shell(
         mnemonic = "KernelBuild",

--- a/bazel/linux/defs.bzl
+++ b/bazel/linux/defs.bzl
@@ -466,12 +466,12 @@ def kernel_module(*args, **kwargs):
         kwargs["make_format_str"] = "-C {kernel_build_dir} M=$PWD/{src_dir} {modules}"
 
     kwargs["local_kernel"] = select({
-        "@enfabrica//:kernel_dir_placeholder": None,
-        "//conditions:default": "@enfabrica//:kernel_dir",
+        Label("//:kernel_dir_placeholder"): None,
+        "//conditions:default": Label("//:kernel_dir"),
     })
 
     kwargs["remote"] = select({
-        "@enfabrica//:kernel_dir_placeholder": True,
+        Label("//:kernel_dir_placeholder"): True,
         "//conditions:default": False,
     })
 

--- a/bazel/linux/repository.bzl
+++ b/bazel/linux/repository.bzl
@@ -160,7 +160,7 @@ local_kernel_package = repository_rule(
     implementation = _local_kernel_impl,
     attrs = {
         "path": attr.string(
-            doc = "Optional path to kernel install directory",
+            doc = "Optional path to kernel install directory. Defaults to /home/{user}/rootfs",
         ),
         "version": attr.string(
             doc = "Version metadata for kernel image - will be appended to vmlinuz-{version}",
@@ -168,7 +168,7 @@ local_kernel_package = repository_rule(
         ),
         "_build_tpl": attr.label(
             doc = "BUILD template for kernel_image target and kernel_modules filegroup",
-            default = Label("//bazel/linux:BUILD.bazel.tpl"),
+            default = "//bazel/linux:BUILD.bazel.tpl",
         ),
     },
 )


### PR DESCRIPTION
Extends our Linux kernel build rules to enable building and testing against a locally built kernel
instead of the prebuilt sdk's from our artifact store.

## Usage

Bazel currently requires 3 main integration points with a build of the Linux kernel:
- A `vmlinuz` image (supplied by `kernel_image` targets)
- A `filegroup` containing the in tree Linux kernel modules
- A path to a Linux kernel build tree (obj dir)  for building a kernel module against - (typically supplied by `kernel_tree` target)

This change enables users to point bazel to locally built versions of these artifacts.

### Integrating locally built kernel image and in tree kernel modules

A new repository rule: `local_kernel_package` has been written that will import a local kernel install into bazel:
(in `WORKSPACE`):
```bazel
load("@enkit//bazel/Linux:repository.bzl", "local_kernel_package")

local_kernel_package(
    name = "local-kernel"
    version = "6.3.12+",
)
```

By default this will search `/home/{user}/rootfs` for `/boot/vm-linuz-6.3.12+` and `/lib/modules/*` and generate a `BUILD.bazel` file that integrates those artifacts into the build system. The resulting targets can be referenced in bazel:
- `@local-kernel//:image` -> (`vmlinuz`)
- `@local-kernel//:modules` -> (The `/lib/modules/*` folder)

`/home/{user}/rootfs` is a typically install target for local kernel builds at Enfabrica. You can point to a different install root using the `path` attribute:
```bazel
local_kernel_package(
    name = "local-kernel",
    version = "6.3.12+",
    path = "/home/isaac/rootfs-debug",
)
```

**note**: A typical kernel install (i.e `make modules_install`) will create symlinks back to the build and source dirs - these break bazel and must be deleted.

### Buildng modules against a local kernel tree

To support building `kernel_module` targets against a local kernel built tree, we have added the `kernel_dir` string flag:
```sh
bazel build --//:kernel_dir=/home/isaac/linux/build //:some/kernel_module:target
```

Not that this is non hermetic - the kernel builds tree itself is not tracked by bazel - and for these reason we force these actions to execute on the local host using `exec_properties` even in an RBE build.

The kernel build tree *must* be the same as which produced the corresponding `vm-linuz` and `lib/modules`.