### PR TITLE
Bazel 7 compilation error message fix

### DIFF
--- a/bazel/dependencies/com_google_protobuf/0001-Add-requires-keyword-to-fix-compilation-errors.patch
+++ b/bazel/dependencies/com_google_protobuf/0001-Add-requires-keyword-to-fix-compilation-errors.patch
@@ -1,0 +1,25 @@
+From aa7a3072ce8c24d9c57bb79be791d397bcdbacfb Mon Sep 17 00:00:00 2001
+From: Brian Huynh <bbhuynh@enfabrica.net>
+Date: Tue, 1 Apr 2025 20:04:16 +0000
+Subject: [PATCH] Add requires keyword to fix compilation errors
+
+---
+ src/google/protobuf/port.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/port.h b/src/google/protobuf/port.h
+index 3a0162ca9..440a465c0 100644
+--- a/src/google/protobuf/port.h
++++ b/src/google/protobuf/port.h
+@@ -178,7 +178,7 @@ void AssertDownCast(From* from) {
+   // Check that this function is not used to downcast message types.
+   // For those we should use {Down,Dynamic}CastTo{Message,Generated}.
+   static_assert(!requires {
+-    std::derived_from<std::remove_pointer_t<To>,
++    requires std::derived_from<std::remove_pointer_t<To>,
+                       typename std::remove_pointer_t<To>::MessageLite>;
+   });
+ #endif
+-- 
+2.47.0
+

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -287,9 +287,9 @@ filegroup(
     maybe(
         name = "rules_foreign_cc",
         repo_rule = http_archive,
-        sha256 = "4b33d62cf109bcccf286b30ed7121129cc34cf4f4ed9d8a11f38d9108f40ba74",
-        strip_prefix = "rules_foreign_cc-0.11.1",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.11.1/rules_foreign_cc-0.11.1.tar.gz",
+        sha256 = "9561b3994232ccb033278ade83c2ce48e763e9cae63452cd8fea457bedd87d05",
+        strip_prefix = "rules_foreign_cc-816905a078773405803e86635def78b61d2f782d",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/816905a078773405803e86635def78b61d2f782d.tar.gz",
         patches = [
             "@enkit//bazel/dependencies:rules_foreign_cc_export_functions.patch",
             "@enkit//bazel/dependencies:rules_foreign_cc_module_linker_flags.patch",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -291,9 +291,9 @@ filegroup(
     maybe(
         name = "rules_foreign_cc",
         repo_rule = http_archive,
-        sha256 = "9561b3994232ccb033278ade83c2ce48e763e9cae63452cd8fea457bedd87d05",
-        strip_prefix = "rules_foreign_cc-816905a078773405803e86635def78b61d2f782d",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/816905a078773405803e86635def78b61d2f782d.tar.gz",
+        sha256 = "4b33d62cf109bcccf286b30ed7121129cc34cf4f4ed9d8a11f38d9108f40ba74",
+        strip_prefix = "rules_foreign_cc-0.11.1",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.11.1/rules_foreign_cc-0.11.1.tar.gz",
         patches = [
             "@enkit//bazel/dependencies:rules_foreign_cc_export_functions.patch",
             "@enkit//bazel/dependencies:rules_foreign_cc_module_linker_flags.patch",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -51,6 +51,10 @@ def stage_1():
         repo_rule = http_archive,
         integrity = "sha256-EKDVjzmhqQnpXgDougtbHcZNApl/dBFRlTorNln254w=",
         strip_prefix = "protobuf-29.0",
+        patch_args = ["-p1"],
+        patches = [
+            "@enkit//bazel/dependencies/com_google_protobuf:0001-Add-requires-keyword-to-fix-compilation-errors.patch",
+        ],
         urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v29.0.tar.gz"],
     )
 


### PR DESCRIPTION
This change fixes compilation errors discovered in the bazel 7 upgrade in internal: https://github.com/enfabrica/internal/pull/50532

Compilation error that this change fixes:
```
cc1plus: all warnings being treated as errors
error: testing if a concept-id is a valid expression; add 'requires' to check satisfaction [-Werror=missing-requires]
```

Tested:
- `bazel build --override_repository=enkit=$HOME/enkit --target_pattern_file=/tmp/targets.txt` the following targets in internal:
```
//model/functional/events:all
//model/functional/libpcirpc:all
//model/functional/sfa-model:all
//model/functional/sfa-model/hbt:all
//model/functional/sfa-model/host-egress:all
//model/functional/sfa-model/mcu:all
//model/functional/sfa-model/switchcore:all
```

JIRA: ENGPROD-410