### PR TITLE
gee rmbr: fix deletion of pr_NNN branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1390,17 +1390,17 @@ function _git_rev_list_counts() {
   local P="$2"
 
   if [[ "${B}" == upstream/refs/pull/*/head ]]; then
-    "${GIT}" fetch --quiet upstream "${B#upstream/refs/}:FETCH_HEAD_B" >/dev/null 2>&1
+    "${GIT}" fetch --quiet --force upstream "${B#upstream/refs/}:FETCH_HEAD_B" >/dev/null 2>&1
     B=FETCH_HEAD_B
   elif [[ "${B}" == */* ]]; then
-    "${GIT}" fetch --quiet "${B%%/*}" "${B#upstream}:FETCH_HEAD_B" >/dev/null 2>&1
+    "${GIT}" fetch --quiet --force "${B%%/*}" "${B#upstream}:FETCH_HEAD_B" >/dev/null 2>&1
     B=FETCH_HEAD_B
   fi
   if [[ "${P}" == upstream/refs/pull/*/head ]]; then
-    "${GIT}" fetch --quiet upstream "${P#upstream/refs/}:FETCH_HEAD_P" >/dev/null 2>&1
+    "${GIT}" fetch --quiet --force upstream "${P#upstream/refs/}:FETCH_HEAD_P" >/dev/null 2>&1
     P=FETCH_HEAD_P
   elif [[ "${P}" == */* ]]; then
-    "${GIT}" fetch --quiet "${P%%/*}" "${P#upstream}:FETCH_HEAD_P" >/dev/null 2>&1
+    "${GIT}" fetch --quiet --force "${P%%/*}" "${P#upstream}:FETCH_HEAD_P" >/dev/null 2>&1
     P=FETCH_HEAD_P
   fi
   "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true
@@ -2695,7 +2695,7 @@ function gee__diff() {
   PARENT_BRANCH="$(_get_parent_branch)"
   # branches created with "gee pr_checkout" need special handling:
   if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
-    _git fetch upstream "${PARENT_BRANCH#upstream/}"
+    _git fetch --force upstream "${PARENT_BRANCH#upstream/}"
     PARENT_BRANCH="FETCH_HEAD"
   fi
   if (( "$#" )); then
@@ -3493,7 +3493,7 @@ function gee__cleanup() {
       local parent
       parent="$(_get_parent_branch "${br}")"
       if [[ "${parent}" == upstream/* ]]; then
-        _git fetch upstream "${parent#upstream/}"
+        _git fetch --force upstream "${parent#upstream/}"
         parent="FETCH_HEAD"
       fi
       local -a  counts=()
@@ -3922,7 +3922,7 @@ function gee__pr_push() {
   if ! "${GIT}" remote get-url "${REMOTE_USER}" >/dev/null 2>&1; then
     _git remote add "${REMOTE_USER}" "${GIT_AT_GITHUB}:${REMOTE_USER}/${REPO}.git" >&2
   fi
-  _git fetch "${REMOTE_USER}" "${REMOTE_BRANCH}"
+  _git fetch --force "${REMOTE_USER}" "${REMOTE_BRANCH}"
 
   # Check if we are behind remote branch
   local -a COUNTS


### PR DESCRIPTION
@hilakarp disocvered that the following sequence was failing:

  gee pr_checkout 53809
  gee rmbr pr_53809

Enabling debug mode (`DEBUG=1`), I saw that a hidden `git fetch` command was failing.
The error message was being suppressed because the `--quiet` flag was being supplied.

The actual failure was:

```
$ /usr/bin/git fetch  upstream pull/53809/head:FETCH_HEAD_B; echo $?
From github.com:enfabrica/internal
 ! [rejected]              refs/pull/53809/head -> FETCH_HEAD_B  (non-fast-forward)
1
```

What's going on here?  gee is calling "git fetch" on up to two different branches,
each of which could potentially be in upstream.  To facilitate, gee is replacing
the normal "FETCH_HEAD" temporary tag with "FETCH_HEAD_B" and "FETCH_HEAD_P" tags.
However, these tags aren't "magic" the way FETCH_HEAD is, and so if a command
sets FETCH_HEAD_B to one particular commit, and then attempts the same operation
in a different branch, git will notice that the ref being fetched isn't a
descendant of the previous FETCH_HEAD_B, and will refuse to run ("non-fast-forward").

The fix is to tell git to ignore any previous commit indicated by FETCH_HEAD_B or
FETCH_HEAD_P by using the "--force" flag on "git fetch."

This is probably a good option to use everywhere gee uses git fetch.  Fixed.

Tested: The previously failing sequence of commands now succeeds.


