### PR TITLE
fix(grpc): revert include changes that cause annoying bazel warnings

### DIFF
--- a/bazel/dependencies/grpc/fix_includes_warning.patch
+++ b/bazel/dependencies/grpc/fix_includes_warning.patch
@@ -1,0 +1,39 @@
+diff --git a/bazel/grpc_build_system.bzl b/bazel/grpc_build_system.bzl
+index 16e0185d90..05bf84e080 100644
+--- a/bazel/grpc_build_system.bzl
++++ b/bazel/grpc_build_system.bzl
+@@ -200,7 +200,6 @@ def grpc_cc_library(
+     if select_deps:
+         for select_deps_entry in select_deps:
+             deps += select(select_deps_entry)
+-    include_prefix = _include_prefix()
+     native.cc_library(
+         name = name,
+         srcs = srcs,
+@@ -225,9 +224,9 @@ def grpc_cc_library(
+         testonly = testonly,
+         linkopts = linkopts,
+         includes = [
+-            include_prefix + "include",
+-            include_prefix + "src/core/ext/upb-gen",  # Once upb code-gen issue is resolved, remove this.
+-            include_prefix + "src/core/ext/upbdefs-gen",  # Once upb code-gen issue is resolved, remove this.
++            "include",
++            "src/core/ext/upb-gen",  # Once upb code-gen issue is resolved, remove this.
++            "src/core/ext/upbdefs-gen",  # Once upb code-gen issue is resolved, remove this.
+         ],
+         alwayslink = alwayslink,
+         data = data,
+diff --git a/src/core/BUILD b/src/core/BUILD
+index eda740ee1f..52d6d1f753 100644
+--- a/src/core/BUILD
++++ b/src/core/BUILD
+@@ -67,6 +67,9 @@ grpc_cc_library(
+         "absl/strings:str_format",
+     ],
+     language = "c++",
++    deps = [
++      "//:gpr_platform",
++    ],
+ )
+ 
+ grpc_cc_library(

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -65,6 +65,7 @@ def stage_1():
         patch_args = ["-p1"],
         patches = [
             "@enkit//bazel/dependencies/grpc:hermetic_py_no_remote.patch",
+            "@enkit//bazel/dependencies/grpc:fix_includes_warning.patch",
         ],
         urls = [
             "https://github.com/grpc/grpc/archive/refs/tags/v1.70.0.tar.gz",


### PR DESCRIPTION
Recently upstream grpc has tried to refactor how includes are done in their builds - however the new way they're trying to do includes is going to be illegal in future versions of bazel resulting in nauseating warnings spamming the terminal during builds.

We will simply revert this commit until upstream gets around to properly fixing it.

commit: https://github.com/grpc/grpc/commit/06eda49d45a2697e1726e6802759c4fc5c09997c