### PR TITLE
gee update: fix behavior when updating PR branches

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -3323,8 +3323,8 @@ function _get_parent_head_commit() {
   local -a WORDS=()
   if [[ "${PARENT}" == */* ]]; then
     # make sure remote is up to date:
-    _git fetch "${PARENT%%/*}"
-    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" ls-remote "${PARENT%%/*}" "${PARENT#*/}"
+    _git fetch "${PARENT%%/*}" "${PARENT#*/}"
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" show -s --format=oneline FETCH_HEAD
     read -r -a WORDS <<< "${OUTPUT[0]}"
     _PARENT_HEAD="${WORDS[0]}"
   else

--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.54"
+readonly VERSION="0.2.55"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### 0.2.55
+
+* `gee update`: fix fetching of commits from other user's PRs.
+
 ### 0.2.54
 
 * `gee pr_checkout`: add "-n" flag to explicitly specify a branch name.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.54
+gee version: 0.2.55
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
`gee up` was failing for some branches created with `gee pr_checkout`, with error
messages along the lines of "upstream commit was not found."

`gee` was previously performing the following steps:

```
git fetch upstream
git ls-remote upstream refs/pull/12345/head
```

The first command was intended to ensure that the local image of the upstream
repo was up to date, and the 2nd command was designed to look up the commit
associated with the upstream pull request.

The problem was: `git fetch upstream` was only fetching commits associated
with branches (ie. master), but wasn't fetching commits associated with
references.  So: ls-remote was returning the SHA of a commit that `git fetch`
had not fetched.

The simplest fix is to just tell git to fetch what we want it to fetch.
The above two commands are now replaced with:

```
git fetch upstream refs/pull/12345/head  # updates FETCH_HEAD
git show -s --pretty=oneline FETCH_HEAD  # queries FETCH_HEAD
```

Tested: manually tested in my local pr branches.


