### PR TITLE
Add json_to_yaml rule

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -421,3 +421,11 @@ proto_library(
         strip_prefix = "opentelemetry-proto-0.19.0",
         urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.19.0.tar.gz"],
     )
+
+    maybe(
+        name = "yq",
+        repo_rule = http_file,
+        sha256 = "654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049",
+        urls = ["https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64"],
+        executable = True,
+    )

--- a/bazel/utils/yaml.bzl
+++ b/bazel/utils/yaml.bzl
@@ -1,0 +1,32 @@
+def _json_to_yaml_impl(ctx):
+    output = ctx.actions.declare_file(ctx.attr.output)
+    ctx.actions.run_shell(
+        command = "{} -P -o yaml {} > {}".format(ctx.executable._tool.path, ctx.file.src.path, output.path),
+        progress_message = "Converting {} to yaml".format(ctx.file.src.basename),
+        inputs = [ctx.file.src],
+        tools = [ctx.executable._tool],
+        outputs = [output],
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+json_to_yaml = rule(
+    implementation = _json_to_yaml_impl,
+    doc = "Converts json to yaml using the yq tool",
+    attrs = {
+        "src": attr.label(
+            doc = "Single json file",
+            allow_single_file = [".json"],
+            mandatory = True,
+        ),
+        "output": attr.string(
+            doc = "Name of the output yaml file",
+            mandatory = True,
+        ),
+        "_tool": attr.label(
+            doc = "Path to yq tool",
+            default = "@yq//file:file",
+            executable = True,
+            cfg = "exec",
+        )
+    }
+)


### PR DESCRIPTION
This change implements a custom bazel rule that converts JSON to YAML required by: https://github.com/enfabrica/internal/pull/52398

Tested: 
- `bazel build --override_repository=enkit=$HOME/enkit //infra/networking/...` in the internal repo

JIRA: INFRA-11467