### PR TITLE
WORKSPACE: Update `pkg_files` to the latest release

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -185,10 +185,9 @@ def stage_1():
         name = "rules_pkg",
         repo_rule = http_archive,
         urls = [
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz",
         ],
-        sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+        sha256 = "b7215c636f22c1849f1c3142c72f4b954bb12bb8dcf3cbe229ae6e69cc6479db",
     )
 
     maybe(


### PR DESCRIPTION
This change updates `pkg_files` to 1.1.0, to (hopefully) pick up some bug fixes to `pkg_tar`.

Tested: `bazel test //...` in this repo only
Jira: REL-44