### PR TITLE
gee: fix rmbr of branches created with pr_checkout

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1388,12 +1388,20 @@ function _git_can_fail() {
 function _git_rev_list_counts() {
   local B="$1"
   local P="$2"
+
+  if [[ "${B}" == upstream/refs/pull/*/head ]]; then
+    "${GIT}" fetch --quiet upstream "${B#upstream/refs/}:FETCH_HEAD_B" >/dev/null 2>&1
+    B=FETCH_HEAD_B
+  elif [[ "${B}" == */* ]]; then
+    "${GIT}" fetch --quiet "${B%%/*}" "${B#upstream}:FETCH_HEAD_B" >/dev/null 2>&1
+    B=FETCH_HEAD_B
+  fi
   if [[ "${P}" == upstream/refs/pull/*/head ]]; then
-    "${GIT}" fetch upstream "${P#upstream/refs/}" >/dev/null 2>&1
-    P=FETCH_HEAD
+    "${GIT}" fetch --quiet upstream "${P#upstream/refs/}:FETCH_HEAD_P" >/dev/null 2>&1
+    P=FETCH_HEAD_P
   elif [[ "${P}" == */* ]]; then
-    "${GIT}" fetch "${P%%/*}" "${P#upstream}" >/dev/null 2>&1
-    P=FETCH_HEAD
+    "${GIT}" fetch --quiet "${P%%/*}" "${P#upstream}:FETCH_HEAD_P" >/dev/null 2>&1
+    P=FETCH_HEAD_P
   fi
   "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true
 }
@@ -4961,7 +4969,7 @@ function _remove_a_branch() {
     PARENT="$(_get_parent_branch "${BR}")"
     STATE=CLEAN
     local -a  counts=()
-    read -r -a counts < <("${GIT}" rev-list --left-right --count "${PARENT}...${BR}")
+    read -r -a counts < <(_git_rev_list_counts "${PARENT}" "${BR}")
     if (( counts[1] != 0 )); then
       _warn "Branch \"${BR}\" is ${counts[1]} commit(s) ahead of ${PARENT}."
       STATE=UNCLEAN
@@ -4988,7 +4996,7 @@ function _remove_a_branch() {
       BAZELCACHE="$(readlink -f ./bazel-out)"
       BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"
       _info "Removing linked bazel cache directory \"${BAZELCACHE}\""
-      chmod -R u+w "${BAZELCACHE}"
+      chmod -fR u+w "${BAZELCACHE}"
       rm -rf "${BAZELCACHE}"
     fi
 


### PR DESCRIPTION
This fixes an issue Hila was experiencing.

Problem:

```
$ gee pr_checkout 51143
$ gee rmbr pr_51143

fatal: ambiguous argument 'upstream/refs/pull/51143/head...pr_51143': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Under the hood, gee was running:

```
git rev-list --left-right --count 'upstream/refs/pull/51143/head...pr_51143'
```

Because `upstream/refs/pull/51143/head` is a tag, not a branch, git rejects
this command.  The fix is to perform a fetch from upstream for that tag,
creating a "FETCH_HEAD" virtual branch that can be used in the rev-list
operation.

This modifies gee to re-use the existing `_git_rev_list_counts` function,
and fixes that function to robustly handling tags provided as either the
left or right sides of the rev-list evaluation.

The same command now succeeds:

```
$ gee rmbr pr_51143

CMD: /usr/bin/git worktree remove --force pr_51143
CMD: /usr/bin/git branch -D pr_51143
Deleted branch pr_51143 (was 16bcab9e3e).
Deleted local branch pr_51143.  To undo: gee make_branch pr_51143 16bcab9e3e
CMD: /usr/bin/git push --quiet origin --delete pr_51143
Deleted remote branch origin/pr_51143
```

Tested: see above


