### PR TITLE
Revert rules_foreign_cc to an older version

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -287,9 +287,9 @@ filegroup(
     maybe(
         name = "rules_foreign_cc",
         repo_rule = http_archive,
-        sha256 = "4b33d62cf109bcccf286b30ed7121129cc34cf4f4ed9d8a11f38d9108f40ba74",
-        strip_prefix = "rules_foreign_cc-0.11.1",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.11.1/rules_foreign_cc-0.11.1.tar.gz",
+        sha256 = "9561b3994232ccb033278ade83c2ce48e763e9cae63452cd8fea457bedd87d05",
+        strip_prefix = "rules_foreign_cc-816905a078773405803e86635def78b61d2f782d",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/816905a078773405803e86635def78b61d2f782d.tar.gz",
         patches = [
             "@enkit//bazel/dependencies:rules_foreign_cc_export_functions.patch",
             "@enkit//bazel/dependencies:rules_foreign_cc_module_linker_flags.patch",


### PR DESCRIPTION
Upgrading `rules_foreign_cc` broke some `meson` targets in the `internal` repo.

Tested:
- `bazel test` all `cc_test` targets included in the presubmit in the internal repo

JIRA: ENGPROD-410