### PR TITLE
kbuild: include kernel modules into astore artifact

### DIFF
--- a/kbuild/v2/scripts/build-kernel-release.sh
+++ b/kbuild/v2/scripts/build-kernel-release.sh
@@ -62,7 +62,7 @@ ${SCRIPT_PATH}/build-kernel-tree.sh -q -c -v "$kernel_version_suffix" -a "$ARCH"
 kernel_version="$(cat ${BUILD_DIR}/install/build/enf-kernel-version.txt)"
 
 # remove a bunch of unneeded stuff from build directory
-PATTERNS=".*.cmd *.a *.o *.d *.ko *.order *.mod *.mod.c *.mod.o *.log"
+PATTERNS=".*.cmd *.a *.o *.d *.order *.mod *.mod.c *.mod.o *.log"
 for p in $PATTERNS ; do
     find "${BUILD_DIR}/install" -name $p -type f -exec rm -f {} +
 done


### PR DESCRIPTION
We're at the place were we need some modules to be exported from the kernel build.

Tested with:

```

$ ./enkit/kbuild/v2/kpub-astore -r <linux_fork_with_kmods_included> -s 'arm64,emulator' -v

$ enkit astore get <artifact_uuid>
$ tar xf kernel-tree-image-arm64-emulator.tar.gz
$ cd install/build/
$ find . -iname "*.ko"
./lib/crypto/libarc4.ko
./drivers/net/ethernet/microchip/encx24j600-regmap.ko
./drivers/net/ethernet/microchip/encx24j600.ko
./drivers/net/ethernet/microchip/lan743x.ko
./drivers/net/ethernet/microchip/enc28j60.ko
./drivers/net/ppp/ppp_deflate.ko
./drivers/net/ppp/ppp_mppe.ko
./drivers/net/ppp/ppp_synctty.ko
./drivers/net/ppp/pppoe.ko
./drivers/net/ppp/pppox.ko
./drivers/net/ppp/bsd_comp.ko

```

Ticket: EMU-1151