### PR TITLE
bazel: Add custom bazel flag for setting astore upload tags

### DIFF
--- a/f/README.md
+++ b/f/README.md
@@ -1,0 +1,11 @@
+# What the `f`?
+
+This directory contains targets that are Bazel [user-defined build
+settings](https://bazel.build/extending/config#user-defined-build-settings).
+These settings are essentially "custom bazel flags" that can be specified on the
+command-line to alter the behavior of particular rules.
+
+Since these flags are referenced on the command-line as labels (like
+`--//f/some:flag` or `--@enkit//f/some:flag`) the names can get quite long. In
+an effort to shorten the names as much as possible, the flags are specified in
+this top-level `f` directory, with subdirectories for different rule categories.

--- a/f/astore/BUILD.bazel
+++ b/f/astore/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//bazel/astore:defs.bzl", "astore_tag")
+
+astore_tag(
+    name = "upload_tag",
+    build_setting_default = [],
+    visibility = ["//bazel/astore:__pkg__"],
+)


### PR DESCRIPTION
Shortly we may need to run multiple astore upload targets and tag said uploads with the same tag (where the tag may change on each upload). There are a few ways to do this currently, none of which are great:

* edit the BUILD files before uploading, changing the `upload_tag` attribute on each target (requires building and pushing with a dirty source tree)
* find the UIDs after pushing and tag each file (tough/impossible to do from a script today)

This change introduces a third way, by creating a custom bazel setting that can propagate an array of tags from the `bazel run` commandline.

Example:

`experimental/BUILD.bazel`:

```
load("//bazel/astore:defs.bzl", "astore_upload")

astore_upload(
    name = "tags_test",
    file = "home/scott/foo.txt",
    targets = ["foo.txt"],
    upload_tag = "v0",
)
```

Running normally adds the `v0` tag from the BUILD file, as before:

```
scott-> bazel run //experimental:tags_test

// bazel output omitted

| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2025-04-10 14:56:38.336 scott@enfabrica.net            all            3858f62230ac3c915f300c664312c63f 68i4v8fmeewuzjj44qr5objmqnhyuxpv 6 B     [v0 latest]
experimental/foo.txt uploaded as home/scott/foo.txt: assigned UID 68i4v8fmeewuzjj44qr5objmqnhyuxpv
```

Running with extra tags on the commandline adds both the BUILD file tag and the tags from the commandline:

```
scott-> bazel run //experimental:tags_test --//f/astore:upload_tag=v1 --//f/astore:upload_tag=v2

// bazel output omitted

experimental/foo.txt: uploading 6 B / 6 B [----------------------------------------------------------------------------------------] 100.00% 11 B p/s 0s
experimental/foo.txt: committing all 6 B / 6 B [-----------------------------------------------------------------------------------] 100.00% 11 B p/s 0s
| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
| 2025-04-10 14:57:46.621 scott@enfabrica.net            all            3858f62230ac3c915f300c664312c63f rxqozcgjst6by2xn2fkqe7c5338hagb8 6 B     [v0 v1 v2 latest]
experimental/foo.txt uploaded as home/scott/foo.txt: assigned UID rxqozcgjst6by2xn2fkqe7c5338hagb8
```

Tested: See above examples