### PR TITLE
gee: fix pr_cancel

### DIFF
--- a/gee
+++ b/gee
@@ -1,0 +1,6718 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# (due to https://github.com/koalaman/shellcheck/issues/817)
+
+readonly VERSION="0.2.57"
+
+if read -r -d '' USAGE <<'EOT'
+. __ _  ___  ___
+ / _` |/ _ \/ _ \  git
+| (_| |  __/  __/  enabled
+ \__, |\___|\___|  enfabrication
+ |___/
+
+gee version: {{VERSION}}
+
+gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
+tools  gee is an opinionated tool that implements a specific, simple, powerful
+workflow.
+
+"gee" is also an instructional tool: by showing each command as it executes,
+gee helps users learn git.
+
+## Features:
+
+Uses the "worktree" feature so that:
+
+* every branch is always visible in its own directory.
+* switching branches is accomplished by changing directory.
+* it's harder to accidentally save changes to the wrong branch.
+* users can have uncommitted changes pending in more than one branch.
+
+All branch directories are named ~/gee/<REPO>/<BRANCH>.
+
+All local commits are automatically backed up to github.
+
+Tracks "parentage" (which branch is derived from which).
+
+Sets up and enforces use of ssh for all interactions with github.
+
+Supports multi-homed development (user can do work on various hosts without
+NFS-mounted home directories).
+
+## An example of simple use:
+
+1. Run "gee init" to clone and check out the enfabrica/internal repo.  This
+   only needs to be done once per home directory.
+
+2. "cd ~/gee/internal/main" to start in the main branch.
+
+3. Make a feature branch: "gee make_branch my_feature"
+   Then: "cd $(gee gcd my_feature)"
+
+4. Make some changes, and call "gee commit" whenever needed to checkpoint
+   your work.
+
+5. Call "gee update" to pull new changes from upstream.
+
+6. When ready to send your change out for review:
+
+    gee fix  # runs all automatic code formatters
+    gee commit -a -m "ran gee fix"
+    gee make_pr  # creates a pull request.
+
+7. You can continue to make updates to your branch, and update your
+   PR by running "gee commit".
+
+8. When approved, run "gee submit_pr" to merge your change.
+
+## An example of more complex use:
+
+You can continue to develop a second feature while the first feature is out for
+review.
+
+1. Make a branch of a branch:
+
+     cd $(gee gcd my_feature)
+     gee mkbr my_feature2
+
+2. Do work in the child branch:
+
+     cd $(gee gcd my_feature2)
+
+3. Recursively update a chain of branches:
+
+     gee rupdate
+
+## Environment variables
+
+`gee`'s behavior can be moderated by setting the following variables in your shell environment:
+
+* `GHUSER`: Your github username.
+
+* `GEE_DIR`: By default, gee will place all work directories in `~/gee`.  This variable can
+  be set to a different path to override this behavior.  `gee` will still create a repository
+  directory beneath `$GEE_DIR` (ie, `~/gee/internal`), so if you want to change the repository
+  directory as well, use the GEE_REPO and GEE_REPO_DIR environment variables.
+
+* `GEE_REPO_DIR`: By default, gee will place a repository's workdirs in a directory specified
+  by `${GEE_DIR}/${GEE_REPO}` where `GEE_DIR` defaults to `~/gee` and `GEE_REPO` defaults to `internal`.
+  The `GEE_REPO_DIR` can be set to specify a different directory.  However, if `GEE_REPO_DIR` is set,
+  you must also set the `GEE_REPO` environment variable.
+
+* `GEE_REPO`: By default, gee will attempt to guess which repository to use based on the current
+  working directory (ie. the `enkit` repo is inferred from `~/gee/enkit/master`).  To override this
+  behavior (or, if you are using `GEE_REPO_DIR` to use a non-standard directory structure), set
+  the `GEE_REPO` variable to the repository name (ie. `internal`, `enkit`, etc.).
+
+* `GEE_BUILDLOGS_PROJECT`: If you are using gcloud to store your presubmit testing logs, you can
+  override gee's default gcloud project by setting this environment variable.
+
+* `UPSTREAM`: The name of the github user hosting the specified repository.  By default, `enfabrica`.
+
+* `YESYESYES`: If set to a non-zero integer, will cause all yes/no prompts within `gee` to automatically
+  select "yes".
+
+* `gee` looks in a few places to find the tools it needs, but if gee has a hard time finding the
+  right version of a tool, you can force `gee` to use a specific path by setting any or all
+  of the variables `GIT`, `JQ`, `GH`, and `ENKIT`.
+
+* The following environment variables can be set to a curses color value to override gee's default
+  color scheme.  (The `gee colortest` command can be used to dump a color table and examples of the
+  current color scheme.)
+
+  * `GEE_COLOR_CMD_FG`
+  * `GEE_COLOR_CMD_BG`
+  * `GEE_COLOR_BANNER_FG`
+  * `GEE_COLOR_BANNER_BG`
+  * `GEE_COLOR_DBG_FG`
+  * `GEE_COLOR_DBG_BG`
+  * `GEE_COLOR_DIE_FG`
+  * `GEE_COLOR_DIE_BG`
+  * `GEE_COLOR_WARN_FG`
+  * `GEE_COLOR_WARN_BG`
+  * `GEE_COLOR_INFO_FG`
+  * `GEE_COLOR_INFO_BG`
+
+* `VERBOSE`: If set to a non-zero integer, will cause additional debug information to be logged.
+  For developer use only.
+
+* `GEE_ENABLE_PRESUBMIT_CANCEL`: If set to any value other than 0, will cause
+  gee to cancel any running presubmit job when pushing a change to remote
+  branch with an open PR.  Setting to 0 will disable this functionality.  This
+  feature is no longer experimental and now defaults to enabled.
+
+See also: `gee help bash_setup` for more environment variables to help you customize the git-aware
+prompt that `gee bash_setup` makes available.
+
+EOT
+then :; fi
+# Philosophy:
+#
+#    If I have to look it up on stack overflow, it should get encoded in gee.
+#    Automatic but not automagic.  No surprises.  Show your work.  Never change
+#    the system in a way the user doesn't expect.  When in doubt, ask.
+#
+#    Do what I mean: I'm lysdexic, so a lot of the commands have reverse order
+#    aliases.
+#
+# Branches:
+#    upstream: the original repo we have forked (enfabrica/$REPO)
+#              we issue pull requests to this repo, and we integrate
+#              changes from here.
+#    origin:   the user's forked repo ($GHUSER/$REPO)
+#              we pull and push to this repo.
+#    upstream/main: top of tree
+#    origin/main: user's top-of-tree with no local changes,
+#        updated periodically from upstream/main.
+#    main: local repo top of tree, no local changes,
+#        updated periodically from upstream/main.
+#    $feature: fork of main (or other $feature), contains
+#        local changes.  May have 0 or 1 PRs associated with it.
+#    origin/$feature: github backup of $feature branch.
+#
+# Updates flow in one direction through these branches:
+#
+#   upstream/main -> main -> origin/main -> $feature -> origin/$feature
+#
+# The user only commits changes to $feature.
+#
+# Changes then migrate from origin/$feature back to upstream/main when a PR is
+# approved and merged.
+#
+# Note: We are transitioning from "master" to "main."  Gee always tries to find
+# a "main" remote branch first, but falls back to "master" if "main" does not
+# exist.
+#
+# TODO(jonathan): Bash implementation is a prototype.  rewrite in golang?
+# TODO(jonathan): "git push -u" option is going to change soon.
+# TODO(jonathan): check/help the user authenticate to gcloud.
+
+set -E  # enables errtrace (allows ERR traps to be inherited by functions and subshells)
+set -e  # terminate script on any simple command failure.
+
+if [[ -n "${DEBUG}" ]]; then
+  set -x
+fi
+
+function _fix_pwd() {
+  # Make sure we're in a real directory.
+  #
+  # Sometimes funny things happen with git and directories:
+  #  - git rebase can re-create a directory, changing the inode and leaving pwd
+  #    invalid.
+  #  - removing a worktree can leave the pwd in an invalid directory.
+  #
+  # Let's make sure we're in a directory that exists:
+  local PIFS="${IFS}"
+  local D="${PWD}"
+  cd /
+  local p
+  IFS="/"; for p in ${D}; do
+    if [[ -n "$p" && -d "$p" ]]; then
+      cd "$p"
+    fi
+  done
+  IFS="${PIFS}"
+}
+_fix_pwd
+
+# Globals:
+declare -a HELP=()
+declare -A LONGHELP
+declare -A PARENTS     # initialized by _load_parents_file
+declare -A MERGEBASES  # initialized by _load_parents_file
+declare -A BRANCH_TO_WORKTREE=()
+readonly GEE_LOG_FILE="${HOME}/gee.log"
+# GEE_BUILDLOGS_PROJECT is used by gcloud to access build logs:
+readonly GEE_BUILDLOGS_PROJECT="${GEE_BUILDLOGS_PROJECT:-cloud-build-290921}"
+readonly TRUE=0
+readonly FALSE=1
+readonly GEE_ON_ASTORE="test/gee"
+readonly GIT_PATHS=(   /usr/enfabrica/bin/git   /enf_mounts/bin/git   ~/bin/git   /usr/bin/git)
+readonly GH_PATHS=(    /usr/enfabrica/bin/gh    /enf_mounts/bin/gh    ~/bin/gh    /usr/bin/gh)
+readonly JQ_PATHS=(    /usr/enfabrica/bin/jq    /enf_mounts/bin/jq    ~/bin/jq    /usr/bin/jq)
+readonly ENKIT_PATHS=( /usr/enfabrica/bin/enkit /enf_mounts/bin/enkit ~/bin/enkit /opt/enfabrica/bin/enkit /usr/bin/enkit)
+readonly -a SSHKEYFILES=("${HOME}/.ssh/id_ed25519" "${HOME}/.ssh/gee_github_ed25519")
+SSHKEYFILE="${SSHKEYFILES[0]}"  # default
+# Backwards compatibility: Use first keyfile that exists.
+for f in "${SSHKEYFILES[@]}"; do
+  if [[ -f "${f}" ]]; then
+    SSHKEYFILE="${f}"
+    break
+  fi
+done
+readonly GIT_AT_GITHUB="org-64667743@github.com"
+readonly NEWLINE=$'\n'
+readonly CLONE_DEPTH_MONTHS=3  # months of history to fetch
+# PR_LIST_MAX_FETCH: "gh pr list" fetches N records, and then filters, so this
+# window needs to cover the horizon of all possibly active PRs.  Hilariously,
+# the default is 30.
+readonly PR_LIST_MAX_FETCH=300
+readonly YESYESYES="${YESYESYES:-0}"  # for testing: disables all interactivity.
+GHUSER="${GHUSER:-}"  # can be set by _startup_checks
+VERBOSE="${VERBOSE:-1}"
+GEE_ENABLE_PRESUBMIT_CANCEL="${GEE_ENABLE_PRESUBMIT_CANCEL:-1}"
+DRYRUN="${DRYRUN:-0}"
+UPSTREAM="${UPSTREAM:-enfabrica}"
+TESTMODE="${TESTMODE:-0}"
+MAIN="" # Unknown, call _set_main to set.
+REPO="${REPO:-"${GEE_REPO:-}"}"
+PAGER="${PAGER:-less}"
+PARENTS_FILE_IS_LOADED=0
+PWD_CMD="$(command -v pwd)"  # dev: /usr/bin/pwd, fpga-dev: /bin/pwd  :-(
+declare -A FLAGS=()  # for _parse_options(), below
+declare -a ARGS_POSITIONAL=()  # for _parse_options(), below
+
+# Make sure we're in a directory that exists:
+while ! "${PWD_CMD}" >/dev/null; do
+  cd ..
+done
+
+function _find_executable() {
+  local P
+  for P in "$@"; do
+    if [[ -x "${P}" ]]; then
+      echo "${P}"
+      return
+    fi
+  done
+  P="$(command -v "$(basename "$1")")"
+  if [[ -x "$P" ]]; then
+    echo "${P}"
+    return
+  fi
+  # don't fail, allow the repair flow to attempt to install missing tools:
+  printf >&2 "WARNING: missing tool: %s\n" "$(basename "$1")"
+  basename "$1"
+}
+readonly GIT="${GIT:-"$(_find_executable "${GIT_PATHS[@]}")"}"
+readonly GH="${GH:-"$(_find_executable "${GH_PATHS[@]}")"}"
+readonly JQ="${JQ:-"$(_find_executable "${JQ_PATHS[@]}")"}"
+readonly ENKIT="${ENKIT:-"$(_find_executable "${ENKIT_PATHS[@]}")"}"
+
+# Normalize any paths that we get from the environment.  We perform some regex
+# matches using these paths, and spurious things like extra slashes can trip
+# things up.  "realpath -m" will convert "/foo////bar/bum/" to "/foo/bar/bum".
+if [[ -n "${GEE_DIR}" ]]; then
+  GEE_DIR="$(realpath -m "${GEE_DIR}")"
+fi
+if [[ -n "${GEE_REPO_DIR}" ]]; then
+  GEE_REPO_DIR="$(realpath -m "${GEE_REPO_DIR}")"
+fi
+
+if [[ -z "${REPO}" ]]; then
+  # Examine the directory to see if we're in a repo already.
+  # Try GEE_DIR if set:
+  if [[ -n "${GEE_DIR}" ]] && [[ "${PWD}" =~ ^"${GEE_DIR}/\([a-zA-Z0-9_-]+)" ]]; then
+    REPO="${BASH_REMATCH[1]}"
+  # Try the test directory layout:
+  elif [[ "${PWD}" =~ ^${HOME}/testgee/([a-zA-Z0-9_-]+) ]]; then
+    TESTMODE=1
+    REPO="${BASH_REMATCH[1]}"
+  # Try the new directory layout:
+  elif [[ "${PWD}" =~ ^${HOME}/gee/([a-zA-Z0-9_-]+) ]]; then
+    REPO="${BASH_REMATCH[1]}"
+  # Try the old directory layout:
+  elif [[ "${PWD}" =~ ^${HOME}/([a-z0-9_-]+)/branches ]]; then
+    REPO="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# If all else fails, default to internal
+if [[ -z "${REPO}" ]]; then
+  REPO=internal
+fi
+
+# Set GEE_REPO_DIR:
+GEE_DIR="${GEE_DIR:-"${HOME}/gee"}"
+GEE_REPO_DIR="${GEE_REPO_DIR:-"${GEE_DIR}/${REPO}"}"
+if (( "${TESTMODE}" )); then
+  UPSTREAM="enfabrica"
+  REPO="github-playground"
+  GEE_DIR="${HOME}/testgee"
+  GEE_REPO_DIR="${GEE_DIR}/${REPO}"
+fi
+# Now that GEE_REPO_DIR is set, GEE_REPO_DIR should be used exclusively and GEE_DIR
+# should be ignored.
+
+function safe_tput() {
+  if [[ -z "${TERM}" ]] || [[ "${TERM}" == "none" ]]; then
+    return
+  fi
+  tput "$@"
+}
+
+# colors library
+#
+# The user can override these colors by setting any of these
+# variables in their environment.
+GEE_COLOR_CMD_FG="${GEE_COLOR_CMD_FG:-16}"
+GEE_COLOR_CMD_BG="${GEE_COLOR_CMD_BG:-12}"
+GEE_COLOR_BANNER_FG="${GEE_COLOR_BANNER_FG:-15}"
+GEE_COLOR_BANNER_BG="${GEE_COLOR_BANNER_BG:-21}"
+GEE_COLOR_DBG_FG="${GEE_COLOR_DBG_FG:-2}"
+GEE_COLOR_DBG_BG="${GEE_COLOR_DBG_BG:-0}"
+GEE_COLOR_DIE_FG="${GEE_COLOR_DIE_FG:-16}"
+GEE_COLOR_DIE_BG="${GEE_COLOR_DIE_BG:-9}"
+GEE_COLOR_WARN_FG="${GEE_COLOR_WARN_FG:-11}"
+GEE_COLOR_WARN_BG="${GEE_COLOR_WARN_BG:-0}"
+GEE_COLOR_INFO_FG="${GEE_COLOR_INFO_FG:-6}"
+GEE_COLOR_INFO_BG="${GEE_COLOR_INFO_BG:-0}"
+
+_COLOR_RST="$(safe_tput sgr0)"
+_COLOR_CMD="$(    safe_tput bold; safe_tput setaf "${GEE_COLOR_CMD_FG}";    safe_tput setab "${GEE_COLOR_CMD_BG}")"
+_COLOR_BANNER="$( safe_tput bold; safe_tput setaf "${GEE_COLOR_BANNER_FG}"; safe_tput setab "${GEE_COLOR_BANNER_BG}")"
+_COLOR_DBG="$(                    safe_tput setaf "${GEE_COLOR_DBG_FG}";    safe_tput setab "${GEE_COLOR_DBG_BG}")"
+_COLOR_DIE="$(    safe_tput bold; safe_tput setaf "${GEE_COLOR_DIE_FG}";    safe_tput setab "${GEE_COLOR_DIE_BG}")"
+_COLOR_WARN="$(                   safe_tput setaf "${GEE_COLOR_WARN_FG}";   safe_tput setab "${GEE_COLOR_WARN_BG}")"
+_COLOR_INFO="$(                   safe_tput setaf "${GEE_COLOR_INFO_FG}";   safe_tput setab "${GEE_COLOR_INFO_BG}")"
+
+##########################################################################
+# utility functions
+#
+# (the good stuff, the commands, are in the next section below.)
+##########################################################################
+
+function _to_gee_log() {
+  # fail functional for r/o filesystems.
+  ( cat - >>"${GEE_LOG_FILE}" || /bin/true) 2>/dev/null
+}
+
+function _rotate_gee_log() {
+  if [[ -f "${GEE_LOG_FILE}" ]]; then
+    local size
+    size="$(stat -c%s "${GEE_LOG_FILE}")"
+    if (( size > 65536 )); then
+      savelog -n -c 9 -C -p "${GEE_LOG_FILE}" 1>&2 || /bin/true
+    fi
+  fi
+  if [[ ! -f "${GEE_LOG_FILE}" ]]; then
+    date | _to_gee_log
+  fi
+}
+
+function _parse_options() {
+  # _parse_options <optstring> <args...>
+  #
+  # This function populates the global FLAGS associative array with all
+  # of the set flags.  Any remaining positional arguments are left behind
+  # in the ARGS_POSITIONAL array
+  export FLAGS=()
+  export ARGS_POSITIONAL=()
+  local optstring="$1"; shift
+  local arg
+  OPTERR=0  # enable silent error reporting
+  while [[ $# -gt 0 ]]; do
+    unset OPTARG
+    unset OPTIND
+    while getopts "${optstring}" arg; do
+      if [[ "${arg}" == "?" ]]; then
+        local x
+        x=$((OPTIND-1))
+        _fatal "Bad command flag: ${!x}"
+      fi
+      FLAGS["${arg}"]="${OPTARG:-1}"
+    done
+    shift $((OPTIND-1))
+    if [[ $# -gt 0 ]]; then
+      ARGS_POSITIONAL+=( "$1" )
+      shift
+    fi
+  done
+  return 0
+}
+
+function _contains_element() {
+  # Returns true if the first argument is present in one of the subsequent
+  # arguements.
+  local MATCH="$1"
+  shift
+  local E
+  for E in "$@"; do
+    if [[ "$E" == "${MATCH}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+function _egrep_array() {
+  # Usage: _egrep_array <output> <regex> <elements...>
+  #
+  # Filters a list of elements by a regex, and stores an array of those
+  # filtered elements into the specified "output" variable.
+  local OUTPUT="$1"
+  local REGEX="$2"
+  unset "${OUTPUT}"
+  declare -a "${OUTPUT}"
+  readarray -t "${OUTPUT}" < <( printf "%s\n" "$@" | grep -E "${REGEX}" | cat )
+}
+
+function _set_alias_if_missing() {
+  # Creates a git alias, only if one does not already exist.
+  local ALIAS="$1"
+  local DEFN="$2"
+  if ! "${GIT}" config --get "alias.${ALIAS}" >/dev/null; then
+    _git config --global "alias.${ALIAS}" "${DEFN}"
+  fi
+}
+
+function _set_main_by_asking_github() {
+  _check_ssh
+  local UPSTREAM_URL
+  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
+  MAIN="$(
+    "${GIT}" remote show "${UPSTREAM_URL}" \
+      | awk '/HEAD branch/ {print $NF}'
+  )"
+  if [[ -z "${MAIN}" ]]; then
+    _die "Can't identify default branch for ${UPSTREAM_URL}."
+  fi
+}
+
+function _set_main() {
+  # Sets the ${MAIN} global variable to be the name of the main branch of the
+  # current repository.  Usually "main" or "master," but not always.
+
+  # Use a cached result if available:
+  if [[ -n "${MAIN}" ]]; then return; fi
+
+  # Try to guess the default branch by examining which branches exist on
+  # the local filesystem.
+  if [[ -d "${GEE_REPO_DIR}/main" ]] && [[ -d "${GEE_REPO_DIR}/master" ]]; then
+    # oh no, the user has both main and master available.  Refuse to
+    # guess and ask github.
+    _warn "Confusing!  You have both \"main\" and \"master\" branches."
+  elif [[ -d "${GEE_REPO_DIR}/main" ]]; then
+    MAIN=main
+    return
+  # Fall back to "master" if "main" doesn't exist:
+  elif [[ -d "${GEE_REPO_DIR}/master" ]]; then
+    MAIN=master
+    return
+  fi
+
+  # Ok, let's ask github:
+  _set_main_by_asking_github
+}
+
+function _set_ghuser() {
+  # Attempts to ensure that the GHUSER environment variable is set correctly.
+  # If GHUSER is unset, _set_ghuser first tries to get the username from
+  # github.  Failing that, the default username of $(whoami)-enf is set.
+  if [[ -n "${GHUSER}" ]]; then
+    return 0
+  fi
+
+  # try to get ghuser from ssh interface:
+  local OUTPUT
+  set +e
+  OUTPUT="$(ssh -T "${GIT_AT_GITHUB}" 2>&1)"
+  set -e
+  if [[ "${OUTPUT}" =~ ^Hi\ ([a-zA-Z0-9_-]+) ]]; then
+    GHUSER="${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  # let's just ask the user
+  _warn "Can't automatically determine your github username."
+  if [[ -z "${USER}" ]]; then
+    USER="$(whoami)"
+  fi
+  if [[ -n "${USER}" ]]; then
+    GHUSER="${USER}-enf"
+  fi
+  if (( ! YESYESYES )); then
+    read -r -i "${GHUSER}" -p "What is your github username?  " -e GHUSER
+  fi
+
+  if [[ -z "${GHUSER}" ]]; then
+    _fatal "Cannot proceed without a github username."
+  fi
+  if _confirm_default_no \
+    "Is it okay to add \"export GHUSER=${GHUSER}\" to your .bashrc file? (y/N)  "
+  then
+    printf "\nexport GHUSER=%q\n" "${GHUSER}" >> ~/.bashrc
+  fi
+}
+
+
+function _check_ssh_agent() {
+  # Check that the ssh-agent is loaded and reachable.
+  if [[ -z "${SSH_AUTH_SOCK}" ]]; then
+    _warn "SSH_AUTH_SOCK is not set."
+    _info "Consider adding to your .bashrc: eval \"\$(${ENKIT} agent print)\""
+    if _confirm_default_no \
+      "Would you like gee to append this line to your .bashrc file now? (y/N)  "
+    then
+      printf "eval \"\$(%s agent print)\"\n" "${ENKIT}" >> ~/.bashrc
+    fi
+    eval "$("${ENKIT}" agent print)"
+    if [[ -z "${SSH_AUTH_SOCK}" ]]; then
+      _fatal "Something is wrong with enkit's ssh agent."
+    fi
+  fi
+  if ! timeout 2 ssh-add -l > /dev/null; then
+    local RC=$?
+    if (( RC == 2 )); then
+      _fatal "Unable to communicate with enkit's ssh agent."
+    fi
+  fi
+}
+
+function _check_enkit_cert() {
+  # Check if we have a valid enkit authentication token.
+  local COUNT
+  COUNT="$("${ENKIT}" agent print | wc -l)"
+  if (( COUNT == 0 )); then
+    _warn "enkit certificate is expired."
+    _info "Please authenticate:"
+    "${ENKIT}" auth "${USER}@enfabrica.net"
+    COUNT="$("${ENKIT}" agent print | wc -l)"
+    if (( COUNT == 0 )); then
+      _fatal "No enkit certificate, aborting."
+    fi
+  fi
+  COUNT="$(timeout 2 ssh-add -l | wc -l)"
+  if (( COUNT == 0 )); then
+    _fatal "enkit's certificate isn't showing up in ssh-agent."
+  fi
+}
+
+function _check_ssh() {
+  # Troubleshoot ssh connection to github.
+
+  # First check if we have an ssh-agent running:
+  _check_ssh_agent
+
+  # Check that the enkit certificate is available
+  _check_enkit_cert
+
+  # Check if we can connect via ssh to github.
+  # Takes 0.7 seconds.  Use only as-needed.
+  local OUTPUT
+  set +e
+  # </dev/null disable's ssh's ability to prompt for a passphrase:
+  OUTPUT="$(ssh -T "${GIT_AT_GITHUB}" </dev/null 2>&1)"
+  set -e
+  if [[ "${OUTPUT}" =~ ^Hi\ ([a-zA-Z0-9_-]+) ]]; then
+    GHUSER="${BASH_REMATCH[1]}"
+    return 0
+  fi
+  _warn "Could not authenticate to github using ssh."
+  _info "ssh -T \"${GIT_AT_GITHUB}\" got:"
+  _info "  ${OUTPUT}"
+
+  if [[ -f "${SSHKEYFILE}" ]]; then
+    _info "Perhaps you need to run: ssh-add ${SSHKEYFILE}"
+    _cmd ssh-add "${SSHKEYFILE}"
+    _info "Trying again..."
+    set +e
+    # Still don't allow a passphrase prompt
+    OUTPUT="$(ssh -T ${GIT_AT_GITHUB} </dev/null 2>&1)"
+    set -e
+    if [[ "${OUTPUT}" =~ ^Hi\ ([a-zA-Z0-9_-]+) ]]; then
+      GHUSER="${BASH_REMATCH[1]}"
+      return 0
+    fi
+    _warn "Still couldn't authenticate to github using ssh."
+    _info "ssh -T ${GIT_AT_GITHUB} got:"
+    _info "  ${OUTPUT}"
+  fi
+
+  # Backstory: a gee user ran into trouble because someone told them to
+  # run "ssh-keygen", which replaced their gee-generated ssh identity
+  # with a new one that now required a passphrase to unlock.  They didn't
+  # realize they needed to enroll their identity using ssh-add.  This
+  # extra code is added to try to diagnose this scenario and provide
+  # a useful help message, if this ever arises again.
+  _info "Perhaps you need to enter a passphrase?  Trying again..."
+  set +e
+  # This time, allow ssh to prompt for a passphrase:
+  OUTPUT="$(ssh -T "${GIT_AT_GITHUB}" 2>&1)"
+  set -e
+  if [[ "${OUTPUT}" =~ ^Hi\ ([a-zA-Z0-9_-]+) ]]; then
+    _info "Success!  It appears you needed to unlock your ssh keyfile with "
+    _info "a passphrase.  Congratulations on better security practices!"
+    _info "However, you will need to occasionally run \"ssh-add\" to"
+    _info "unlock your keyfile and enroll it with the ssh-agent, otherwise"
+    _info "gee will prompt you for your passphrase every time it runs."
+    GHUSER="${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  _warn "After repeated attempts, could not connect to github using ssh."
+  return 1
+}
+
+function _check_gh_auth() {
+  # Check that the gh-cli tool has a valid access token for
+  # communicating with github.
+  local OUTPUT RC
+
+  set +e
+  OUTPUT="$("${GH}" auth status 2>&1)";
+  RC=$?
+  set -e
+  if (( RC != 0 )); then
+    _gh_authenticate
+    if ! "${GH}" auth status; then
+      _fatal "Still can't authenticate to github."
+    fi
+  fi
+}
+
+
+function _check_cwd() {
+  # Check that we're in a directory beneath ~/gee.
+  local DIR
+  DIR="$("${PWD_CMD}")"
+  if ! [[ "$DIR" =~ ^"${GEE_REPO_DIR}" ]]; then
+    echo "${DIR}"
+    _fatal "This command must be run from with a branch directory beneath ~/gee."
+  fi
+}
+
+function _get_ghuser_via_ssh() {
+  # Set GHUSER or die.
+  if ! _check_ssh; then
+    _fatal "Could not determine github username."
+  fi
+}
+
+function _startup_checks() {
+  # Ensure that (most) gee commands are run from within the gee repository,
+  # otherwise strange things might happen (if the user's home directory is a
+  # git repository, for instance).
+  local COMMAND="$1"
+
+  # 1. Ensure that a gee repository exists.
+  if [[ ! -d "${GEE_REPO_DIR}" ]]; then
+    _info "Directory ${GEE_REPO_DIR} not found, run \"gee init\" to create."
+    exit 1
+  fi
+  _set_main
+  if [[ ! -d "${GEE_REPO_DIR}/${MAIN}" ]]; then
+    _die "Directory ${GEE_REPO_DIR}/${MAIN} not found." \
+      "Somehow your ${MAIN} branch got removed?"
+    exit 1
+  fi
+
+  # 1.5. Make sure we're not in one of bazel's weird symlink directories.
+  while [[ "$(pwd -P)" != "$(pwd -L)"  ]]; do cd ..; done
+
+  # 2. Ensure that we are in a gee-controlled git repo.  If not,
+  #    switch to the main branch of the git repo, if we are running
+  #    a command on the "safe" list.
+  local -a SAFE_COMMANDS_ARRAY=(
+      "bash_setup"
+      "bazelgc"
+      "cleanup"
+      "codeowners"
+      "config"
+      "create_ssh_key"
+      "diagnose"
+      "diff"
+      "gcd"
+      "get_parent"
+      "hello"
+      "help"
+      "log"
+      "lsbranches"
+      "make_branch"
+      "pack"
+      "pr_check"
+      "pr_checkout"
+      "pr_edit"
+      "pr_list"
+      "pr_make"
+      "pr_push"
+      "pr_rerun"
+      "pr_rollback"
+      "pr_submit"
+      "pr_view"
+      "remove_branch"
+      "repair"
+      "restore_all_branches"
+      "rupdate"
+      "share"
+      "update"
+      "update_all"
+      "upgrade"
+      "version"
+      "whatsout"
+  )
+  # compose into a glob-comparable string, with a space at the start and end:
+  local SAFE_COMMANDS=" ${SAFE_COMMANDS_ARRAY[*]} "
+  local GITDIR
+  if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
+    # not in a git directory
+    _set_main
+    if [[ "${SAFE_COMMANDS}" != *" ${COMMAND} "* ]]; then
+      _fatal "${COMMAND} must be run from within a gee branch."
+    fi
+    cd "${GEE_REPO_DIR}/${MAIN}"
+    if ! GITDIR="$("${GIT}" rev-parse --git-common-dir 2>/dev/null )"; then
+      _fatal "Somehow, ${GEE_REPO_DIR}/${MAIN} is not a git repository."
+    fi
+  fi
+  GITDIR="$(readlink -f "${GITDIR}")"
+  if [[ "${GITDIR}" != "${GEE_REPO_DIR}"/*/.git ]]; then
+    if [[ "${SAFE_COMMANDS}" != *" ${COMMAND} "* ]]; then
+      _fatal "${COMMAND} must be run from within a gee branch."
+    fi
+    _info "Switching to ${GEE_REPO_DIR}/${MAIN}"
+    cd "${GEE_REPO_DIR}/${MAIN}"
+  fi
+
+  # Troubleshoot our environment before running (most) commands.
+  if [[ ! -x "${GIT}" ]]; then
+    _fatal "${GIT} is not installed."
+  fi
+  if [[ ! -x "${GH}" ]]; then
+    _fatal "${GH} is not installed."
+  fi
+
+  # If GHUSER is unset, find username via ssh to github.
+  if [[ -z "${GHUSER}" ]]; then
+    _set_ghuser
+  fi
+
+  local GIT_EMAIL
+  GIT_EMAIL="$("${GIT}" config --get user.email | cat)"
+  if [[ -z "${GIT_EMAIL}" ]]; then
+    _warn "git user.email setting is empty."
+    GIT_EMAIL="${USER}@enfabrica.net"
+    if (( ! YESYESYES )); then
+      read -e -r -i "${GIT_EMAIL}" -p \
+          "What email address should git use for you?   " \
+          GIT_EMAIL
+    fi
+    if [[ -z "${GIT_EMAIL}" ]]; then
+      _fatal "git needs user.email to be set."
+    fi
+    _git config --global user.email "${GIT_EMAIL}"
+  fi
+
+  local GIT_NAME
+  GIT_NAME="$("${GIT}" config --get user.name | cat)"
+  if [[ -z "${GIT_NAME}" ]]; then
+    _warn "git user.name setting is empty."
+    GIT_NAME="${USER}"
+    if (( ! YESYESYES )); then
+      read -e -r -i "${GIT_NAME}" -p \
+        "What name should git use for you?   " \
+        GIT_NAME
+    fi
+    if [[ -z "${GIT_NAME}" ]]; then
+      _fatal "git needs user.name to be set."
+    fi
+    _git config --global user.name "${GIT_NAME}"
+  fi
+
+  # check ssh agent
+  local RC
+  set +e
+  timeout 2 ssh-add -l >/dev/null
+  RC=$?
+  set -e
+  if (( RC == 0 )); then
+    return 0
+  elif (( RC == 1 )); then
+    if [[ -f "${SSHKEYFILE}" ]]; then
+      _cmd ssh-add "${SSHKEYFILE}"
+    fi
+  elif (( RC == 2 )); then
+    _warn "Could not connect to ssh-agent."
+    _info "Consider adding to your .bashrc file: eval \"\$(${ENKIT} agent print)\""
+    if _confirm_default_no \
+      "Would you like gee to append this line to your .bashrc file now? (y/N)  "
+    then
+      printf "eval \"\$(%s agent print)\"\n" "${ENKIT}" >> ~/.bashrc
+    fi
+    eval "$(${ENKIT} agent print)"
+  fi
+
+  set +e
+  timeout 2 ssh-add -l >/dev/null
+  RC=$?
+  set -e
+  if (( RC == 1 )); then
+    _fatal "ssh-agent doesn't report any keys.  Please \"enkit login\" and try again."
+  elif (( RC == 2 )); then
+    _fatal "Persistent failure connecting to ssh-agent."
+  elif (( RC != 0 )); then
+    _fatal "Unknown error from ssh-add command: RC=${RC}"
+  fi
+}
+
+function _gh_auth_check() {
+  # Wrap gh auth check and return correct exit codes on failure,
+  # to work around https://github.com/cli/cli/issues/8845
+  local -a RESULT=()
+  # Check gh auth status:
+  if _read_cmd RESULT "${GH}" auth status; then
+    if [[ "${RESULT[1]}" =~ Failed ]]; then
+      _error "gh auth status command failed.  Do you have a valid github API token?"
+      return 1
+    fi
+  else
+    return 1
+  fi
+  # Check if we have the right token scopes:
+  local SCOPES=""
+  SCOPES="$("${GH}" api --verbose / | grep X-Oauth-Scopes: )"
+  MISSING=""
+  for S in "read:org" "repo" "admin:public_key" "admin:ssh_signing_key"; do
+    if ! [[ "${SCOPES}" == *"${S}"* ]]; then
+      MISSING+=" ${S}"
+    fi
+  done
+  if [[ -n "${MISSING}" ]]; then
+    _error "Your github API token is missing the following permissions: ${MISSING}"
+    return 1
+  fi
+  _info "All github API permissions present."
+  return 0
+}
+
+function _gh_authenticate() {
+  local TRIES=3
+
+  while ! _gh_auth_check; do
+    if [[ "$TRIES" -eq 0 ]]; then
+      _fatal "Failed to authenticate to github.  Join \"git help\" chatroom and ask for help?"
+    fi
+    _info \
+      "You are not currently authenticated to github.  We need to create a github" \
+      "authentication token for you before we can proceed." \
+      "" \
+      "To create a github authentication token:" \
+      "" \
+      "1. Open in a web browser: https://github.com/settings/tokens/new" \
+      "2. Log in to github, if you aren't already." \
+      "3. Fill in the \"Note\" field with something descriptive." \
+      "4. Select a reasonable Expiration duration (90 days is recommended)." \
+      "5. Click to enable the following permissions:" \
+      "   * \"repo\" (enables the whole sub-tree of permissions)" \
+      "   * \"read:org\" (below the \"admin:org\" permission tree)" \
+      "   * \"admin:public_key\" (enables the whole sub-tree of permissions)" \
+      "6. Finally, click \"Generate token\" at the bottom of the form." \
+      ""
+    local TOKEN=""
+    read -rp "Paste your github authentication token here: " TOKEN
+    _info "Trying to authenticate using your token..."
+    # Note: the auth --insecure-storage flag is not supported on all versions of gh.
+    if ! _gh auth login -p ssh -h github.com --with-token <<< "${TOKEN}"; then
+      _warn "\"gh auth login\" failed with exit code $?" ""
+      echo ""
+    fi
+    TRIES="$(( TRIES - 1 ))"
+  done
+}
+
+function _ssh_enroll() {
+  # Enroll the user for ssh access to github by creating and uploading a keyfile.
+  if [[ -z "${SSH_AUTH_SOCK}" ]]; then
+    _warn "No ssh-agent is running."
+    _info "Please add to your .bashrc: eval \"\$(${ENKIT} agent print)\""
+    if _confirm_default_no \
+      "Would you like gee to append this line to your .bashrc file now? (y/N)  "
+    then
+      printf "eval \"\$(%s agent print)\"\n" "${ENKIT}" >> ~/.bashrc
+    fi
+    eval "$(${ENKIT} agent print)"
+  fi
+  if [[ -z "${SSH_AUTH_SOCK}" ]]; then
+    _fatal "gee requires ssh-agent to be running.  Fix and retry."
+  fi
+
+  if [[ ! -f "${SSHKEYFILE}" ]]; then
+    _cmd ssh-keygen -f "${SSHKEYFILE}" -t ed25519 -C "${USER}@enfabrica.net"
+  else
+    _info "Reusing existing ${SSHKEYFILE}"
+  fi
+  if [[ ! -f "${SSHKEYFILE}" ]]; then
+    _fatal "Key file ${SSHKEYFILE} was not created."
+  fi
+
+  local COUNT
+  COUNT="$("${ENKIT}" agent list | wc -l)"
+  if (( COUNT == 0 )); then
+    _warn "No enkit certificates are present."
+    _info "Let's try authenticating:"
+    "${ENKIT}" auth "${USER}@enfabrica.net"
+    COUNT="$("${ENKIT}" agent list | wc -l)"
+    if (( COUNT == 0 )); then
+      _die "Still could not find any enkit certificates."
+    fi
+  fi
+
+  local COUNT
+  COUNT="$("${ENKIT}" agent list | wc -l)"
+  if (( COUNT == 0 )); then
+    _warn "No enkit certificates are present."
+    _info "Let's try authenticating:"
+    "${ENKIT}" auth "${USER}@enfabrica.net"
+    COUNT="$("${ENKIT}" agent list | wc -l)"
+    if (( COUNT == 0 )); then
+      _die "Still could not find any enkit certificates."
+    fi
+  fi
+
+  # TODO(jonathan): Is this necessary?
+  if [[ "${SSHKEYFILE}" != "${SSHKEYFILES[0]}" ]]; then
+    cat <<EOT >> ~/.ssh/config
+# gee: block start
+Host *.github.com github.com
+  IdentityFile ${SSHKEYFILE}
+# gee: block stop
+EOT
+  fi
+
+  _cmd ssh-add "${SSHKEYFILE}"
+  _gh config set git_protocol ssh
+
+  _info "Checking your access to github using the \"gh\" tool:"
+  _gh_authenticate
+
+  if ! _gh ssh-key add "${SSHKEYFILE}.pub" --title "gee-created-key"; then
+    _warn "Could not add your key to github (maybe it's already there?)."
+  fi
+
+  _gh ssh-key list
+
+  if ! _check_ssh; then
+    _fatal "Something still wrong: can't authenticate to github via ssh."
+  fi
+}
+
+function _register_help() {
+  # Registers help text about a gee command.
+  #
+  # Usage: _register_help <command> <shorthelp> <aliases...>
+  #
+  # The "long help" for this command must be presented to this
+  # function as stdin.
+  local COMMAND SHORT LONG ALIAS
+  COMMAND="$1"
+  shift
+  SHORT="$1"
+  shift
+  LONG="$(</dev/stdin)"
+  HELP+=( "${COMMAND}: ${SHORT}" )
+  local -a ALIASES
+  ALIASES=("$@")
+  if (( "${#ALIASES[@]}" > 0 )); then
+    LONG="Aliases: ${ALIASES[*]}${NEWLINE}${NEWLINE}${LONG}"
+  fi
+  LONGHELP+=(["${COMMAND}"]="${LONG}")
+  for ALIAS in "${ALIASES[@]}"; do
+    LONGHELP+=(["${ALIAS}"]="${LONG}")
+  done
+}
+
+function _get_parent_branch() {
+  # Return the name of the branch that is the parent of this
+  # branch.
+  local BRANCH
+  BRANCH="$1"
+  if [[ -z "${BRANCH}" ]]; then
+    BRANCH="$(_get_current_branch)"
+  fi
+
+  _read_parents_file
+  # BRANCH should be in the parents file.  Let's check there first:
+  if [[ -v PARENTS["${BRANCH}"] ]]; then
+    echo "${PARENTS[$BRANCH]}"
+    return
+  fi
+
+  _set_main
+  if [[ "${BRANCH}" == "${MAIN}" ]]; then
+    # Parent of $MAIN is always upstream/$MAIN.
+    PARENTS["${BRANCH}"]="upstream/${MAIN}"
+    echo "upstream/${MAIN}"
+    return
+  fi
+
+  _warn "Strangely, ${BRANCH} was missing from ${GEE_REPO_DIR}/.gee/parents."
+
+  # The safest thing to do is to just set parent to $MAIN and move on.
+  PARENTS["${BRANCH}"]="${MAIN}"
+  echo "${MAIN}"
+}
+
+function _gee_get_all_children_of() {
+  local PARENT="$1"
+  local -a QUEUE=( "${PARENT}" )
+  local -A KIDSMAP=()
+  _read_parents_file  # populate PARENTS associative array
+  while [[ "${#QUEUE[@]}" -ne 0 ]]; do
+    PARENT="${QUEUE[0]}"
+    QUEUE=("${QUEUE[@]:1}")  # shift QUEUE
+    for CHILD in "${!PARENTS[@]}"; do
+      if [[ "${PARENTS["${CHILD}"]}" == "${PARENT}" ]]; then
+        if ! [[ -v "KIDSMAP[${CHILD}]" ]]; then
+          KIDSMAP["${CHILD}"]=1
+          QUEUE+=("${CHILD}")
+        fi
+      fi
+    done
+  done
+  printf "%q\n" "${!KIDSMAP[@]}" | sort
+}
+
+function _update_branch_to_worktree() {
+  # Initialize the global BRANCH_TO_WORKTREE associative array with
+  # a mapping of branch names onto worktree paths.
+  #
+  # Unfortunately, the output of git worktree list isn't exactly what
+  # we need.  For branches that are in a detached state, git only
+  # tells us that the branch is "detached".  For example:
+  #
+  #   worktree /home/hanu/gee/internal/master
+  #   HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
+  #   branch refs/heads/master
+  #
+  #   worktree /home/hanu/gee/internal/cmn_reg
+  #   HEAD b144e5c34ff7bd8f24717337bde4bfd03fc649d0
+  #   detached
+  #
+  # For "detached" branches, we need to directly query .git meta
+  # data directories to determine the branch name.  This is a bit
+  # hacky, so I fall back on using the basename of the directory
+  # as the branch name if all else fails.
+  BRANCH_TO_WORKTREE=()  # global
+  local LINE WT BR
+  _set_main
+  while IFS="" read -r LINE; do
+    if [[ "${LINE}" =~ ^worktree\ (.+) ]]; then
+      WT="${BASH_REMATCH[1]}"
+    elif [[ "${LINE}" =~ ^branch\ refs/heads/(.+) ]]; then
+      BR="${BASH_REMATCH[1]}"
+      BRANCH_TO_WORKTREE["${BR}"]="${WT}"
+    elif [[ "${LINE}" =~ ^detached ]]; then
+      if [[ ! -d "${WT}" ]]; then
+        # ignore pruneable worktrees that don't exist anymore.
+        continue
+      fi
+      BR="$(
+        cd "${WT}";
+        for loc in rebase-merge rebase-apply; do
+          GDIR=$("${GIT}" rev-parse --git-path "${loc}");
+          if [[ -d "${GDIR}" ]]; then
+            HEADNAME="$(<"${GDIR}/head-name")"
+            echo "${HEADNAME##refs/heads/}"
+            break
+          fi
+        done
+      )"
+      if [[ -z "${BR}" ]]; then
+        BR="$(basename "${WT}")"
+      fi
+      BRANCH_TO_WORKTREE["${BR}"]="${WT}"
+    elif [[ "${LINE}" == "" ]]; then
+      WT=""
+      BR=""
+    fi
+  done < <(cd "${GEE_REPO_DIR}/${MAIN}"; "${GIT}" worktree list --porcelain ) \
+    || /bin/true
+}
+
+function _get_branch_rootdir() {
+  # Return the root directory of a git branch
+  local BRANCH_NAME BRDIR
+  BRANCH_NAME="$1"
+  if [[ -z "${BRANCH_NAME}" ]]; then
+	  BRANCH_NAME="$(_get_current_branch)"
+  fi
+  _update_branch_to_worktree
+  BRDIR="${BRANCH_TO_WORKTREE["${BRANCH_NAME}"]}"
+  if [[ -z "${BRDIR}" ]]; then
+    _die "_get_branch_rootdir failed for ${BRANCH_NAME}"
+  fi
+  echo "${BRDIR}"
+}
+
+function _choose_one() {
+  local PROMPT="$1"
+  local OPTIONS="$2"
+  local DEFAULT="$3"
+  declare -g RESP="${DEFAULT}"
+  if (( YESYESYES )); then
+    echo "${PROMPT}: default to ${DEFAULT}"
+    return 0
+  fi
+  while /bin/true; do
+    read -rp "${PROMPT}"  RESP
+    if [[ -z "${RESP}" ]]; then
+      RESP="${DEFAULT}"
+    fi
+    case "${RESP}" in
+      ["${OPTIONS}"]*) return 0;
+    esac
+    echo "Invalid response: ${RESP} must be one of ${OPTIONS}"
+  done
+}
+
+function _confirm_default_yes() {
+  # Ask the user for confirmation, defaulting to "yes."
+  # Returns true if the user confirms.
+  local _PROMPT RESP
+  _PROMPT="$*"
+  if [[ -z "${_PROMPT}" ]]; then
+    _PROMPT="Confirm? (y/N)  "
+  fi
+  if (( YESYESYES )); then echo "${_PROMPT}: yesyesyes"; return 0; fi
+  read -rp "${_PROMPT}" RESP
+  case "${RESP}" in
+    [Nn]*) return 1 ;;
+    *)     return 0 ;;
+  esac
+}
+
+function _confirm_default_no() {
+  # Ask the user for confirmation, defaulting to "no."
+  # Returns true if the user confirms.
+  local _PROMPT RESP
+  _PROMPT="$*"
+  if [[ -z "${_PROMPT}" ]]; then
+    _PROMPT="Confirm? (y/N)  "
+  fi
+  if (( YESYESYES )); then echo "${_PROMPT}: yesyesyes"; return 0; fi
+  read -rp "${_PROMPT}" RESP
+  case "${RESP}" in
+    [Yy]*) return 0 ;;
+    *)     return 1 ;;
+  esac
+}
+
+function _confirm_or_exit() {
+  # Ask the user for confirmation, defaulting to "no."
+  # Terminates gee if the user does not confirm.
+  if ! _confirm_default_no "$@"; then
+    _fatal "Exiting."
+  fi
+}
+
+# "The developer wants to read this."
+function _debug() {
+  if (( "${DEBUG:-0}" > 0 )); then
+    printf "  dbg: %s\n" "$@" | _to_gee_log
+    printf >&2 "${_COLOR_DBG}DBG: %s${_COLOR_RST}\n" "$@"
+  fi
+}
+
+# "The user wants to read this."
+function _info() {
+  if (( "${DEBUG:-0}" > 0 )); then
+    printf "  info: %s\n" "$@" | _to_gee_log
+  fi
+  printf >&2 "${_COLOR_INFO}%s${_COLOR_RST}\n" "$@"
+}
+
+# "The user needs this to visually separate information."
+function _banner() {
+  local COLS LEN BAR BLANK
+  COLS="$(safe_tput cols)"
+  COLS="$(( COLS - 1 ))"
+  LEN="$( printf "%s\n" "$@" | wc -L )"
+  if (( LEN > (COLS-4) )); then
+    LEN="$(( COLS - 4 ))"
+  fi
+  BAR="$(head -c "$(( LEN + 4 ))" /dev/zero | tr '\0' '#')"
+  BLANK="$(head -c "$(( COLS - LEN - 4 ))" /dev/zero | tr '\0' ' ')"
+  printf >&2 "\n"
+  printf >&2 "%s%s%s\n" "${_COLOR_BANNER}" "${BAR}" "${BLANK}"
+  printf >&2 "# %-${LEN}.${LEN}s #${BLANK}\n" "$@"
+  printf >&2 "%s%s%s\n" "${BAR}" "${BLANK}" "${_COLOR_RST}"
+}
+
+
+# Warn the user.  "The user should know this."
+function _warn() {
+  printf "  warn: %s\n" "$@" | _to_gee_log
+  printf >&2 "${_COLOR_WARN}WARNING: %s${_COLOR_RST}\n" "$@"
+}
+
+# Use _fatal for user errors that don't require a stack dump.
+# "The user is going to be sad when they see this."
+function _fatal() {
+  local COLS LINE LEN BLANK
+  printf "  fatal: %s\n" "$@" | _to_gee_log
+  COLS="$(safe_tput cols)"
+  for LINE in "$@"; do
+    LEN="$( printf "%s\n" "$@" | wc -L )"
+    BLANK="$(head -c "$(( COLS - LEN - 8 ))" /dev/zero | tr '\0' ' ')"
+    printf >&2 "${_COLOR_DIE}FATAL: %s%s${_COLOR_RST}\n" "${LINE}" "${BLANK}"
+  done
+  ABNORMAL=0  # we died intentionally.
+  exit 1
+}
+
+# Use _die to report internal errors that require a stack dump.
+# "The user is going to be mad when they see this."
+function _die() {
+  local COLS LINE LEN BLANK
+  printf "  die: %s\n" "$@" | _to_gee_log
+  COLS="$(safe_tput cols)"
+  for LINE in "$@"; do
+    LEN="$( printf "%s\n" "$@" | wc -L )"
+    BLANK="$(head -c "$(( COLS - LEN - 8 ))" /dev/zero | tr '\0' ' ')"
+    printf >&2 "${_COLOR_DIE}FATAL: %s%s${_COLOR_RST}\n" "${LINE}" "${BLANK}"
+  done
+  if [[ -z "${NOSTACK}" ]]; then
+    echo >&2 "Stack trace:"
+    local i
+    i=0
+    while caller "${i}"; do
+      (( i++ ))
+    done
+  fi
+  printf >&2 "Please notify: jonathan@enfabrica.net\n"
+  exit 1
+}
+
+function _cmd() {
+  # Run a command and generate associated log messages.
+  #
+  # The complexity of this function's logging is all the proof anyone
+  # should need that this script should have been written in python.
+  #
+  # The following globals affect the behavior of this function:
+  #
+  #    DRYRUN: prints the command that would be executed instead of executing it.
+  #    VERBOSE: if VERBOSE > 0, then the command is display before execution.
+  #    LCF_ENABLED: enable for the ERR trap function
+  #    NOFAIL: always succeed regardless of exit code
+  local COLS ESCAPED_CMD
+  COLS="$(safe_tput cols)"
+  ESCAPED_CMD="$( printf " %q" "$@")"
+  echo "  cmd: ${ESCAPED_CMD}" | _to_gee_log
+  if [[ $DRYRUN -eq 0 ]]; then
+    if [[ $VERBOSE -gt 0 ]]; then
+      local C
+      C=$(( COLS - 4 ))
+      printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" "${ESCAPED_CMD}"
+    fi
+    local RC LCF_ENABLED_PREV
+    set +e
+    LCF_ENABLED_PREV="${LCF_ENABLED}"
+    LCF_ENABLED=0
+    "$@"
+    RC=$?
+    set -e
+    LCF_ENABLED="${LCF_ENABLED_PREV}"
+    if [[ "${RC}" -eq 0 ]]; then
+      return 0
+    else
+      _warn "Command $* failed with exit code ${RC}"
+      if [[ -n "${NOFAIL}" ]]; then
+        return 0
+      fi
+    fi
+    return "${RC}"
+  else
+    local C
+    C=$(( COLS - 7 ))
+    printf >&2 "${_COLOR_CMD}DRYRUN:%-${C}s${_COLOR_RST}\n" "${ESCAPED_CMD}"
+  fi
+}
+
+function _read_cmd() {
+  # Run a command, and save each line of output to an array variable.
+  local VAR="$1"; shift
+
+  local COLS ESCAPED_CMD
+  COLS="$(safe_tput cols)"
+  ESCAPED_CMD="$( printf " %q" "$@")"
+  if [[ $DRYRUN -eq 0 ]]; then
+    if [[ $VERBOSE -gt 0 ]]; then
+      local C
+      C=$(( COLS - 4 ))
+      printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" "${ESCAPED_CMD}"
+    fi
+    set +e
+    # We want to capture the return code, but not trigger an ERR trap:
+    if (( GRAB_STDERR )); then
+      mapfile -t "${VAR}" < <( 2>&1 "$@" && echo "$?" || echo "$?")
+    else
+      mapfile -t "${VAR}" < <("$@" && echo "$?" || echo "$?")
+    fi
+    local TMP
+    TMP="${VAR}[-1]"
+    RC="${!TMP}"  # indirect
+    unset "${VAR}[-1]"
+    if [[ "${RC}" -ne 0 ]]; then
+      [[ $DONT_WARN -eq 0 ]] && _warn "Command returned non-zero exit code: ${RC}"
+      if [[ -n "${NOFAIL}" ]]; then
+        RC=0
+      fi
+    fi
+    set -e
+    if [[ "${READ_CMD_ECHO}" == 1 ]]; then
+      local VAR_ITEMS="${VAR}[@]"
+      printf >&2 "%s\n" "${!VAR_ITEMS}"
+    fi
+    return "${RC}"
+  else
+    local C
+    C=$(( COLS - 7 ))
+    printf >&2 "${_COLOR_CMD}DRYRUN:%-${C}s${_COLOR_RST}\n" "${ESCAPED_CMD}"
+  fi
+}
+
+function _gh() {
+  # Invoke gh
+  _cmd "${GH}" "$@"
+}
+
+function _git() {
+  # Invoke git
+  _cmd "${GIT}" "$@"
+}
+
+function _silent_cmd() {
+  # Run a command and don't write anything to stdout.
+  local ESCAPED_CMD
+  ESCAPED_CMD="$( printf " %q" "$@")"
+  if [[ $DRYRUN -eq 0 ]]; then
+    set +e
+    "$@" > /dev/null
+    RC=$?
+    set -e
+    if [[ "${RC}" -ne 0 ]]; then
+      _info "CMD: ${ESCAPED_CMD}"
+      if [[ -z "${NOFAIL}" ]]; then
+        _fatal "Command failed with exit code ${RC}"
+      else
+        _warn "Command failed with exit code ${RC}"
+      fi
+    fi
+    return "${RC}"
+  fi
+}
+
+function _git_can_fail() {
+  # Invoke git, but don't exit if git returns a non-zero exit code.
+  NOFAIL=1 _git "$@"
+}
+
+function _git_rev_list_counts() {
+  local B="$1"
+  local P="$2"
+
+  if [[ "${B}" == upstream/refs/pull/*/head ]]; then
+    "${GIT}" fetch --quiet --force upstream "${B#upstream/refs/}:FETCH_HEAD_B" >/dev/null 2>&1
+    B=FETCH_HEAD_B
+  elif [[ "${B}" == */* ]]; then
+    "${GIT}" fetch --quiet --force "${B%%/*}" "${B#upstream/}:FETCH_HEAD_B" >/dev/null 2>&1
+    B=FETCH_HEAD_B
+  fi
+  if [[ "${P}" == upstream/refs/pull/*/head ]]; then
+    "${GIT}" fetch --quiet --force upstream "${P#upstream/refs/}:FETCH_HEAD_P" >/dev/null 2>&1
+    P=FETCH_HEAD_P
+  elif [[ "${P}" == */* ]]; then
+    "${GIT}" fetch --quiet --force "${P%%/*}" "${P#upstream/}:FETCH_HEAD_P" >/dev/null 2>&1
+    P=FETCH_HEAD_P
+  fi
+  "${GIT}" rev-list --left-right --count "${B}...${P}" || /bin/true
+}
+
+function _install_tools() {
+  # Checks for and installs any missing tools.
+
+  # If your dev image is missing the github-cli tool, this should install it.
+  if [ ! -x "${GH}" ]; then
+    _info "Installing missing tool: gh"
+    local KRFILE; KRFILE="/usr/share/keyrings/githubcli-archive-keyring.gpg"
+    /usr/bin/curl -fsSL \
+      https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo /usr/bin/apt-key --keyring "${KRFILE}" add -
+    echo "deb [arch=amd64 signed-by=${KRFILE}] https://cli.github.com/packages stable main" \
+      | sudo /usr/bin/tee /etc/apt/sources.list.d/githubcli-archive.list
+    sudo /usr/bin/apt-get update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt-get install gh
+    GH="$(_find_executable "${GH_PATHS[@]}")"
+    if [ ! -x "${GH}" ]; then
+      _fatal "Could not install gh."
+    fi
+  fi
+
+  if [ ! -x "${JQ}" ]; then
+    _info "Installing missing tool: jq"
+    sudo /usr/bin/apt-get update || /bin/true  # ignore errors associated with stale repos.
+    sudo /usr/bin/apt-get install jq
+    JQ="$(_find_executable "${JQ_PATHS[@]}")"
+    if [ ! -x "${JQ}" ]; then
+      _fatal "Could not install jq."
+    fi
+  fi
+}
+
+function _count_diffs() {
+  # Could the number of files that are different between two branches.
+  local BRANCH_A BRANCH_B DIFFS
+  BRANCH_A="$1"
+  BRANCH_B="$2"
+  "${GIT}" diff --name-only "${BRANCH_A}..${BRANCH_B}" | wc -l
+}
+
+function _branch_has_unstaged_changes() {
+  if "${GIT}" diff --quiet; then
+    # RC=0 means no differences, so return false
+    return 1
+  else
+    # RC=1 means differences were found, so return true
+    return 0
+  fi
+}
+
+function _branch_ahead_behind() {
+  # Report how many commits this branch is ahead/behind another branch.
+  local branch; branch="$1"
+  local obr="$2";
+  _read_parents_file
+  if [[ -z "${obr}" ]]; then
+    obr="$(_get_parent_branch "${branch}")"
+  fi
+  local -a counts
+  read -r -a counts < <(_git_rev_list_counts "${branch}" "${obr}") || /bin/true
+  if [[ "${counts[0]}" == "0" ]] && [[ "${counts[1]}" == "0" ]]; then
+    printf "%-20s: same as %s" "${branch}" "${obr}"
+  else
+    printf "%-20s: %q ahead, %q behind %s" "${branch}" "${counts[0]}" "${counts[1]}" "${obr}"
+  fi
+  if _remote_branch_exists origin "${branch}"; then
+    counts=()
+    read -r -a counts < <("${GIT}" rev-list --left-right --count "${branch}...origin/${branch}") || /bin/true
+    if (( counts[1] > 0 )); then
+      printf ", %d behind %s" "${counts[1]}" "origin/${branch}"
+    fi
+  fi
+  printf "\n"
+}
+
+function _remote_branch_exists() {
+  # Returns true if a remote branch exists (on "origin").
+  local REPO="$1"; shift  # origin?
+  local BRANCH="$1"; shift
+  if [[ -z "${BRANCH}" ]]; then
+    _die "insufficient args"
+  fi
+  local OUTPUT
+  OUTPUT="$("${GIT}" ls-remote "${REPO}" "${BRANCH}")"
+  if [[ -z "${OUTPUT}" ]]; then
+    return "${FALSE}"
+  else
+    return "${TRUE}"
+  fi
+}
+
+function _local_branch_exists() {
+  # Returns true if a local branch exists (even if it's worktree was deleted).
+  # Fixes up the worktree if the branch is missing from the worktree.
+  local BRANCH="$1"; shift
+
+  if [[ "${BRANCH}" == */* ]]; then
+    _warn "${BRANCH}: is not a local branch name."
+    return 1
+  fi
+
+  _set_main
+  if ! "${GIT}" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    return 1  # false
+  fi
+
+  # branch exists, but let's double check that worktree is set up correctly:
+  local BRDIR
+  BRDIR="${GEE_REPO_DIR}/${BRANCH}"
+  if ! [[ -d "${BRDIR}" ]]; then
+    # try to fix worktree.
+    _git worktree add -f "${GEE_REPO_DIR}/${BRANCH}"
+    _info "Created ${BRDIR}"
+  fi
+  _update_branch_to_worktree
+  BRDIR="${BRANCH_TO_WORKTREE["${BRANCH}"]}"
+  if [[ -n "${BRDIR}" ]]; then
+    return 0
+  else
+    _fatal "Branch ${BRANCH} exists but could not create worktree."
+    return 1
+  fi
+}
+
+function _open_rebase_shell() {
+    # Opens an interactive subshell for resolving conflicts during a rebase.
+    # This is the "old" flow, and it's a bit messy.
+    # TODO(jonathan): make the prompts less noisy.
+    local BOLD RST
+    BOLD="$(safe_tput bold)"
+    RST="$(safe_tput sgr0)"
+    export GEE_HELP=""
+    GEE_HELP+="You are interactively rebasing a branch with conflicts.${NEWLINE}"
+    GEE_HELP+="  To see where conflicts are: ${BOLD}git status${RST}${NEWLINE}"
+    GEE_HELP+="  To run a 3-way merge tool: ${BOLD}git mergetool${RST}${NEWLINE}"
+    GEE_HELP+="  To mark a file as fixed: ${BOLD}git add <file>${RST}${NEWLINE}"
+    GEE_HELP+="  To continue rebase after fixing: ${BOLD}git rebase --continue${RST}${NEWLINE}"
+    GEE_HELP+="  To give up and go back to original state: ${BOLD}git rebase --abort${RST}${NEWLINE}"
+    GEE_HELP+="  To return to gee: ${BOLD}exit${RST}${NEWLINE}"
+    _git status
+    _banner "Entering subshell: resolve conflicts or abort and then exit."
+    echo "${GEE_HELP}"
+    set +e
+    bash --noprofile --norc
+    _banner "Subshell terminated with exit code $?."
+    set -e
+}
+
+function _interactive_conflict_resolution() {
+  # The function walks the user through a rebase operation, one conflict at a
+  # time, and gives the user the option to use their file, the upstream file,
+  # skip the commit, run a mergetool, or abort.
+  local PARENT CHILD
+  PARENT="$1"
+  CHILD="$2"
+  ONTO="$3"
+  if [[ -z "${CHILD}" ]]; then
+    _die "Must specify branch name."
+  fi
+  local CHILD_ROOT
+  CHILD_ROOT="${BRANCH_TO_WORKTREE["${CHILD}"]}"
+  cd "${CHILD_ROOT}"
+  local ABORT=0
+  while _is_rebase_in_progress; do
+    local -a STATUS=()
+    mapfile -t STATUS < <( "${GIT}" status --porcelain )
+    # We're merging onto this commit:
+    local ONTO_COMMIT ONTO_DESC
+    ONTO_COMMIT="$("${GIT}" rev-parse HEAD)"
+    ONTO_DESC="$("${GIT}" show --oneline -s "${ONTO_COMMIT}")"
+    # This is the commit we're trying to apply:
+    local FROM_COMMIT FROM_DESC
+    FROM_COMMIT="$("${GIT}" rev-parse REBASE_HEAD)"
+    FROM_DESC="$("${GIT}" show --oneline -s "${FROM_COMMIT}")"
+
+    _banner "Attempting to apply: ${FROM_DESC}" \
+            "               onto: ${ONTO_DESC}"
+    local STATUS_LINE DONE SKIP RESTART
+    SKIP=0
+    RESTART=0
+    if [[ "${#STATUS[@]}" -eq 0 ]]; then
+      _warn "Empty commit, skipping automatically."
+      SKIP=1
+    fi
+    for STATUS_LINE in "${STATUS[@]}"; do
+      local DECODED_ST ST FILE
+      read -r ST FILE <<< "${STATUS_LINE}"
+      case "${ST}" in
+        # TODO(jonathan): do I have "us" and "them" backwards here?
+        ?) DECODED_ST="" ;;  # The no-conflict case
+        DD) DECODED_ST="Both deleted" ;;
+        AU) DECODED_ST="Added by them" ;;
+        UD) DECODED_ST="Deleted by us" ;;
+        UA) DECODED_ST="Added by us" ;;
+        DU) DECODED_ST="Deleted by them" ;;
+        AA) DECODED_ST="Both added" ;;
+        UU) DECODED_ST="Both modified" ;;
+        *)  DECODED_ST="Bizarre!" ;;
+      esac
+      if [[ -z "${DECODED_ST}" ]]; then
+        _info "${FILE}: no conflicts."
+        continue
+      fi
+      _info "${FILE}: ${ST}=${DECODED_ST}"
+
+      local -a MERGE_HELP
+      MERGE_HELP=(
+        "Help:"
+        "   Y = Yours: discard their changes to a file, keeps yours."
+        "   T = Theirs: discard your changes to a file, keeps theirs."
+        "   M = Merge: invokes the merge resolution tool ($("${GIT}" config --get merge.tool))."
+        "   G = Guimerge: invokes the gui merge tool ($("${GIT}" config --get merge.guitool))."
+        "   V = View: view the conflict."
+        "   A = Abort: abort this rebase operation."
+        "   H = Help: this text."
+        ""
+        "Psst!  Secret menu for advanced users:"
+        "   P = Pick: abort this merge, and instead try \"git rebase -i\"."
+        "   S = Shell: drop into interactive shell."
+        "   K = sKip: discard your entire conflicting commit."
+      )
+      DONE=0
+      while (( DONE == 0 )); do
+        local M RESP
+        if (( YESYESYES )); then
+          _warn "YESYESYES is enabled: taking your version automatically."
+          RESP="Y";
+        else
+          read -r -n1 -p \
+            "keep (Y)ours, keep (T)heirs, (M)erge, (G)ui-Merge, (V)iew, (A)bort, or (H)elp? " \
+            RESP
+          printf "\n"
+        fi
+        # https://stackoverflow.com/questions/25576415/what-is-the-precise-meaning-of-ours-and-theirs-in-git
+        # During a rebase operation:
+        # "Ours" = branch being merged into = older version of file.
+        # "Theirs" = branch being merged from = newer version of file.
+        case "${RESP}" in
+          [Yy])
+            _info "${FILE}: Keeping your version from ${FROM_DESC}"
+            _info "${FILE}: Discarding their version from ${ONTO_DESC}"
+            if [[ "${ST}" == "UD" ]]; then
+              # Keep "your" change: deleting the file.
+              yes d | "${GIT}" mergetool -- "${FILE}"
+              echo ""  # git mergetool above sometimes needs a newline here.
+            else
+              "${GIT}" checkout --theirs "${FILE}"  # during rebase, "theirs" is actually ours.
+            fi
+            DONE=1
+            ;;
+          [Tt])
+            _info "${FILE}: Discarding your version from ${FROM_DESC}"
+            _info "${FILE}: Keeping their version from ${ONTO_DESC}"
+            _info "Keeping older ${FILE} from ${ONTO_DESC}"
+            if [[ "${ST}" == "DU" ]]; then
+              # Keep "their" change: deleting the file.
+              yes d | "${GIT}" mergetool -- "${FILE}"
+              echo ""  # git mergetool above sometimes needs a newline here.
+            else
+              "${GIT}" checkout --ours "${FILE}"  # during rebase, "ours" is actually theirs.
+            fi
+            DONE=1
+            ;;
+          [Mm])
+            _git mergetool "${FILE}"
+            M="$("${GIT}" diff --check "${FILE}" | grep -c "conflict marker" | cat)"
+            if (( M == 0 )); then
+              DONE=1
+            else
+              _warn "${FILE} still contains conflict markers."
+            fi
+            ;;
+          [Gg])
+            local GUI_MERGETOOL
+            GUI_MERGETOOL="$(git config --get merge.guitool)"
+            if [[ -z "${GUI_MERGETOOL}" ]]; then
+              GUI_MERGETOOL=meld  # default
+            fi
+            _git mergetool --tool="${GUI_MERGETOOL}" --no-prompt "${FILE}"
+            M="$("${GIT}" diff --check "${FILE}" | grep -c "conflict marker" | cat)"
+            if (( M == 0 )); then
+              DONE=1
+            else
+              _warn "${FILE} still contains conflict markers."
+            fi
+            ;;
+          [Pp])
+            _warn "\"Pick\" will abort and restart your rebase merge from the beginning."
+            if _confirm_default_no "Are you sure you want to restart? (y/N)  "; then
+              _git rebase --abort
+              local -a GITCMD=( rebase --autostash -i )
+              if [[ -n "${ONTO}" ]]; then
+                GITCMD+=( --onto "${ONTO}" )
+              fi
+              GITCMD+=( "${PARENT}" "${CHILD}" )
+              if ! _git "${GITCMD[@]}"; then
+                if ! _is_rebase_in_progress; then
+                  # This should never happen.
+                  _die "Rebase command failed, but rebase is not in progress.  Bug!"
+                fi
+                _warn "Rebase operation had merge conflicts."
+              else
+                _info "Rebase succeeded."
+              fi
+              RESTART=1
+              DONE=1
+            fi
+            ;;
+          [Ss])
+            _open_rebase_shell
+            RESTART=1  # go back to beginning, maybe we're done?
+            DONE=1
+            ;;
+          [Vv])
+            # TODO(jonathan): create a better, colorized viewer for merge conflicts.
+            ( git status; echo ""; echo "${FILE}" ; cat "${FILE}" )  | less -R
+            ;;
+          [Kk])
+            _info "Skipping commit: ${FROM_DESC}"
+            DONE=1
+            SKIP=1
+            ;;
+          [Aa])
+            _info "Aborting rebase, and resetting."
+            DONE=1
+            ABORT=1
+            ;;
+          [Hh])
+            _info "${MERGE_HELP[@]}"
+            ;;
+          *)
+            _warn "Invalid choice: ${RESP}"
+            _info "${MERGE_HELP[@]}"
+            ;;
+        esac
+      done  # DONE
+
+      if (( SKIP == 1 )); then break; fi
+      if (( ABORT == 1 )); then break; fi
+      if (( RESTART == 1 )); then break; fi
+    done  # STATUS_LINE
+
+    if (( SKIP == 1 )); then
+      _git_can_fail rebase --skip | cat
+    fi
+    if (( ABORT == 1 )); then break; fi
+    if (( RESTART == 1 )); then continue; fi
+
+    local -a MARKERS
+    mapfile -t MARKERS < <( "${GIT}" diff --check | grep "conflict marker" | cat )
+
+    if (( "${#MARKERS[@]}" == 0 )); then
+      _git add .
+      _git_can_fail rebase --continue
+    else
+      _warn "Cannot proceed with rebase: conflict markers still present."
+      _info "${MARKERS[@]}"
+      _info "Try again..."
+    fi
+  done  # while rebase is in progress
+
+  _check_diff_for_merge_conflict_markers
+
+  if (( ABORT == 1 )); then
+    _git rebase --abort
+    return
+  fi
+}
+
+function _grep_for_merge_conflict_markers() {
+  grep -E "^((<{6,})|(={6,})|(>{6,}))"
+}
+
+function _check_diff_for_merge_conflict_markers() {
+  if "${GIT}" diff | _grep_for_merge_conflict_markers >/dev/null; then
+    _warn "Uncommited files contain conflict markers: please resolve."
+  fi
+}
+
+function _safer_rebase() {
+  # Performs a safe version of "git rebase $PARENT $CHILD".  If a merge
+  # conflict occurs, invokes gee's conflict resolution flow.
+  #
+  # If ONTO is specified, performs "git rebase --onto $ONTO $PARENT $CHILD"
+  # This last form resets $CHILD to the head of $ONTO, and then replays the
+  # sequence of commits in $CHILD that are not in $PARENT.
+  local CHILD="$1"
+  local PARENT="$2"
+  local ONTO="$3"  # optional
+  local MB=""
+
+  if [[ "$(git config --global rerere.enabled || /bin/true)" != "true" ]]; then
+    _git config --global rerere.enabled true
+  fi
+
+  # check if child branch has an outstanding PR:
+  local -a OPEN_PRS
+  mapfile -t OPEN_PRS < <( _list_open_pr_numbers )
+  if (( "${#OPEN_PRS[@]}" )); then
+    _warn "Open PR exists for branch ${CHILD}: ${OPEN_PRS[*]}"
+    _info "If a reviewer is already looking at your PR, rebasing this branch" \
+          "will break the reviewer's ability to see what has changed when" \
+          "you commit new changes.  Are you sure you want to do this?"
+    if ! _confirm_default_no ; then
+      _warn "Skipped update of branch ${CHILD}."
+      return 0
+    fi
+  fi
+
+  # update BRANCH_TO_WORKTREE before rebasing, as this information
+  # becomes unavailable when in detached head mode:
+  _update_branch_to_worktree
+
+  # TODO(jonathan): check if origin is ahead of local, and if so, do a git pull --rebase
+  # operation.  This will allow multi-homed gee to work better.
+
+  _checkout_or_die "${CHILD}"
+
+  # Check if we're rebasing onto a branch with uncommitted changes:
+  local -a UNCOMMITTED
+  mapfile -t UNCOMMITTED < <( "${GIT}" status --short -uall )
+  if (( "${#UNCOMMITTED[@]}" )); then
+    _warn "Branch ${CHILD} contains ${#UNCOMMITTED[@]} uncommitted changes:" \
+      "${UNCOMMITTED[@]}"
+  fi
+
+  _silent_cmd "${GIT}" tag -f "${CHILD}.REBASE_BACKUP"
+  local CHILD_DIR
+  CHILD_DIR="$(_get_branch_rootdir "${CHILD}")"
+  cd "${CHILD_DIR}"
+  local PARENT_HEAD
+  _get_parent_head_commit PARENT_HEAD "${PARENT}"
+
+  local -a GITCMD=()
+  GITCMD+=( rebase --autostash )
+  if [[ -n "${ONTO}" ]]; then
+    GITCMD+=(--onto "${ONTO}")
+  fi
+  GITCMD+=( "${PARENT_HEAD}" "${CHILD}" )
+
+  _checkout_or_die "${CHILD}"
+  if ! _git "${GITCMD[@]}"; then
+    if ! _is_rebase_in_progress; then
+      # This should never happen.
+      _die "Rebase command failed, but rebase is not in progress.  Bug!"
+    fi
+    _warn "Rebase operation had merge conflicts."
+    _interactive_conflict_resolution "${PARENT}" "${CHILD}" "${ONTO}"
+
+    if _is_rebase_in_progress; then
+      local STATUS
+      mapfile -t STATUS < <( "${GIT}" status );
+      _warn "${STATUS[@]}"
+      _warn "Merge conflict in branch ${CHILD}, must be manually resolved."
+      _fatal "Exited without resolving rebase conflict."
+    fi
+
+    if "${GIT}" merge-base --is-ancestor "${PARENT_HEAD}" HEAD; then
+      _info "Rebase merge confirmed."
+    else
+      _warn "Rebase did not succeed, aborting."
+      return 1
+    fi
+  fi
+  _check_diff_for_merge_conflict_markers
+
+  _info "To undo: git checkout ${CHILD}; git reset --hard ${CHILD}.REBASE_BACKUP"
+  _push_to_origin "+${CHILD}"
+}
+
+function _is_rebase_in_progress() {
+  local RC
+  NOFAIL=1 "${GIT}" rev-parse --verify REBASE_HEAD >/dev/null 2>/dev/null
+  RC=$?
+  if [[ "${RC}" == 0 ]]; then
+    return 0  # rebase is in progress
+  elif [[ "${RC}" == 128 ]]; then
+    return 1  # rebase is not in progress
+  else
+    _die "git rev-parse --verify REBASE_HEAD failed with unexpected code: ${RC}"
+  fi
+}
+
+function _is_cherry_pick_in_progress() {
+  local RC
+  NOFAIL=1 "${GIT}" rev-parse --verify CHERRY_PICK_HEAD >/dev/null 2>/dev/null
+  RC=$?
+  if [[ "${RC}" == 0 ]]; then
+    return 0  # cherry-pick is in progress
+  elif [[ "${RC}" == 128 ]]; then
+    return 1  # cherry-pick is not in progress
+  else
+    _die "git rev-parse --verify CHERRY_PICK_HEAD failed with unexpected code: ${RC}"
+  fi
+}
+
+function _push_to_origin() {
+  local B="$1"
+  if [[ -z "${B}" ]]; then
+    B="$(_get_current_branch)"
+  fi
+  _git push --quiet -u origin "${B}"
+}
+
+
+function _checkout_or_die() {
+  # we want to check out a branch.  Maybe there is already a
+  # worktree.  Maybe we need to create a worktree.  Let's do
+  # whatever is necessary.
+  local BRANCH BRDIR
+  BRANCH="$1"; shift
+
+  if [[ "${BRANCH}" == */* ]]; then
+    _warn "${BRANCH}: is not a local branch name."
+    return 1
+  fi
+
+  # Do we already have a worktree?
+  BRDIR="${GEE_REPO_DIR}/${BRANCH}"
+  if ! [[ -d "${BRDIR}" ]]; then
+    _git worktree add -f "${GEE_REPO_DIR}/${BRANCH}"
+    BRDIR="$(_get_branch_rootdir "${BRANCH}")"
+    _info "Created ${BRDIR}"
+  fi
+  cd "${BRDIR}"
+  local CUR_BRANCH
+  CUR_BRANCH="$(_get_current_branch)"
+  if [[ "${CUR_BRANCH}" != "${BRANCH}" ]]; then
+    _warn "${BRDIR} pointed to branch ${CUR_BRANCH} instead of ${BRANCH}."
+    _git checkout "${BRANCH}"
+    _info "... Fixed."
+  fi
+}
+
+function _in_gee_repo() {
+  if [[ "${PWD}" =~ ^"${GEE_REPO_DIR}" ]]; then
+    return "${TRUE}"
+  else
+    return "${FALSE}"
+  fi
+}
+
+function _in_gee_branch() {
+  if [[ "${PWD}" =~ ^"${GEE_REPO_DIR}"/[a-zA-Z0-9_-]+ ]]; then
+    return "${TRUE}"
+  else
+    return "${FALSE}"
+  fi
+}
+
+function _get_current_branch() {
+  # Outside of a gee repo, current branch is always "main":
+  _set_main
+  if ! _in_gee_repo; then
+    echo "${MAIN}"
+    return
+  fi
+  # Inside of a gee repo, use git rev-parse:
+  local CB
+  CB="$("${GIT}" rev-parse --abbrev-ref HEAD)"
+  if [[ -z "${CB}" ]]; then
+    _die "Could not get current branch in directory $("${PWD}")"
+  fi
+  echo "${CB}"
+}
+
+function _update_from_upstream() {
+  local LOCAL_BRANCH="$1"
+  local UPSTREAM_BRANCH="$2"
+  _checkout_or_die "${LOCAL_BRANCH}"
+  # I don't know why, but sometimes github rejects pull requests right after
+  # merging PRs.
+  #    $ /usr/bin/git pull --rebase --autostash upstream master
+  #    ssh_dispatch_run_fatal: Connection to 192.30.255.113 port 22: Broken pipe
+  #    fatal: Could not read from remote repository.
+  #
+  #    Please make sure you have the correct access rights
+  #    and the repository exists.
+  #
+  # The command always suceeds on retry.  So -- let's just enable retries for
+  # this operation.
+  local TRIES=0
+  local MAX_RETRIES=3
+  while [[ "$TRIES" -lt "$MAX_RETRIES" ]]; do
+    if _git pull --rebase --autostash upstream "${UPSTREAM_BRANCH}"; then
+      # success
+      break
+    fi
+    _warn "Git pull operation failed."
+    if _is_rebase_in_progress; then
+      _interactive_conflict_resolution "upstream/${UPSTREAM_BRANCH}" "${LOCAL_BRANCH}"
+      if _is_rebase_in_progress; then
+        local STATUS
+        mapfile -t STATUS < <( "${GIT}" status );
+        _warn "${STATUS[@]}"
+        _warn "Merge conflict in branch ${LOCAL_BRANCH}, must be manually resolved."
+        _fatal "Exited without resolving rebase conflict."
+      fi
+      # successful merge conflict resolution
+      break
+    fi
+    _info "Retrying..."
+    sleep 1
+    TRIES="$(( TRIES + 1 ))"
+  done
+
+  local -a COUNTS=()
+  read -r -a COUNTS < \
+    <( "${GIT}" rev-list --left-right --count "upstream/${UPSTREAM_BRANCH}...${LOCAL_BRANCH}" | cat) \
+    || /bin/true
+  if (( COUNTS[0] != 0 )); then
+    _fatal "pull failed: upstream/${UPSTREAM_BRANCH} is ${COUNTS[1]} commits ahead of ${LOCAL_BRANCH}"
+  fi
+  _check_diff_for_merge_conflict_markers
+  _push_to_origin "+${MAIN}"
+}
+
+function _update_main() {
+  # Merge from upstream/main into main:
+  local BRANCH
+  BRANCH="$(_get_current_branch)"
+  _set_main
+  _checkout_or_die "${MAIN}"
+  # check for local changes
+  local -a CHANGES
+  read -r -a CHANGES < \
+    <( "${GIT}" diff --name-only | cat) \
+    || /bin/true
+  if [[ "${#CHANGES[@]}" != 0 ]]; then
+    _warn "${MAIN} branch contains uncommitted changes."
+  fi
+  # TODO(jonathan): maybe just use _safer_rebase here instead.
+  _update_from_upstream "${MAIN}" "${MAIN}"
+  _checkout_or_die "${BRANCH}"
+}
+
+# The parents file keeps track of two things:
+#   - parent: the branch that spawned the current branch
+#   - mb: the commit id of the mergebase with the parent branch
+#
+# mb is updated every time a branch is rebased, and is used to keep track of
+# the last mergebase of a child branch, even if the parent branch gets rebased.
+# This allows us to defer rebase operations of children, even after parents get
+# rebased.
+#
+# TODO(jonathan): is there a better way to track this information?
+# TODO(jonathan): maybe we don't need to track MB after all?
+
+# Lazy-load parents metadata:
+function _read_parents_file() {
+  # Update the global PARENTS associative array from a file.
+  if (( PARENTS_FILE_IS_LOADED )); then
+    return
+  fi
+  local PATH="${GEE_REPO_DIR}/.gee/parents"
+  local KEY VALUE
+  if [[ ! -d "${GEE_REPO_DIR}/.gee" ]]; then
+    /usr/bin/mkdir "${GEE_REPO_DIR}/.gee"
+  fi
+  if [[ ! -f "${PATH}" ]]; then
+    /usr/bin/touch "${PATH}"
+  fi
+  local BRANCH PARENT MB
+  while read -r BRANCH PARENT MB; do
+    PARENTS["${BRANCH}"]="${PARENT}"
+    MERGEBASES["${BRANCH}"]="${MERGEBASE}"
+  done < "${PATH}" \
+    || /bin/true
+  # Hack: fixup the parent for the special branch "master":
+  PARENTS["master"]="upstream/master"
+  MERGEBASES["master"]=""
+  PARENTS_FILE_IS_LOADED=1
+}
+
+function _write_parents_file() {
+  # Write back the global PARENTS associative array to a file.
+  if ! (( PARENTS_FILE_IS_LOADED )); then
+    return
+  fi
+  if [[ "${#PARENTS[@]}" -eq 0 ]]; then
+    _warn "Almost wrote empty parents file!"
+    return
+  fi
+  local PATH="${GEE_REPO_DIR}/.gee/parents"
+  if [[ ! -d "${GEE_REPO_DIR}/.gee" ]]; then
+    /usr/bin/mkdir "${GEE_REPO_DIR}/.gee"
+  fi
+  local KEY VALUE MB
+  for KEY in "${!PARENTS[@]}"; do
+    VALUE="${PARENTS["$KEY"]}"
+    MB="${MERGEBASES["$KEY"]}"
+    printf "%q %q %q\n" "${KEY}" "${VALUE}" "${MB}"
+  done > "${PATH}"
+}
+
+ABNORMAL=1
+LCF_ENABLED=0  # enables logging of failed commands.
+function _cleanup() {
+  set +e
+  trap - ERR
+  if (( ABNORMAL == 1 )); then
+    _warn "Abnormal termination: gee unexpectedly exited."
+  fi
+  # Ensure we always save the PARENTS file, even if we die:
+  _write_parents_file
+  # Warn the user if we terminated abnormally (for example, if set -e fired).
+}
+function _log_command_failure() {
+  local lineno="$1"
+  local cmd="$2"
+  local rc="$3"
+  local msg
+  msg="$(printf "gee:%s: command %q failed with rc=%d" "${lineno}" "${cmd}" "${rc}")"
+  (( LCF_ENABLED == 1 )) && printf >&2 "${_COLOR_WARN}WARNING: %s${_COLOR_RST}\n" "$msg"
+  printf "  warn: %s\n" "$msg" | _to_gee_log
+}
+
+trap '_log_command_failure "${LINENO}" "${BASH_COMMAND}" "$?"' ERR
+trap '_cleanup "${LINENO}"' EXIT
+
+function _join() {
+  # Usage:  _join <delimiter> <elements...>
+  # Example: _join "," "${ARRAY[@]}"
+  local DELIM="$1"; shift
+  local TEXT="$1"; shift
+  TEXT+="$(printf "${DELIM}%s" "$@")"
+  echo "${TEXT}"
+}
+
+function _get_pull_requests() {
+  # Prints list of PRs associated with this branch.
+  local BRANCH="$1"
+  if [[ -z "${BRANCH}" ]]; then
+    BRANCH="$(_get_current_branch)"
+  fi
+  # "gh pr view" arguments are similar to "gh pr create" but not identical.
+  local FROM_BRANCH="${GHUSER}:${BRANCH}"
+  if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
+    # gh-cli treats this as a special case for some reason.
+    FROM_BRANCH="${BRANCH}"
+  fi
+  local Q
+  Q='if .isDraft then ["DRAFT", .number, .title] '
+  Q+='else [.state, .number, .title] '
+  Q+='end | join(" ")'
+  "${GH}" pr view \
+    --repo="${UPSTREAM}/${REPO}" "${FROM_BRANCH}" \
+    --json "state,number,title,isDraft" \
+    --jq "${Q}" \
+    | cat
+}
+
+function _list_open_pr_numbers() {
+  local BRANCH="$1"
+  if [[ -z "${BRANCH}" ]]; then
+    BRANCH="$(_get_current_branch)"
+  fi
+  _get_pull_requests "${BRANCH}" | grep ^OPEN | awk '{print $2}'
+}
+
+function _list_merged_pr_numbers() {
+  local BRANCH="$1"
+  if [[ -z "${BRANCH}" ]]; then
+    BRANCH="$(_get_current_branch)"
+  fi
+  _get_pull_requests "${BRANCH}" | grep ^MERGED | awk '{print $2}'
+}
+
+function _gh_pr_view() {
+  # Normalize the interface to calling "gh pr view"
+  local CURRENT_BRANCH;
+  CURRENT_BRANCH="$(_get_current_branch)"
+  local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
+  if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
+    # gh-cli treats this as a special case for some reason.
+    FROM_BRANCH="${CURRENT_BRANCH}"
+  fi
+  _gh pr view --repo "${UPSTREAM}/${REPO}" "${FROM_BRANCH}"
+}
+
+function _check_pr_description() {
+  local PATH="$1"
+  local -a LINES
+  mapfile -t LINES <"${PATH}"
+  if [[ "${#LINES[@]}" -lt 3 ]]; then
+    _warn "The description must contain at least a title, a blank line, and a body."
+    return 1
+  fi
+  if [[ -z "${LINES[0]}" ]]; then
+    _warn "The first line of the description must be the title."
+    return 1
+  fi
+  if [[ "${LINES[0]}" == "Tested:" ]]; then
+    # This will happen if the user saves the PR description template without any edits.
+    _warn "\"Tested:\" can't be the title of the PR description." \
+      "(Did you not make any edits to the PR description template?)"
+    return 1
+  fi
+  if [[ -n "${LINES[1]}" ]]; then
+    _warn "The second line of the description must be blank."
+    return 1
+  fi
+  if [[ -z "${LINES[2]}" ]]; then
+    _warn "The third line must be the beginning of the longer description."
+    return 1
+  fi
+  return 0
+}
+
+# Walks the list of parents of the current branch and returns the first
+# upstream parent (the upstream branch these changes will eventually be merged
+# into).
+function _get_upstream_parent() {
+  _read_parents_file
+
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$1"
+
+  local -a CHAIN=()
+  _add_parent_branches_to_chain "${CURRENT_BRANCH}"
+
+  local FIRST_PARENT UPSTREAM_PARENT
+  FIRST_PARENT="${CHAIN[0]}"
+  UPSTREAM_PARENT="$(_get_parent_branch "${FIRST_PARENT}")"
+  echo "${UPSTREAM_PARENT}"
+}
+
+# _print_codeowners prints a codeowners report for the opened files
+# in this branch.  It also annotates each user with their associated
+# review state (ie, COMMENTED, APPROVED) if available.  Note that
+# for this feature to work, CODEOWNERS must be expressed as a list
+# of github usernames, not email addresses.
+function _print_codeowners() {
+  _check_cwd
+  _set_main
+
+  local -A RMAP=()
+  local REVIEWER STATE
+  while read -r REVIEWER STATE; do
+    RMAP["${REVIEWER}"]="${STATE}"
+  done < <(
+    ${GH} pr view --json reviews \
+      --jq ".reviews[] | [.author.login, .state] | @tsv" \
+      2>/dev/null \
+      | cat
+  )
+
+  local UPSTREAM_PARENT CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  UPSTREAM_PARENT="$(_get_upstream_parent "${CURRENT_BRANCH}")"
+  local FILES=()
+  mapfile -t FILES < <(
+    (
+      "${GIT}" diff --name-only "${UPSTREAM_PARENT}...HEAD";
+      "${GIT}" diff --name-only;
+    ) | sort -u; /bin/true )
+  if [[ "${#FILES[@]}" -eq 0 ]]; then
+    _warn "There are no tracked, modified files in this client."
+    return 0
+  fi
+
+  local ROOT
+  ROOT="$(_get_branch_rootdir)"
+  local RULES=()
+  if ! [[ -f "${ROOT}/CODEOWNERS" ]]; then
+    _warn "No CODEOWNERS file was found in ${ROOT}."
+    return 0
+  fi
+  mapfile -t RULES < <( \
+    sed -e 's/[[:space:]]*#.*//' < "${ROOT}/CODEOWNERS" \
+    | grep -v -e '^[[:space:]]*$' )
+
+  # Check each file against CODEOWNERS rules, in order.  The last matching
+  # rule determines the owners associated with that file.
+  local F O R
+  for F in "${FILES[@]}"; do
+    O=""
+    for R in "${RULES[@]}"; do
+      local EXP VAL
+      read -r EXP VAL <<<"${R}"
+      if [[ "$EXP" == "/"* ]]; then
+        if [[ "/$F" == "${EXP}"* ]]; then
+          O="${VAL}"
+        fi
+      elif [[ "$EXP" == *"/" ]]; then
+        if [[ "/$F" == */"${EXP}"* ]]; then
+          O="${VAL}"
+        fi
+      elif [[ "$EXP" == "*"* ]]; then
+        if [[ "/$F" == *"${EXP:1}" ]]; then
+          O="${VAL}"
+        fi
+      else
+        if [[ "/$F" == *"/${EXP}" ]]; then
+          O="${VAL}"
+        fi
+      fi
+    done
+    if [[ -n "${O}" ]]; then
+      local -a owners=()
+      mapfile -t owners < <( echo "${O}" | xargs -n1 | sort -u )
+      local owner
+      for owner in "${owners[@]}"; do
+        local oname="${owner}"
+        if [[ "${oname}" == @* ]]; then
+          oname="${oname:1}"
+        fi
+        if [[ "${RMAP["${oname}"]+found}" ]]; then
+          echo "${owner}(${RMAP["${oname}"]})"
+        else
+          echo "${owner}"
+        fi
+      done | xargs
+    fi
+  done | sort -u
+}
+
+# Returns true iff this is the latest available version of gee.
+function _check_gee_version_is_current() {
+  local GEE_PATH CUR_MD5 NEW_MD5
+  GEE_PATH="$(readlink -f "$0")"
+  CUR_MD5="$(md5sum "${GEE_PATH}" | awk '{print $1}')"
+  NEW_MD5=""
+  local -a ASTORE_OUTPUT=()
+  if _read_cmd ASTORE_OUTPUT "${ENKIT}" astore list "${GEE_ON_ASTORE}"; then
+    local -a FIELDS
+    read -r -a FIELDS <<< "${ASTORE_OUTPUT[2]}"
+    if [[ "${#FIELDS[@]}" -eq 10 ]]; then
+      NEW_MD5="${FIELDS[5]}"
+    else
+      _warn "Unexpected output from astore:" "${ASTORE_OUTPUT[2]}"
+    fi
+  else
+    _warn "Could not access astore, perhaps you need to run \"enkit auth\"?"
+  fi
+
+  if [[ -z "${NEW_MD5}" ]]; then
+    _warn "Could not check for a newer version of gee."
+    return
+  fi
+
+  if [[ "${CUR_MD5}" == "${NEW_MD5}" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+
+##########################################################################
+# init command
+##########################################################################
+
+_register_help "init" "initialize a new git workspace" <<'EOT'
+Usage: gee init [<repo>]
+
+Arguments:
+
+   repo: Specifies which enfabrica repository to check out.
+         If repo is not specified, `internal` is used by default.
+
+`gee init` creates a new gee-controlled workspace in the user's home directory.
+The directory `~/gee/<repo>/main` will be created and populated, and all
+other branches will be checked out into `~/gee/<repo>/<branch>`.
+EOT
+
+function gee__init() {
+  local R
+  # REPO and GEE_REPO_DIR are already set.
+
+  # ensure all tools are installed.
+  _install_tools
+
+  if ! _check_ssh; then
+    _warn "Cannot connect to github over ssh."
+    _confirm_or_exit "Would you like to set up ssh access now? (y/N)  "
+    _ssh_enroll
+  fi
+
+  gee__hello
+
+  # _set_main won't work without a cloned repo, so assume MAIN for now
+  # and fix the branch name later.
+  MAIN=main
+  _gh config set git_protocol ssh
+  _check_gh_auth
+
+  _info "Initializing ${GEE_REPO_DIR} for ${REPO}/${MAIN}"
+
+  if [[ -d "${GEE_REPO_DIR}/${MAIN}" ]]; then
+    _fatal \
+      "Initialized workspace already exists in ${GEE_REPO_DIR}"
+  fi
+  _cmd mkdir -p "${GEE_REPO_DIR}/.gee"
+  local URL UPSTREAM_URL
+  URL="${GIT_AT_GITHUB}:${GHUSER}/${REPO}.git"
+  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
+
+  # Make fork if needed
+  if ! "${GH}" repo list | grep "^${GHUSER}/${REPO}" > /dev/null; then
+    _gh repo fork --clone=false "${UPSTREAM}/${REPO}"
+  fi
+  # Get the data from N months ago.  This is more useful than specifying
+  # --depth=3, and provides a big enough window that a user who is
+  # restoring a deleted gee repository is unlikely to have issues.
+  local OLDEST_COMMIT
+  OLDEST_COMMIT="$(date --date="-${CLONE_DEPTH_MONTHS} months" +"%Y-%m-%d")"
+  _info "Fetching all commits since ${OLDEST_COMMIT}"
+  _git clone \
+    --shallow-since "${OLDEST_COMMIT}" \
+    --no-single-branch \
+    "${URL}" \
+    "${GEE_REPO_DIR}/${MAIN}"
+  cd "${GEE_REPO_DIR}/${MAIN}"
+  _git remote add upstream "${UPSTREAM_URL}"
+  _git fetch upstream
+  _git remote -v
+  _gh repo set-default "${UPSTREAM}/${REPO}"
+  _gh repo set-default --view
+
+  # Fix the name of the main branch to match the actual branch name:
+  local OLD_MAIN="${MAIN}"
+  unset MAIN
+  _set_main_by_asking_github
+  cd "${GEE_REPO_DIR}"
+  mv "${OLD_MAIN}" "${MAIN}"
+  cd "${MAIN}"
+
+  _info "Created ${GEE_REPO_DIR}/${MAIN}"
+
+  # by default, enable meld (guitool) and vimdiff (mergetool):
+  gee__config default
+}
+
+##########################################################################
+# config command
+##########################################################################
+
+_register_help "config" \
+  "Set various configuration options." <<'EOT'
+Usage: gee config <option>
+
+Valid configuration options are:
+
+* "default": Reset to default settings.
+* "enable_vim": Set "vimdiff" as your diff/merge tool.
+* "enable_nvim": Set "nvimdiff" as your diff/merge tool.
+* "enable_emacs": Set "emacs" as your diff/merge tool.
+* "enable_vscode": Set "vscode" as your GUI diff/merge tool.
+* "enable_meld": Set "meld" as your GUI diff/merge tool.
+* "enable_bcompare": Set "BeyondCompare" as your GUI diff/merge tool.
+EOT
+function gee__config() {
+  _git config --global rerere.enabled true
+  case "$1" in
+    default)
+      if command -v nvim >/dev/null; then
+        gee__config enable_nvim
+      else
+        gee__config enable_vim
+      fi
+      gee__config enable_meld
+      ;;
+    enable_vim)
+      _info "Setting vimdiff as the default text-based diff and merge tool."
+      _git config --global merge.tool vimdiff
+      _git config --global merge.conflictstyle diff3
+      _git config --global mergetool.prompt false
+      _git config --global diff.difftool vimdiff
+      _git config --global difftool.vimdiff.cmd \
+        "vimdiff \"\$LOCAL\" \"\$REMOTE\""
+      ;;
+    enable_nvim)
+      _info "Setting vimdiff as the default text-based diff and merge tool."
+      _git config --global merge.tool nvimdiff
+      _git config --global merge.conflictstyle diff3
+      _git config --global mergetool.prompt false
+      _git config --global diff.difftool nvimdiff
+      _git config --global difftool.nvimdiff.cmd \
+        "nvim -d \"\$LOCAL\" \"\$REMOTE\""
+      ;;
+    enable_vscode)
+      _info "Setting vscode as the default GUI diff and merge tool."
+      _git config --global merge.guitool vscode
+      _git config --global mergetool.vscode.cmd \
+         "code --wait \$MERGED"
+      ;;
+    enable_meld)
+      _info "Setting meld as the default GUI diff and merge tool."
+      _git config --global merge.guitool meld
+      _git config --global mergetool.meld.cmd \
+        "/usr/bin/meld \"\$LOCAL\" \"\$MERGED\" \"\$REMOTE\" --output \"\$MERGED\""
+      _git config --global diff.guitool meld
+      _git config --global difftool.meld.cmd \
+        "/usr/bin/meld \"\$LOCAL\" \"\$REMOTE\""
+      ;;
+    enable_bcompare)
+      if ! command -v bcompare > /dev/null; then
+        _error "bcompare is not currently installed."
+        _info \
+          "To install BeyondCompare:" \
+          "" \
+          "  wget https://www.scootersoftware.com/files/bcompare-5.0.2.30045_amd64.deb" \
+          "  sudo apt install poppler-utils" \
+          "  sudo dpkg -i ./bcompare-5.0.2.30045_amd64.deb" \
+          "  which bcompare  # ensure tool is installed" \
+          "" \
+          "Install bcompare and try again."
+        _fatal "bcompare not installed."
+      else
+        _info "Setting BeyondCompare as the default GUI diff and merge tool."
+        # Note "bc" selects a wrapper for beyondcompare that is distributed with git.
+        _git config --global merge.guitool bc
+        _git config --global diff.guitool bc
+        _git config --global mergetool.bc.trustExitCode true
+        _git config --global difftool.bc.trustExitCode true
+      fi
+      ;;
+    enable_emacs)
+      # TODO: I'm hoping an emacs expert can contribute
+      # something here.
+      _fatal "enable_emacs: not yet supported."
+      ;;
+    *)
+      _info "Valid options include:" \
+           default \
+           enable_bcompare \
+           enable_emacs \
+           enable_meld \
+           enable_nvim \
+           enable_vim \
+           enable_vscode
+      _fatal "Unknown configuration directive."
+      ;;
+  esac
+}
+
+##########################################################################
+# make_branch command
+##########################################################################
+
+_register_help "make_branch" \
+  "Create a new child branch based on the current branch." \
+  "mkbr" \
+  <<'EOT'
+Usage: gee make_branch <branch-name> [<parent-branch>]
+Aliases: mkbr
+
+Create a new branch based.  The new branch will be located in the
+directory:
+  ~/gee/<repo>/<branch-name>
+
+If the parent branch is not specified, the current branch is used as the parent
+branch.  An arbitrary upstream branch may be specified as the parent branch
+(ie. `upstream/master_a0`).
+
+Note that if the parent branch is a non-master upstream branch, any PR created
+from this branch (or a child of this branch) will use that non-master branch
+as the base branch to merge into.
+
+If a matching branch exists in origin (ie, if `origin/<branch-name>` exists),
+gee will ask the user if they want to integrate commits from origin into the
+current branch.
+
+For example:
+
+    cd $(gee gcd bar)
+    gee make_branch foo  # foo is a child branch of the current branch, bar
+    gee make_branch based_on_master upstream/master
+    gee make_branch based_on_fork_a0 upstream/fork_a0
+
+EOT
+
+function gee__mkbr() { gee__make_branch "$@"; }
+function gee__make_branch() {
+  _startup_checks "make_branch"
+
+  local BRNAME SHA CURRENT_BRANCH
+  # TODO(jonathan): Let the user name the branch to branch from.
+  BRNAME="$1"; shift
+  SHA="$1"
+
+  _set_main
+  if [[ -z "${SHA}" ]]; then
+    SHA="$(_get_current_branch)"
+    if [[ -z "${SHA}" ]]; then
+      SHA="upstream/${MAIN}"
+    fi
+  fi
+
+  if [[ "${SHA}" == "upstream/"* ]]; then
+    _git fetch upstream
+  fi
+
+  local -a ARGS=( worktree add -b "${BRNAME}" -f "${GEE_REPO_DIR}/${BRNAME}" "${SHA}")
+  _git "${ARGS[@]}"
+  _info "Created ${GEE_REPO_DIR}/${BRNAME}"
+
+  _read_parents_file
+  PARENTS["${BRNAME}"]="${SHA}"
+  _write_parents_file
+
+  # If the user has created a branch whose name matches an
+  # existing branch in their existing repo, reset this branch
+  # to match what is in origin.
+  _git fetch origin
+  if _remote_branch_exists origin "${BRNAME}"; then
+    _warn "Found existing \"origin/${BRNAME}\" branch: resetting local \"${BRNAME}\" to match."
+    _checkout_or_die "${BRNAME}"
+    # always make our local branch the same as what's in origin.
+    _git reset --hard "origin/${BRNAME}"
+    local -a COUNTS
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "HEAD...${SHA}")
+    if [[ "${COUNTS[1]}" -gt 0 ]]; then
+      _warn "Parent branch ${SHA} is ${COUNTS[1]} commits ahead of this branch." \
+            "You probably want to do a \"gee update\" operation in branch ${BRNAME}."
+    fi
+  fi
+}
+
+##########################################################################
+# log command
+##########################################################################
+
+_register_help "log" \
+  "Log of commits since parent branch." <<'EOT'
+Usage: gee log [<args...>]
+
+Invokes `git logp` with the supplied arguments.
+
+If the supplied arguments do not contain a commit range, then gee will show the
+log messages for commits between the parent branch and the the current branch.
+
+For example:
+
+    gee log                # show all commits since HEAD of parent branch.
+
+    gee log ./scripts/gee  # show commits since parent for a single file.
+
+    gee log master...mybr  # show all commits in a specific range
+
+EOT
+
+function gee__log() {
+  _startup_checks "log"
+
+  _check_cwd
+  local -a ARGS=( "$@" )
+  local -a RANGE=()
+  _egrep_array RANGE '^\w*\.\.\.\w*$' "${ARGS[@]}"
+  if (( ${#RANGE[@]} == 0 )); then
+    local PARENT_BRANCH CURRENT_BRANCH
+    _read_parents_file
+    PARENT_BRANCH="$(_get_parent_branch)"
+    CURRENT_BRANCH="$(_get_current_branch)"
+    ARGS=("${PARENT_BRANCH}...${CURRENT_BRANCH}" "${ARGS[@]}")
+  fi
+  local -a PRETTYLOG=(
+      log
+      --color
+      --graph
+      "--pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
+      --abbrev-commit
+  )
+  _set_alias_if_missing logp "${PRETTYLOG[*]}"
+  _git logp "${ARGS[@]}"
+}
+
+##########################################################################
+# diff command
+##########################################################################
+
+_register_help "diff" \
+  "Differences in this branch." <<'EOT'
+Usage: gee diff [<files...>]
+
+Shows all local changes this since branch diverged from its parent branch.
+
+If <files...> are omited, shows changes to all files.
+EOT
+
+function gee__diff() {
+  _startup_checks "diff"
+
+  _check_cwd
+  local PARENT_BRANCH
+  _read_parents_file
+  PARENT_BRANCH="$(_get_parent_branch)"
+  # branches created with "gee pr_checkout" need special handling:
+  if [[ "${PARENT_BRANCH}" == upstream/* ]]; then
+    _git fetch --force upstream "${PARENT_BRANCH#upstream/}"
+    PARENT_BRANCH="FETCH_HEAD"
+  fi
+  if (( "$#" )); then
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD -- "$@"
+  else
+    _git_can_fail diff "${PARENT_BRANCH}"...HEAD
+  fi
+  if _branch_has_unstaged_changes; then
+    _info "Note: This branch contains uncommitted changes."
+  fi
+}
+
+##########################################################################
+# find command
+##########################################################################
+
+_register_help "find" "Finds a file by name in the current branch." <<'EOT'
+Usage: gee find [options] <expression>
+
+Searches the current branch for a file whose name matches the specified
+expression.  Will initially search for the file without traversing symlinks.
+If it fails to find any files, it will search again in the bazel-bin
+subdirectory (and follow symlinks) to see if the file is generated by a bazel
+rule.
+
+Roughly equivalent to running:
+
+    find -L "$(git rev-parse --show-toplevel)" -name .git -prune -or \
+         -name "${expression}" -print
+
+Example of use:
+
+    gee find WORKSPACE
+
+EOT
+function gee__find() {
+  # The GEE_NO_RIPGREP environment variable is available for testing, to force
+  # the use of find without requiring that ripfind be uninstalled.
+  _startup_checks "find"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  (
+    # first look in the repo directory but without searching symlinks. find always returns 0, even
+    # if no files are found.  By piping through "grep .", grep will succeed if at least one line is
+    # processed, or will fail otherwise.
+    if ! _cmd find "${BRANCH_ROOT_DIR}" -name .git -prune -or -name "${1}" -print | grep .; then
+      # try search again, but look in bazel-bin with -L enabled.  Sort results by line length.
+      NOFAIL=1 _cmd find -L "${BRANCH_ROOT_DIR}/bazel-out" -name .git -prune -or -name "${1}" -print
+    fi
+  ) | perl -e 'print sort { length($a) <=> length($b) } <>'  # sort results by line length.
+}
+
+##########################################################################
+# grep command
+##########################################################################
+
+_register_help "grep" "Greps the current branch." <<'EOT'
+Usage: gee grep [options] <expression>
+
+Searches the current branch for the specified expression.
+
+If the ripgrep tool is installed, then this command invokes:
+
+    rg "$@" "${BRANCH_ROOT_DIR}"
+
+If ripgrep is not installed, this command falls back on the grep utility,
+invoked to be similar in operation to ripgrep, like this:
+
+    grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"
+
+If the `gee bash_setup` environment is loaded, `grg` is an alias for this
+command.
+
+Example of use:
+
+    grg -l fdst
+
+EOT
+function gee__grep() {
+  # The GEE_NO_RIPGREP environment variable is available for testing, to force
+  # the use of grep without requiring that ripgrep be uninstalled.
+  _startup_checks "grep"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  if [[ "${GEE_NO_RIPGREP}" == "" ]] && command -v rg > /dev/null; then
+    NOFAIL=1 _cmd rg "$@" "${BRANCH_ROOT_DIR}"
+  else
+    NOFAIL=1 _cmd grep -r --exclude-dir=.git "$@" "${BRANCH_ROOT_DIR}"
+  fi
+}
+
+##########################################################################
+# vimdiff command
+##########################################################################
+
+_register_help "difftool" "Runs the difftool to compare changes in a file." <<'EOT'
+Usage: gee difftool <filename>
+
+Invokes difftool to show and edit the changes to a specific file in the current
+branch, versus the version in the parent branch.  This can be useful to clean
+up local changes, especially after resolving merge conflicts.
+
+If installed, neovim will be used.  Otherwise, gee will fallback to vim.
+
+When working in a branch created with `pr_checkout`, the parent branch isn't
+a local worktree, and so difftool will produce an error and fail.
+
+Example of use:
+
+    gee difftool BUILD.bazel
+
+See also: the "gee config" command can be used to select between different
+supported diff/merge tools.
+
+EOT
+function gee__difftool() { gee__vimdiff "$@"; }
+function gee__vimdiff() {
+  _startup_checks "vimdiff"
+  _check_cwd
+
+  local CURRENT_BRANCH BRANCH_ROOT_DIR
+  CURRENT_BRANCH="$(_get_current_branch)"
+  BRANCH_ROOT_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+
+  local FILENAME="$1"
+  if [[ -z "${FILENAME}" ]]; then
+    _fatal "gee difftool requires a filename argument."
+  elif [[ ! -e "${FILENAME}" ]]; then
+    _fatal "File \"${FILENAME}\" does not exist."
+  fi
+  local RELPATH
+  RELPATH="$(realpath --relative-to "${BRANCH_ROOT_DIR}" "${FILENAME}")"
+  if [[ "${RELPATH}" == ".."* ]]; then
+    _fatal "File \"${FILENAME}\" is not beneath branch root directory ${BRANCH_ROOT_DIR}."
+  fi
+
+  local PARENT_BRANCH PARENT_ROOT_DIR
+  _read_parents_file
+  PARENT_BRANCH="$(_get_parent_branch)"
+
+  local DIFFTOOL
+  DIFFTOOL="$(${GIT} config --global --get diff.difftool)"
+
+  _git difftool -t "${DIFFTOOL}" "${PARENT_BRANCH}" -- "${FILENAME}"
+}
+
+##########################################################################
+# pack command
+##########################################################################
+
+_register_help "pack" \
+  "Exports all unsubmitted changes in this branch as a pack file." <<'EOT'
+Usage: gee pack [-c] [-o <file.pack>]
+
+Creates a pack file containing all unsubmitted changes in this branch.
+
+Flags:
+  -o  Specifies a file to write to, instead of stdout.
+
+EOT
+
+function gee__pack() {
+  _startup_checks "pack"
+
+  _check_cwd
+  _set_main
+  declare -A FLAGS=()
+  _parse_options "o:" "$@"
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  if _branch_has_unstaged_changes; then
+    _warn "You have uncommitted work in this branch that won't be packed."
+    _confirm_or_exit "Do you want to proceed anyway? (y/N)  "
+  fi
+  local HEAD_COMMIT
+  HEAD_COMMIT="$("${GIT}" rev-parse HEAD)"
+  local -a OPTS=( "--inter-hunk-context=3" )
+  local OUTPUT
+  OUTPUT="${FLAGS[o]}"
+  if [[ -n "${OUTPUT}" ]]; then
+    _info "Writing to ${OUTPUT}"
+    exec >"${OUTPUT}"
+  else
+    _info "Writing to stdout"
+  fi
+  (
+    echo "PACKFILE v1.0"
+    echo "User: $(whoami)"
+    echo "Date: $(date)"
+    echo "Branch: ${CURRENT_BRANCH}"
+    echo "Head: ${HEAD_COMMIT}"
+    echo ""
+    echo "git diff ${MAIN}...${CURRENT_BRANCH}"
+    echo "### start of patch"
+    "${GIT}" diff "${OPTS[@]}" "${MAIN}...${CURRENT_BRANCH}"
+    echo "### end of patch"
+  ) </dev/null
+}
+
+##########################################################################
+# unpack command
+##########################################################################
+
+_register_help "unpack" \
+  "Patch the local branch from a pack file." <<'EOT'
+Usage: gee unpack <file.pack>
+
+"unpack" attempts to patch the current branch from a pack file.
+EOT
+
+function gee__unpack() {
+  _startup_checks "unpack"
+
+  _check_cwd
+  _set_main
+  local PACKFILE
+  PACKFILE="$1"
+  if [[ -z "${PACKFILE}" ]]; then
+    _fatal "unpack: you must specify a pack file to read."
+  fi
+  if ! [[ -f "${PACKFILE}" ]]; then
+    _fatal "unpack: Could not find \"${PACKFILE}\""
+  fi
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  local STATUS
+  STATUS="$("${GIT}" status --porcelain)"
+  if [[ -n "${STATUS}" ]]; then
+    _warn "You have uncommitted work in this branch that could be disrupted."
+    _confirm_or_exit "Do you want to proceed anyway? (y/N)  "
+  fi
+  cd "$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+  local -a HEADER=()
+  local LINE
+  while IFS= read -r LINE; do
+    if [[ -z "${LINE}" ]]; then
+      break
+    fi
+    HEADER+=( "${LINE}" )
+  done <"${PACKFILE}"
+  _info "Applying ${PACKFILE}:" "${HEADER[@]}" ""
+  patch -p1 <"${PACKFILE}"
+}
+
+
+## DEPRECATED: we always squash when submitting a PR, this command adds a lot
+## of complexity but very little value.
+## TODO(jonathan): delete this after we are sure we don't need it.
+## ##########################################################################
+## # squash command
+## ##########################################################################
+##
+## _register_help "squash" "Squash all commits in this branch." <<'EOT'
+## Usage: gee squash
+##
+## Squash all commits in this branch to a single commit.
+## EOT
+##
+## function gee__squash() {
+##  _startup_checks "squash"
+##
+##   _check_cwd
+##   # Note: there is no longer any need to squash before sending out for review,
+##   # as we always merge with "gh pr merge --squash".
+##   # TODO(jonathan): Deprecate this?
+##   local PARENT_BRANCH CURRENT_BRANCH MERGE_BASE TMPFILE NUM_COMMITS
+##   _read_parents_file
+##   PARENT_BRANCH="$(_get_parent_branch)"
+##   CURRENT_BRANCH="$(_get_current_branch)"
+##   MERGE_BASE="$("${GIT}" merge-base "${PARENT_BRANCH}" "${CURRENT_BRANCH}")"
+##   NUM_COMMITS="$("${GIT}" log --oneline "${PARENT_BRANCH}..${CURRENT_BRANCH}" | /usr/bin/wc -l)"
+##   _info "Current branch: ${CURRENT_BRANCH}"
+##   _info "Parent branch: ${PARENT_BRANCH}"
+##   _info "Merge base: ${MERGE_BASE}"
+##   _info "Number of commits outstanding: ${NUM_COMMITS}"
+##   if [[ "${NUM_COMMITS}" -lt 2 ]]; then
+##     _fatal "${NUM_COMMITS} commits outstanding.  Nothing to squash."
+##   fi
+##   TMPFILE="$(mktemp)"
+##   (
+##     echo "# Comment lines will be removed."
+##     echo "# One line summary:"
+##     echo "[REPLACE THIS LINE]"
+##     echo ""
+##     echo "# Details:"
+##     echo ""
+##     echo "Files:"
+##     "${GIT}" diff --name-only "${MERGE_BASE}" | sed 's/^/    /'
+##     echo ""
+##     echo "# Previous commit messages:"
+##     echo "#"
+##     "${GIT}" log --format=medium "${PARENT_BRANCH}..${CURRENT_BRANCH}" | \
+##       sed 's/^/# /'
+##     echo ""
+##   ) >"${TMPFILE}"
+##   "${EDITOR:-vim}" "${TMPFILE}"
+##   sed -i "/^#/d" "${TMPFILE}"
+##   perl -p -i -e 's/(^\s*\n){2,}/\n/gmso' "${TMPFILE}"
+##   if grep -q "^\[REPLACE" "${TMPFILE}"; then
+##     echo "You must replace the summary line."
+##     echo "Commit message saved here: ${TMPFILE}"
+##     _fatal Aborted.
+##   fi
+##   head -n 1 "${TMPFILE}"
+##   _confirm_or_exit \
+##     "Are you sure you want to squash ${NUM_COMMITS} commits? (y/N)  "
+##
+##   _git reset --soft "${MERGE_BASE}"
+##   _git add --all
+##   _git commit -a -F "${TMPFILE}"
+##   rm "${TMPFILE}"
+##   _push_to_origin "+${CURRENT_BRANCH}"  # update remote branch too
+##   _git log --oneline "${PARENT_BRANCH}..${CURRENT_BRANCH}"
+## }
+
+##########################################################################
+# update command
+##########################################################################
+
+_register_help "update" \
+  "integrate changes from parent into this branch." \
+  "up" \
+  <<'EOT'
+Usage: gee update
+
+"gee update" attempts to rebase this branch atop its parent branch.
+
+gee implements an interactive flow to resolve merge conflicts.  At each
+conflict, you will be given the option of choosing:
+
+* (M) for "mergetool", to invoke a mergetool (by default, vimdiff) to resolve
+  the merge.
+* (G) for "gui", to invoke a GUI mergetool (by default, meld).
+* (O) for "old", to discard your changes and preserve the upstream change.
+* (N) for "new", to discard the upstram change and use your change instead.
+* (A) for "abort", to abort the rebase operation and return to your initial
+      state.
+
+gee always creates a `<branch-name>.REBASE_BACKUP` tag before updating your
+branch.  If something went wrong with the merge and want to get back to where
+you started, you can always run:
+
+    git reset --hard your_branch.REBASE_BACKUP
+
+to undo the last rebase operation.
+EOT
+
+function gee__up() { gee__update "$@"; }
+function gee__update() {
+  _startup_checks "update"
+
+  _check_cwd
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  if [[ -z "${CURRENT_BRANCH}" ]]; then
+    _die "Not in a git branch directory."
+  fi
+
+  # Check for upstream changes in "origin" first:
+  if _remote_branch_exists origin "${CURRENT_BRANCH}"; then
+    _git fetch origin
+    local -a COUNTS
+    read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+    if [[ "${COUNTS[1]}" -gt 0 ]]; then
+      _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}."
+      _info \
+        "There are two likely causes.  Either:" \
+        "" \
+        "* If you or another user pushed commits into this branch from another branch" \
+        "  or machine, in which case you probably want to integrate these changes, or" \
+        "" \
+        "* If you manually rebased your local branch, but forgot to force-push the" \
+        "  updated branch to origin, in which case you should do a force-push instead" \
+        "  of integrating."
+      if _confirm_default_yes "Do you want to integrate changes from origin/${CURRENT_BRANCH}? (Y/n)  "; then
+        _info "Pulling in changes from origin/${CURRENT_BRANCH}"
+        HEAD="$("${GIT}" rev-parse HEAD)"
+        _info "Old head commit before rebase: ${HEAD}"
+        _checkout_or_die "${CURRENT_BRANCH}"
+        _safer_rebase "${CURRENT_BRANCH}" "origin/${CURRENT_BRANCH}"
+      else
+        _info "You may need to \"git push -u origin --force\" to fix your origin remote."
+      fi
+    fi
+  fi
+
+  _read_parents_file
+
+  local PREVIOUS_B
+  PREVIOUS_B="$(_get_parent_branch "${CURRENT_BRANCH}")"
+
+  _set_main
+  if [[ "${PREVIOUS_B}" == "${MAIN}" ]]; then
+    _update_main
+  fi
+
+  _checkout_or_die "${CURRENT_BRANCH}"
+  # Rebase from PREVIOUS_B onto B
+  _safer_rebase "${CURRENT_BRANCH}" "${PREVIOUS_B}"
+  _info Done.
+}
+
+##########################################################################
+# rupdate command
+##########################################################################
+
+_register_help "rupdate" \
+  "Recursively integrate changes from parents into this branch." \
+  "rup" <<'EOT'
+Usage: gee rupdate
+
+"gee rupdate" recursively rebases each branch onto it's parent.
+
+gee implements an interactive flow to resolve merge conflicts.  At each
+conflict, you will be given the option of choosing:
+
+* (M) for "mergetool", to invoke a mergetool (by default, vimdiff) to resolve
+  the merge.
+* (G) for "gui", to invoke a GUI mergetool (by default, meld).
+* (O) for "old", to discard your changes and preserve the upstream change.
+* (N) for "new", to discard the upstram change and use your change instead.
+* (A) for "abort", to abort the rebase operation and return to your initial
+      state.
+
+gee always creates a `<branch-name>.REBASE_BACKUP` tag before updating your
+branch.  If something went wrong with the merge and want to get back to where
+you started, you can always run:
+
+    git reset --hard your_branch.REBASE_BACKUP
+
+to undo the last rebase operation.
+EOT
+
+function _add_parent_branches_to_chain() {
+  # Recursively finds all parent branches of B, and inserts them
+  # into CHAIN unless they are already in CHAIN.  Ultimately,
+  # the branches in CHAIN will be strictly ordered so that
+  # any parent is earlier than any child.  Recursive searching
+  # for parent branches ultimately stops when we reach an
+  # upstream branch.
+  #
+  # Recursive list of branches halts at:
+  # * any branch whose parent is in upstream.
+  local B="$1"
+  if _contains_element "${B}" "${CHAIN[@]}"; then return; fi
+
+  # If the current branch is upstr
+  if [[ "${B}" == "upstream/"* ]]; then return; fi
+
+  local P
+  P="$(_get_parent_branch "${B}")"
+  # if parent branch is the current branch, stop.
+  if [[ "${P}" == "${B}" ]]; then return; fi
+
+  # Keep recursing until we reach a branch whose parent is remote:
+  if [[ "${P}" != */* ]]; then
+    _add_parent_branches_to_chain "${P}"
+  fi
+  CHAIN+=( "${B}" )
+}
+
+function gee__rup() { gee__rupdate "$@"; }
+function gee__rupdate() {
+  _startup_checks "rupdate"
+
+  _check_cwd
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  if [[ -z "${CURRENT_BRANCH}" ]]; then
+    _die "Not in a git branch directory."
+  fi
+
+  _read_parents_file
+
+  # Build a chain of branches to update.
+  _set_main
+  local -a CHAIN=()
+  _add_parent_branches_to_chain "${CURRENT_BRANCH}"  # puts branches into CHAIN array
+
+  for B in "${CHAIN[@]}"; do
+    local PARENT_BRANCH
+    PARENT_BRANCH="$(_get_parent_branch "${B}")"
+    _banner "Updating branch \"${B}\" from \"${PARENT_BRANCH}\""
+    _checkout_or_die "${B}"
+
+    # Check if we're rebasing onto a branch with uncommitted changes:
+    if [[ "${B}" != "${CURRENT_BRANCH}" ]]; then
+      local -a UNCOMMITTED
+      mapfile -t UNCOMMITTED < <( "${GIT}" status --short -uall )
+      if (( "${#UNCOMMITTED[@]}" )); then
+        _fatal "Branch ${B} contains ${#UNCOMMITTED[@]} uncommitted changes:" \
+          "${UNCOMMITTED[@]}" \
+          "Commit branch ${B} and try again."
+      fi
+    fi
+
+    # if parent is a remote, make sure remote is up to date.
+    if [[ "${PARENT_BRANCH}" == */* ]]; then
+      _git fetch "${PARENT_BRANCH%%/*}"
+    fi
+
+    # Rebase from PREVIOUS_B onto B
+    _safer_rebase "${B}" "${PARENT_BRANCH}"
+  done
+  _info Done.
+}
+
+##########################################################################
+# update_all command
+##########################################################################
+
+_register_help "update_all" \
+  "Update all branches."  \
+  "up_all" <<'EOT'
+Usage: gee update_all
+
+"gee update_all" updates all local branches (in the correct order),
+by rebasing child branches onto parent branches.
+
+gee implements an interactive flow to resolve merge conflicts.  At each
+conflict, you will be given the option of choosing:
+
+* (M) for "mergetool", to invoke a mergetool (by default, vimdiff) to resolve
+  the merge.
+* (G) for "gui", to invoke a GUI mergetool (by default, meld).
+* (O) for "old", to discard your changes and preserve the upstream change.
+* (N) for "new", to discard the upstram change and use your change instead.
+* (A) for "abort", to abort the rebase operation and return to your initial
+      state.
+
+gee always creates a `<branch-name>.REBASE_BACKUP` tag before updating your
+branch.  If something went wrong with the merge and want to get back to where
+you started, you can always run:
+
+    git reset --hard your_branch.REBASE_BACKUP
+
+to undo the last rebase operation.
+EOT
+
+function gee__up_all() { gee__update_all "$@"; }
+function gee__update_all() {
+  _startup_checks "update_all"
+
+  local -a CONFLICTS=()
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  if [[ -z "${CURRENT_BRANCH}" ]]; then
+    _set_main
+    CURRENT_BRANCH="${MAIN}"
+    _checkout_or_die "${CURRENT_BRANCH}"
+  fi
+
+  _read_parents_file
+
+  # Build an ordered list of branches to update
+  local -a ALL_BRANCHES=()
+  mapfile -t ALL_BRANCHES < <( "${GIT}" branch --format="%(refname:short)" )
+  local -a CHAIN=()
+  local B
+  for B in "${ALL_BRANCHES[@]}"; do
+    _add_parent_branches_to_chain "${B}"
+  done
+  _info "Updating ${CHAIN[*]}"
+
+  local PARENT
+  for B in "${CHAIN[@]}"; do
+    _banner "Updating branch \"${B}\""
+    _checkout_or_die "${B}"
+
+    # Check if we're rebasing onto a branch with uncommitted changes:
+    local -a UNCOMMITTED
+    mapfile -t UNCOMMITTED < <( "${GIT}" status --short -uall )
+    if (( "${#UNCOMMITTED[@]}" )); then
+      _warn "Branch ${B} contains ${#UNCOMMITTED[@]} uncommitted changes:" \
+        "${UNCOMMITTED[@]}" \
+        "This branch will not be updated."
+      continue
+    fi
+
+    # Rebase from PREVIOUS_B onto B
+    PARENT="$(_get_parent_branch "${B}")"
+    if ! _safer_rebase "${B}" "${PARENT}"; then
+      CONFLICTS+=( "${B}" )
+    fi
+  done
+  if (( "${#CONFLICTS[@]}" )); then
+    _fatal "The following branches had merge conflicts:" "${CONFLICTS[@]}"
+  fi
+  _info Done.
+}
+
+##########################################################################
+# whatsout command
+##########################################################################
+
+_register_help "whatsout" \
+  "List locally changed files in this branch." <<'EOT'
+Usage: gee whatsout
+
+Reports which files in this branch differ from parent branch.
+EOT
+
+# _get_parent_head_commit <varname> <parent>
+#
+# git sometimes makes it hard for some commands to refer to branches in
+# remote repos.  This function takes any refspec that looks like it
+# refers to a remote repo and turns that into a commit id.  Otherwise,
+# it leaves it alone.
+#
+# Sets the value of indirect variable <varname> to a commit, local branch, or
+# local tag name associated with the <parent> reference specification.
+function _get_parent_head_commit() {
+  local VARNAME="$1"; shift
+  local PARENT="$1"; shift
+  local _PARENT_HEAD
+  local -a OUTPUT=()
+  local -a WORDS=()
+  if [[ "${PARENT}" == */* ]]; then
+    # make sure remote is up to date:
+    _git fetch "${PARENT%%/*}" "${PARENT#*/}"
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" show -s --format=oneline FETCH_HEAD
+    read -r -a WORDS <<< "${OUTPUT[0]}"
+    _PARENT_HEAD="${WORDS[0]}"
+  else
+    # Note: git show-ref "refs/heads/${PARENTS}" is the conventional wisdom
+    # solution, which doesn't work for tags.  Instead, git rev-list works for
+    # both branches and tags.
+    READ_CMD_ECHO=1 _read_cmd OUTPUT "${GIT}" rev-list -n 1 "${PARENT}"
+    read -r -a WORDS <<< "${OUTPUT[0]}"
+    _PARENT_HEAD="${WORDS[0]}"
+  fi
+  printf -v "${VARNAME}" '%s' "${_PARENT_HEAD}"
+}
+
+function gee__whatsout() {
+  _startup_checks "whatsout"
+
+  _check_cwd
+  local BRANCH PARENT
+  BRANCH="$(_get_current_branch)"
+  _read_parents_file
+  PARENT="$(_get_parent_branch "${BRANCH}")"
+  local PARENT_HEAD
+  _get_parent_head_commit PARENT_HEAD "${PARENT}"
+  _git diff --name-only "${PARENT_HEAD}...${BRANCH}"
+  if _branch_has_unstaged_changes; then
+    _info "Note: This branch contains uncommitted changes."
+  fi
+}
+
+##########################################################################
+# codeowners command
+##########################################################################
+
+_register_help "codeowners" \
+  "Provide detailed information about required approvals for this PR." \
+  owners reviewers \
+  <<'EOT'
+Usage: gee codeowners [--comment]
+
+Gee examines the set of modified files in this branch, and compares it against
+the rules in the CODEOWNERS file.  Gee then presents the user with detailed
+information about which approvals are necessary to submit this PR:
+
+*  Each line contains a list of users who are code owners of at least
+   some part of the PR.
+
+*  A minimum of one user from each line must provide approval in order for the
+   PR to be merged.
+
+If `--comment` option is specified, the codeowners information is appended to the
+current PR as a new comment.
+
+EOT
+
+function gee__owners() { gee__codeowners "$@"; }
+function gee__reviewers() { gee__codeowners "$@"; }
+function gee__codeowners() {
+  _startup_checks "codeowners"
+
+  local OPT_COMMENT=0
+  if [[ "$1" == "--comment" ]]; then
+    OPT_COMMENT=1
+  fi
+
+  local COMMENT
+  read -r -d "" COMMENT < <(
+    # add a second comment containing the CODEOWNERS annotation
+    local OWNERS=()
+    mapfile -t OWNERS < <(_print_codeowners)
+    if [[ "${#OWNERS[@]}" -eq 0 ]]; then
+      printf "This PR can be submitted with approval from any repo owner.\n\n"
+    elif [[ "${#OWNERS[@]}" -eq 1 ]]; then
+      printf "This PR requires approval from at least one of these reviewers:\n\n"
+      printf "* %s\n" "${OWNERS[@]}"
+    else
+      printf "This PR requires approval from at least one reviewer from each line:\n\n"
+      printf "* %s\n" "${OWNERS[@]}"
+    fi
+    printf "\n"
+  ) || /bin/true
+
+  _info "${COMMENT}"
+  if (( OPT_COMMENT )); then
+    _gh pr comment --body "${COMMENT}"
+  fi
+}
+
+##########################################################################
+# lsbranches command
+##########################################################################
+# TODO(jonathan): maybe display a tree?
+# TODO(jonathan): maybe display this suggestion from Jacob Adelmann:
+# branchp = !git for-each-ref \
+#   --sort=committerdate refs/heads/ \
+#   --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
+
+_register_help "lsbranches" \
+  "List information about each branch." \
+  "lsb" "lsbr" <<'EOT'
+Usage: gee lsbranches
+
+List information about all branches.
+
+NOTE: the output of this command is likely to change in the near future.
+EOT
+
+function gee__lsb() { gee__lsbranches "$@"; }
+function gee__lsbr() { gee__lsbranches "$@"; }
+function gee__lsbranches() {
+  _startup_checks "lsbranches"
+
+  _set_main
+  if ! _in_gee_repo; then
+    cd "${GEE_REPO_DIR}"
+  fi
+  if ! _in_gee_branch; then
+    cd "${GEE_REPO_DIR}/${MAIN}"
+  fi
+
+  local -a branches;
+  mapfile -t branches < <( "${GIT}" branch --format "%(refname:short)")
+  local br
+  _set_main
+  _git fetch
+  for br in "${branches[@]}"; do
+    if [[ "${br}" == FETCH_HEAD* ]]; then
+      continue
+    fi
+    if [[ "${br}" != "${MAIN}" ]]; then
+      _branch_ahead_behind "${br}"
+    fi
+  done
+}
+
+##########################################################################
+# cleanup command
+##########################################################################
+_register_help "cleanup" \
+  "Automatically remove branches without local changes." <<'EOT'
+Usage: gee cleanup
+
+Automatically removes branches without local changes.
+EOT
+
+function gee__cleanup() {
+  _startup_checks "cleanup"
+
+  _set_main
+  _read_parents_file
+
+  if ! _in_gee_repo; then
+    cd "${GEE_REPO_DIR}"
+  fi
+  if ! _in_gee_branch; then
+    cd "${GEE_REPO_DIR}/${MAIN}"
+  fi
+
+  local -a branches;
+  mapfile -t branches < <( "${GIT}" branch --format "%(refname:short)")
+
+  local -a empty=()
+  local br
+  for br in "${branches[@]}"; do
+    if [[ "${br}" == */* ]]; then
+      _warn "Skipping branch with a weird name: ${br}"
+      continue
+    fi
+    if [[ "${br}" != "${MAIN}" ]]; then
+      local parent
+      parent="$(_get_parent_branch "${br}")"
+      if [[ "${parent}" == upstream/* ]]; then
+        _git fetch --force upstream "${parent#upstream/}"
+        parent="FETCH_HEAD"
+      fi
+      local -a  counts=()
+      read -r -a counts < <("${GIT}" rev-list --left-right --count "${parent}...${br}")
+      _checkout_or_die "${br}"
+      if [[ -z "$("${GIT}" status --porcelain)" ]]; then
+        if (( counts[1] == 0 )); then
+          empty+=( "${br}" )
+        fi
+      fi
+    fi
+  done
+
+  if [[ "${#empty[@]}" -eq 0 ]]; then
+    _info "Nothing to clean up: all branches contain local changes."
+    return 0
+  fi
+
+  # use "dialog" if it's available in this container:
+  if command -v dialog > /dev/null; then
+    _gee_cleanup_with_dialog "${empty[@]}"
+  else
+    _gee_cleanup_without_dialog "${empty[@]}"
+  fi
+}
+
+function _gee_cleanup_with_dialog() {
+  local -a DIALOG_OPTS=(
+    --no-lines
+    --keep-tite
+    --backtitle "gee ${VERSION}"
+    --title "gee cleanup"
+    --checklist
+    "The following branches have no local changes.  Select the branches that you want to delete:"
+    0 0 0
+  )
+  local BRANCH
+  for BRANCH in "${empty[@]}"; do
+    DIALOG_OPTS+=( "${BRANCH}" "" "off" )
+  done
+
+  # Invoke dialog:
+  local RESULT EXITCODE
+  set +e
+  exec 3>&1
+  RESULT="$(dialog "${DIALOG_OPTS[@]}" 2>&1 1>&3)"
+  EXITCODE=$?
+  exec 3>&-
+  set -e
+  if (( EXITCODE != 0 )); then
+    # The user selected "cancel" instead of "ok"
+    _warn "Cancelled cleanup operation."
+    return
+  fi
+
+  # remove selected branches:
+  local -a SELECTED=()
+  read -r -a SELECTED <<< "${RESULT}"
+  _info "Removing: ${SELECTED[*]}"
+  for BRANCH in "${SELECTED[@]}"; do
+    gee__rmbr "${BRANCH}"
+  done
+}
+
+function _gee_cleanup_without_dialog() {
+  # The dialog utility isn't installed, so we ask the user a series of
+  # yes/no questions instead.
+  local -a empty=( "$@" )
+  _info "The following branches have no local changes:"
+  _info "  ${empty[*]}"
+  _checkout_or_die "${MAIN}"
+  for br in "${empty[@]}"; do
+    if _confirm_default_no "Do you want to remove the \"${br}\" branch? (y/N)  "; then
+      gee__rmbr "${br}"
+    fi
+  done
+}
+
+##########################################################################
+# get_parent command
+##########################################################################
+
+_register_help "get_parent" \
+  "Which branch is this branch branched from?" <<'EOT'
+Usage: gee get_parent
+EOT
+
+function gee__get_parent() {
+  _startup_checks "get_parent"
+  _check_cwd
+
+  local BRANCH PARENT
+  _read_parents_file
+  if [[ "$1" == "--upstream" ]]; then
+    shift
+    BRANCH="${1:-$(_get_current_branch)}"
+    PARENT="$(_get_upstream_parent "${BRANCH}")"
+    echo "${PARENT} is the ultimate upstream base branch of ${BRANCH}"
+  else
+    BRANCH="${1:-$(_get_current_branch)}"
+    PARENT="$(_get_parent_branch "${BRANCH}")"
+    echo "${PARENT} is the parent branch of ${BRANCH}"
+  fi
+
+}
+
+##########################################################################
+# set_parent command
+##########################################################################
+
+_register_help "set_parent" \
+  "Set another branch as parent of this branch." <<'EOT'
+Usage: gee set_parent <parent-branch>
+
+Gee keeps track of which branch each branch is branched from.  You can
+change the parent of the current branch with this command, but be sure
+to do a "gee update" operation afterwards.
+EOT
+
+function gee__set_parent() {
+  _startup_checks "set_parent"
+
+  _check_cwd
+  local BRANCH PARENT
+  BRANCH="$(_get_current_branch)"
+  PARENT="$1"
+  if [[ -z "${PARENT}" ]]; then
+    _fatal "Must specify a parent branch."
+  fi
+  _read_parents_file
+  PARENTS["${BRANCH}"]="$1"
+  _write_parents_file
+  echo "${PARENT} is the parent branch of ${BRANCH}"
+}
+
+##########################################################################
+# commit command
+##########################################################################
+
+_register_help "commit" \
+  "Commit all changes in this branch" \
+  "push" "c" <<'EOT'
+Usage: gee commit [<git commit options>]
+
+Commits all outstanding changes to your local branch, and then immediately
+pushes your commits to `origin` (your private, remote github repository).
+
+"commit" can be used to checkpoint and back up work in progress.
+
+Note that if you are working in a PR-associated branch created with `gee
+pr_checkout`, your commits will be pushed to your `origin` remote, and the
+remote PR branch.  To contribute your changes back to another user's PR branch,
+use the `gee pr_push` command.
+
+Unless GEE_ENABLE_PRESUBMIT_CANCEL feature is disabled, gee
+will check to see if pushing the current commit will invalidate a presubmit job
+in the `pending` state.  If this is the case, gee will kill the previous
+presubmit before pushing the changes and thus kicking off the new presubmit.
+
+Example:
+
+    gee commit -m "Added \"gee commit\" command."
+
+See also:
+
+* pr_push
+
+EOT
+
+function gee__push() { gee__commit "$@"; }
+function gee__c() { gee__commit "$@"; }
+function gee__commit() {
+  _startup_checks "commit"
+
+  _check_cwd
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  _set_main
+  if [[ "${CURRENT_BRANCH}" == "${MAIN}" ]]; then
+    _info "gee's workflow doesn't allow changes to the ${MAIN} branch."
+    _info "You should move your changes to another branch.  For example:"
+    _info "  git add -A; git stash; gcd -m new1; git stash apply"
+    _fatal "Commit to ${MAIN} branch denied."
+  fi
+  BRANCH_DIR="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+  _debug "${BRANCH_DIR}" "${HOME}"
+  if [[ "${BRANCH_DIR}" != "${HOME}" ]]; then
+    _git add --all
+  else
+    echo "Skipped \"git add --all\" because branch is home dir."
+  fi
+
+  local AMENDING=0
+  if printf "%s\0" "$@" | grep -qz "^--amend$"; then
+    _info "Amending previous commit."
+    AMENDING=1
+    if _remote_branch_exists origin "${CURRENT_BRANCH}"; then
+      _git fetch
+      local -a COUNTS
+      read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+      if [[ "${COUNTS[1]}" -gt 0 ]]; then
+        _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}." \
+              "You must integrate these changes before attempting to amend and force-push the head commit."
+        if _confirm_default_yes "Do you want to pull upstream changes now? (Y/n)  "; then
+          _git rebase --autostash "origin/${CURRENT_BRANCH}"
+          _check_diff_for_merge_conflict_markers
+        else
+          _fatal "Aborted commit --amend operation because origin is ahead of local branch."
+          return 0
+        fi
+      fi
+    fi
+  fi
+
+  if _git_can_fail commit "$@"; then
+    if [[ "${GEE_ENABLE_PRESUBMIT_CANCEL}" != "0" ]]; then
+      if _push_will_trigger_presubmit "${CURRENT_BRANCH}"; then
+        # kill running presubmit job, if any exists:
+        _info "Killing any previous presubmit jobs."
+        gee__pr_cancel
+      fi
+    fi
+    if [[ "${AMENDING}" == 1 ]]; then
+      _push_to_origin "+${CURRENT_BRANCH}"  # force push is "safe" because we previously integrated.
+    else
+      if _remote_branch_exists origin "${CURRENT_BRANCH}"; then
+        _git fetch
+        local -a COUNTS
+        read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+        if [[ "${COUNTS[1]}" -gt 0 ]]; then
+          _warn "Remote branch origin/${CURRENT_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${CURRENT_BRANCH}."
+          _warn "You ought to integrate changes from origin before pushing."
+          if _confirm_default_yes "Do you want to pull changes from origin now? (Y/n)  "; then
+            _git rebase --autostash "origin/${CURRENT_BRANCH}"
+            _check_diff_for_merge_conflict_markers
+          else
+            _warn "Skipping push of branch to origin/${CURRENT_BRANCH}" \
+                  "Use \"git push -f\" if you know you want to overwrite the other changes in origin."
+            return 0
+          fi
+        fi
+      fi
+      # We always push upstream so that users have a backup in case they lose their
+      # laptop.  We should not need to force push here.
+      _push_to_origin "${CURRENT_BRANCH}"
+    fi
+    _read_parents_file
+    if [[ "${PARENTS[${CURRENT_BRANCH}]}" == upstream/refs/pull/*/head ]]; then
+      _info "NOTE: This is a branch of another user's PR.  Your changes were pushed to *your* " \
+            "      github fork.  To push your changes back into the other user's PR, you need " \
+            "      to use the \"gee pr_push\" command."
+    fi
+  fi
+}
+
+##########################################################################
+# revert command
+##########################################################################
+
+_register_help "revert" \
+  "Revert specified files to match the parent branch." \
+  <<'EOT'
+Usage: gee revert <files...>
+
+Reverts changes to the specified files, so that they become identical to the
+version in the parent branch.  If the file doesn't exist in the parent
+branch, it is deleted from the current branch.
+
+Example:
+
+    gee revert foobar.txt
+EOT
+
+function gee__revert() {
+  _startup_checks "revert"
+
+  _check_cwd
+  local CURRENT_BRANCH CURRENT_ROOT
+  CURRENT_BRANCH="$(_get_current_branch)"
+  CURRENT_ROOT="$(_get_branch_rootdir "${CURRENT_BRANCH}")"
+  local PARENT_BRANCH
+  _set_main
+  PARENT_BRANCH="$(_get_parent_branch "${CURRENT_BRANCH}")"
+
+  local -a MODIFIED=()
+  local -a ADDED=()
+  local F REL_F
+  for F in "$@"; do
+    REL_F="$(realpath --relative-base="${CURRENT_ROOT}" -e ${F})"
+    if git cat-file blob "${PARENT_BRANCH}:${REL_F}" >/dev/null 2>&1; then
+      MODIFIED+=("${F}")
+    else
+      ADDED+=("${F}")
+    fi
+  done
+  if [[ "${#MODIFIED[@]}" -ne 0 ]]; then
+    _git checkout "${PARENT_BRANCH}" -- "${MODIFIED[@]}"
+  fi
+  if [[ "${#ADDED[@]}" -ne 0 ]]; then
+    _git rm "${ADDED[@]}"
+  fi
+}
+
+##########################################################################
+# pr_checkout command
+##########################################################################
+_register_help "pr_checkout" \
+  "Create a client containing someone's pull request." <<'EOT'
+Usage: gee pr_checkout [-n <branch-name>] <PR>
+
+Creates a new branch containing the specified pull request.
+
+The "-n" flag may be used to specify a name for the locally created branch.
+Otherwise, gee will default to creating a branch named "pr_<PR>" (ie, "gee
+pr_checkout 1234" creates a branch named "pr_1234").
+
+Note that the new will be configured so that `gee update` will update that
+branch by integrating changes from the original pull request.  However,
+`gee commit` will still only push commits to your own local and `origin`
+repositories.  If you want to push commits back into the original PR,
+use the `pr_push` command.
+
+See also:
+
+* commit
+* pr_push
+
+EOT
+
+function gee__pr_checkout() {
+  _startup_checks "pr_checkout"
+
+  _check_gh_auth
+  _set_main
+  local BRANCH=""
+  if [[ "$1" == "-n" ]] || [[ "$1" == "--name" ]]; then
+    BRANCH="$2"
+    shift;shift
+  fi
+  local PRNUM="$1"; shift
+  if [[ -z "${BRANCH}" ]]; then
+    BRANCH="pr_${PRNUM}"
+  fi
+
+  _checkout_or_die "${MAIN}"  # or _local_branch_exists won't work.
+  if ! _local_branch_exists "${BRANCH}"; then
+    gee__mkbr "${BRANCH}"
+  else
+    _confirm_or_exit "Branch ${BRANCH} exists: okay to reset it?  "
+  fi
+  _checkout_or_die "${BRANCH}"
+
+  _gh pr checkout --force --branch "${BRANCH}" "${PRNUM}"
+
+  _read_parents_file
+  PARENTS["${BRANCH}"]="upstream/refs/pull/${PRNUM}/head"
+  _write_parents_file
+
+  _checkout_or_die "${BRANCH}"
+  _push_to_origin "${BRANCH}"
+  _info "Pulled PR #${PRNUM} into branch \"${BRANCH}\""
+}
+
+##########################################################################
+# pr_push command
+##########################################################################
+_register_help "pr_push" \
+  "Push commits into another user's PR branch." <<'EOT'
+Usage: gee pr_push
+
+`gee pr_push` must be executed from within a branch created by `gee pr_checkout`.
+
+`gee commit` will create a local commit, and push that commit to `origin`, the
+remote repository owned by you.  `gee pr_push` can then be used to also push
+your commits into another user's remote pull request branch.
+
+`gee pr_push` will refuse to proceed unless all changes from the remote pull
+request branch are already integrated in your local branch, so you might need
+to `gee update` before `gee pr_push`.
+
+After pushing your changes into another user's PR branch, be sure to directly
+notify that user, so they know to pull your changes into their local branch.
+Otherwise, the other user might accidentally lose your commits entirely if they
+force-push.  Remote users can integrate your changes using the `gee update`
+command, or `git rebase --autostash origin/<branch>` if they aren't a gee user.
+
+See also:
+
+* commit
+* pr_checkout
+
+EOT
+
+function gee__pr_push() {
+  # Check that we are in a PR branch (a branch created with pr_checkout).  This
+  # is somewhat inflexible, but since "pushing to another user's branch" is a
+  # bit of a risky activity, we should be extra careful here and only support
+  # one well-tested way of doing things.
+  local BRANCH
+  BRANCH="$(_get_current_branch)"
+  _read_parents_file
+  local PRNUM=""
+  if [[ "${PARENTS[${BRANCH}]}" == upstream/refs/pull/*/head ]]; then
+    PRNUM="$(cut -d '/' -f4 <<< "${PARENTS[${BRANCH}]}")"
+  else
+    _fatal "This branch does not appear to have been made with \"gee pr_checkout\"."
+  fi
+  _info "This branch appears to be associated with PR #${PRNUM}."
+
+  # Identify remote branch
+  local -a DATA=()
+  _read_cmd DATA "${GH}" pr view "${PRNUM}" \
+    --json author,headRepository,headRepositoryOwner,headRefName,state \
+    --jq '.author["login"],.headRepository["name"],.headRepositoryOwner["login"],.headRefName,.state'
+  local REMOTE_USER REMOTE_BRANCH REMOTE_STATE
+  REMOTE_USER="${DATA[0]}"
+  REMOTE_REPO="${DATA[1]}"
+  REMOTE_REPO_OWNER="${DATA[2]}"
+  REMOTE_BRANCH="${DATA[3]}"
+  REMOTE_STATE="${DATA[4]}"
+
+  # Check that the remote branch hasn't already been merged.
+  if [[ "${REMOTE_STATE}" == "MERGED" ]]; then
+    _fatal "PR${PRNUM} has already been merged, refusing to proceed."
+  fi
+
+  # Fetch from remote branch.
+  # We no longer need to add a new remote:
+  # if ! "${GIT}" remote get-url "${REMOTE_USER}" >/dev/null 2>&1; then
+  #   _git remote add "${REMOTE_USER}" "${GIT_AT_GITHUB}:${REMOTE_USER}/${REPO}.git" >&2
+  # fi
+  _git fetch --force "${GIT_AT_GITHUB}:${REMOTE_REPO_OWNER}/${REMOTE_REPO}" "${REMOTE_BRANCH}"
+
+  # Check if we are behind remote branch
+  local -a COUNTS
+  read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${BRANCH}...FETCH_HEAD")
+  _info "Local has ${COUNTS[0]} more commit(s) than remote ${REMOTE_REPO_OWNER}/${REMOTE_BRANCH}."
+  _info "Remote has ${COUNTS[1]} more commit(s) than local."
+  if [[ "${COUNTS[0]}" -eq 0 ]]; then
+    _fatal "No local commits to push.  Perhaps you need to \"gee commit\" first?"
+  fi
+  if [[ "${COUNTS[1]}" -gt 0 ]]; then
+    _warn "Remote branch ${REMOTE_REPO_OWNER}/${REMOTE_BRANCH} is ${COUNTS[1]} commit(s) ahead of ${BRANCH}."
+    _fatal "You must run \"gee update\" and then try again."
+  fi
+
+  # Push our changes to the remote branch
+  _git push "${GIT_AT_GITHUB}:${REMOTE_REPO_OWNER}/${REMOTE_REPO}" "HEAD:${REMOTE_BRANCH}"
+  _info "Successfully pushed to PR#${PRNUM} (${REMOTE_REPO_OWNER}/${REMOTE_BRANCH})."
+
+  _warn "Please notify ${REMOTE_USER} that they should pull from their remote branch, " \
+        "otherwise they might accidentally force-commit over your changes."
+}
+
+##########################################################################
+# pr_list command
+##########################################################################
+_register_help "pr_list" \
+  "List outstanding PRs" \
+  "lspr" "list_pr" "prls" <<'EOT'
+Usage: gee pr_list [--text] [<user>]
+
+
+Lists information about PRs associated with the specified user (or yourself, if
+no user is specified).
+
+The `--text` option provides an alternative formatting for a list of open PRs, more
+suitable for pasting into an email.
+
+EOT
+function _new_pr_list() {
+  local SEARCH="$1"; shift
+  local JSON TEMPLATE
+  JSON="number,url,author,reviewDecision,title,state,baseRefName,headRefName,createdAt,statusCheckRollup"
+  # golang templates are complex but useful:
+  TEMPLATE=''
+  TEMPLATE+='{{tablerow "URL" "Title" "Author" "Created" "Status" }}'
+  TEMPLATE+='{{tablerow "---" "-----" "------" "-------" "------" }}'
+  TEMPLATE+='{{range .}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ $status := "" }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ $color := "reset" }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.author.login|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
+  TEMPLATE+='{{end}}'
+  gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
+}
+
+function _new_pr_list_with_merging_info() {
+  local SEARCH="$1"; shift
+  local JSON TEMPLATE
+  JSON="number,url,author,reviewDecision,title,state,baseRefName,headRefName,createdAt,statusCheckRollup"
+  # golang templates are complex but useful:
+  TEMPLATE=''
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{tablerow "URL" "Title" "From Branch" "To" "Created" "Status" }}'
+  TEMPLATE+='{{tablerow "---" "-----" "-----------" "--" "-------" "------" }}'
+  TEMPLATE+='{{range .}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ $status := "" }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ $color := "reset" }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ if ne .reviewDecision "REVIEW_REQUIRED" }}{{ $status = .reviewDecision }}{{ end }}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ range .statusCheckRollup}}{{if eq .status "IN_PROGRESS"}}{{ $status = "check pending" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{ range .statusCheckRollup }}{{if eq .conclusion "FAILURE"}}{{ $status = "check failed"}}{{ $color = "red+b:black" }}{{end}}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{if eq $status "APPROVED"}}{{ $color = "blue+b:black" }}{{end}}'
+  # shellcheck disable=SC2016
+  TEMPLATE+='{{tablerow (.url|autocolor $color) (.title|truncate 40|autocolor $color) (.headRefName|autocolor $color) (.baseRefName|autocolor $color) (timeago .createdAt|autocolor $color) ($status|autocolor $color)}}'
+  TEMPLATE+='{{end}}'
+  gh pr list --search "${SEARCH}" --json "${JSON}" --template "${TEMPLATE}"
+}
+
+function gee__lspr() { gee__pr_list "$@"; }
+function gee__list_pr() { gee__pr_list "$@"; }
+function gee__prls() { gee__pr_list "$@"; }
+function gee__pr_list() {
+  _startup_checks "pr_list"
+
+  TEXT_FORMAT=0
+  if [[ "$1" == "--text" ]]; then
+    TEXT_FORMAT=1
+    shift
+  fi
+
+  _check_gh_auth
+  local WHO WHO_3RD_PERSON USER YOUR
+  WHO="@me"
+  WHO_3RD_PERSON="you"
+  USER="${GHUSER}"
+  YOUR="your"
+  if [[ -n "$1" ]]; then
+    WHO="$1"
+    WHO_3RD_PERSON="$1"
+    USER="$1"
+    YOUR="their"
+  fi
+
+  if [[ "${TEXT_FORMAT}" == 1 ]]; then
+    local -a lines=()
+    mapfile -t lines < <(gh \
+      --repo "${UPSTREAM}/${REPO}" \
+      pr list \
+      -L "${PR_LIST_MAX_FETCH}" \
+      --author "${WHO}" \
+      --state open \
+      --json number,reviewDecision,mergeable,createdAt,isDraft,title \
+      --jq '.[] | .number, .reviewDecision, .mergeable, .createdAt, .isDraft, .title')
+    local line number reviewDecision mergeable createdAt isDraft title checks_rc status
+    local -a fields=()
+    local II=0
+    local SIZE="${#lines[@]}"
+    # cap output to first 20 PRs.  TODO(jonathan): make this configurable.
+    if [[ "${SIZE}" -gt 120 ]]; then SIZE=120; fi
+    while (( "$II" < "${SIZE}" )); do
+      number="${lines[$(( II + 0 ))]}"
+      reviewDecision="${lines[$(( II + 1 ))]}"
+      mergeable="${lines[$(( II + 2 ))]}"
+      createdAt="${lines[$(( II + 3 ))]}"
+      isDraft="${lines[$(( II + 4 ))]}"
+      title="${lines[$(( II + 5 ))]}"
+      II="$(( II + 6 ))"
+      status=""
+      if [[ "$isDraft" == "true" ]]; then
+        status+="DRAFT "
+      fi
+      local output checks_rc
+      set +e
+      "${GH}" pr checks "${number}" 2>/dev/null >/dev/null
+      checks_rc="$?"
+      set -e
+      if [[ "$checks_rc" -eq 0 ]]; then
+        status+="Checks passed."
+      elif [[ "$checks_rc" -eq 8 ]]; then
+        status+="Checks pending."
+      elif [[ "$checks_rc" -eq 4 ]]; then
+        status+="Checks: auth failure."
+      elif [[ "$checks_rc" -eq 2 ]]; then
+        status+="Checks cancelled."
+      else
+        status+="CHECKS FAILED."
+      fi
+      echo "* #${number}: ${title}"
+      echo "  ${createdAt:0:10} ${reviewDecision} ${status}"
+      echo "  https://github.com/enfabrica/internal/pull/${number}"
+      echo ""
+    done
+    return
+  fi
+
+  _info "Open PRs authored by ${WHO_3RD_PERSON}:"
+  _new_pr_list_with_merging_info "author:@me"
+  echo ""
+
+  _info "PRs assigned to ${WHO_3RD_PERSON}:"
+  _new_pr_list "assignee:@me"
+  echo ""
+}
+
+##########################################################################
+# edit_pr command
+##########################################################################
+
+_register_help "pr_edit" \
+  "Edit an existing pull request." \
+  "edpr" "pred" "edit_pr" <<'EOT'
+Usage: gee edit_pr <args>
+
+Edit an outstanding pull request.
+
+All arguments are passed to "gh pr edit".
+EOT
+
+function gee__edpr() { gee__pr_edit "$@"; }
+function gee__pred() { gee__pr_edit "$@"; }
+function gee__edit_pr() { gee__pr_edit "$@"; }
+function gee__pr_edit() {
+  _startup_checks "pr_edit"
+
+  _check_cwd
+  _check_gh_auth
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
+  if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
+    # gh-cli treats this as a special case for some reason.
+    FROM_BRANCH="${CURRENT_BRANCH}"
+  fi
+
+  if ! _gh_pr_view > /dev/null; then
+    _fatal "No pull request exists for ${GHUSER}:${CURRENT_BRANCH}."
+  fi
+
+  # The same view options also work for pr edit:
+  _gh pr edit --repo "${UPSTREAM}/${REPO}" "${FROM_BRANCH}" "$@"
+}
+
+##########################################################################
+# pr_debug command
+#
+# gh api for querying pull requests is pretty wonky, this is a temporary
+# command used to get some visibility into the API.
+##########################################################################
+
+function gee__pr_debug() {
+  _startup_checks "pr_debug"
+
+  _check_cwd
+  _check_gh_auth
+  local -a PRS=()
+  _get_pull_requests "$(_get_current_branch)"
+  mapfile -t PRS < <( _list_open_pr_numbers )
+  _info "Open pull requests: ${PRS[*]}"
+  mapfile -t PRS < <( _list_merged_pr_numbers "")
+  _info "Merged pull requests: ${PRS[*]}"
+}
+
+##########################################################################
+# view_pr command
+##########################################################################
+
+_register_help "pr_view" \
+  "View an existing pull request." \
+  "view_pr" <<'EOT'
+Usage: gee pr_view
+
+View an outstanding pull request.
+EOT
+
+function gee__view_pr() { gee__pr_view "$@"; }
+function gee__pr_view() {
+  _startup_checks "pr_view"
+
+  _check_cwd
+  _check_gh_auth
+  if ! _gh_pr_view; then
+    _fatal "No pull request exists for ${GHUSER}:${CURRENT_BRANCH}."
+  fi
+}
+
+##########################################################################
+# make_pr command
+##########################################################################
+
+_register_help "pr_make" \
+  "Creates a pull request from this branch." \
+  "mail" "send" "pr_create" "create_pr" "make_pr" "mkpr" "prmk" <<'EOT'
+Usage: gee make_pr <gh-options>
+
+Creates a new pull request from this branch.  The user will be asked to
+edit a PR description file before the PR is created.
+
+These special tokens, on a line by themselves in your description, have
+the following effect:
+
+* "DRAFT" causes your PR to be marked as a draft.
+* "AUTOMERGE" causes your PR to have auto-merge enabled.
+* "ABORT" will cause gee to abort the creation of your PR.
+
+`pr_make` will look at the recursive parentage of the current branch  until
+it finds a remote branch as a parent.  This remote branch (usually `upstream/master`)
+will be used as the "base" branch for the PR to be merged into.
+
+Uses the same options as "gh pr create".
+EOT
+
+function gee__mail() { gee__pr_make "$@"; }
+function gee__send() { gee__pr_make "$@"; }
+function gee__mkpr() { gee__pr_make "$@"; }
+function gee__prmk() { gee__pr_make "$@"; }
+function gee__make_pr() { gee__pr_make "$@"; }
+function gee__pr_create() { gee__pr_make "$@"; }
+function gee__create_pr() { gee__pr_make "$@"; }
+function gee__pr_make() {
+  _startup_checks "pr_make"
+
+  _check_cwd
+  _check_gh_auth
+  local DEST_BRANCH CURRENT_BRANCH NUM_COMMITS FIRST_PARENT
+  _git fetch upstream
+  _read_parents_file
+
+  CURRENT_BRANCH="$(_get_current_branch)"
+  _info "Current branch: ${CURRENT_BRANCH}"
+
+  local DEST_BRANCH
+  DEST_BRANCH="$(_get_upstream_parent "${CURRENT_BRANCH}")"
+  _info "Destination branch: ${DEST_BRANCH}"
+
+  if [[ "${DEST_BRANCH}" == */pull/* ]]; then
+    _warn "This branch was created from a pull request (${DEST_BRANCH})." \
+          "To create a pull request, you need to change the parent of this branch" \
+          "to indicate the upstream branch you want to merge into.  For example:" \
+          "    gee set_parent upstream/master"
+    _fatal "Refusing to create a PR until parent branch is updated."
+  fi
+
+  local -a pr_vars
+  mapfile -t pr_vars < \
+    <("${GH}" pr view --json number,state,isDraft,title --jq '.number, .state, .isDraft, .title')
+  local NUMBER="${pr_vars[0]}"
+  local STATE="${pr_vars[1]}"
+  local IS_DRAFT="${pr_vars[2]}"
+  local TITLE="${pr_vars[*]:3}"
+
+  if [[ "${STATE}" == "OPEN" ]]; then
+    if [[ "${IS_DRAFT}" == "false" ]]; then
+      _info "Open PR exists: #${NUMBER} \"${TITLE}\"" \
+            "Use \"gee commit\" to update existing PR."
+      exit 0
+    else
+      _info "Draft PR exists: #${NUMBER} \"${TITLE}\""
+      if _confirm_default_yes "Do you want to mark this PR as ready for review? (Y/n)  "; then
+        _gh pr ready "${NUMBER}" || echo $?
+        exit 0
+      else
+        _info "Leaving PR #${NUMBER} as a draft."
+        exit 0
+      fi
+    fi
+  fi
+
+  local UNCOMMITTED
+  UNCOMMITTED="$("${GIT}" status --short -uall | wc -l)"
+  if [[ "${UNCOMMITTED}" -gt 0 ]]; then
+    echo "Branch contains ${UNCOMMITTED} uncommitted changes:"
+    _git status --short -uall
+    echo "Run \"gee commit\" and try again."
+    _fatal Aborted.
+  fi
+
+  NUM_COMMITS="$("${GIT}" log --oneline "${DEST_BRANCH}..${CURRENT_BRANCH}" | wc -l)"
+  if [[ "${NUM_COMMITS}" -eq 0 ]]; then
+    _debug "command: ${GIT} log --oneline ${DEST_BRANCH}..${CURRENT_BRANCH}"
+    _fatal "No changes in this branch."
+  fi
+
+  local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
+  if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
+    # gh-cli treats this as a special case for some reason.
+    FROM_BRANCH="${CURRENT_BRANCH}"
+  fi
+
+  local PARENT
+  PARENT="$(_get_parent_branch)"
+  local -a PARENT_PRS
+  mapfile -t PARENT_PRS < <( _list_open_pr_numbers "$(_get_parent_branch)" )
+
+  local BODYFILE TRIMMED
+  BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
+  TRIMMED="${BODYFILE}.trimmed"
+  (
+    cat <<'EndOfPrTemplate'
+# The first line should be the PR title.  For example: "scripts/gee: Add new PR template."
+
+# Why?  What?  How?
+
+# What manual testing have you performed?
+Tested:
+
+# Uncomment to enable:
+# DRAFT      # To mark this PR as a "draft"
+# AUTOMERGE  # To enable automatic merging when merge requirements are met
+# ABORT      # To abort the creation of a PR.
+
+EndOfPrTemplate
+
+    local OWNERS=()
+    mapfile -t OWNERS < <(_print_codeowners | sed -e 's/@//g')
+    if [[ "${#OWNERS[@]}" -eq 0 ]]; then
+      printf "# This PR can be submitted with anyone's approval.\n"
+    elif [[ "${#OWNERS[@]}" -eq 1 ]]; then
+      printf "# This PR requires approval from at least one of these code owners:\n"
+      printf "#  * %s\n" "${OWNERS[@]}"
+    else
+      printf "# This PR requires approval from at least one code owner on each line:\n"
+      printf "#  * %s\n" "${OWNERS[@]}"
+    fi
+    printf "# Pick assignees:\n"
+    printf "ASSIGNEES: \n\n"
+
+    if (( "${#PARENT_PRS[@]}" > 0 )); then
+      printf "NOTE: this PR includes changes that are also in PR #%d.\n" "${PARENT_PRS[0]}"
+      printf "      Review and submit that PR first, so that this PR will be\n"
+      printf "      easier to read.\n\n"
+    fi
+    printf "\n# Targeting destination branch %s\n" "${DEST_BRANCH}"
+    printf "\n# The following files were modified in this PR:\n"
+    "${GIT}" diff --name-only "${DEST_BRANCH}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
+    printf "#\n# Here is your commit log:\n"
+    "${GIT}" log --reverse "${DEST_BRANCH}...${CURRENT_BRANCH}" | sed 's/^/# /' | cat
+
+    # TODO(jonathan): add support for specifying tags and reviewers in the
+    #                 PR description.
+  ) >"${BODYFILE}"
+
+  DONE=0
+  while (( DONE == 0 )); do
+    if [[ -n "${EDITOR}" ]]; then
+      "${EDITOR}" "${BODYFILE}"
+    else
+      declare -g RESP=""
+      _choose_one "How do you want to edit the PR description?? ([V]im, [e]macs, or [a]bort)  " \
+          "vVeEaA" "v"
+      case "${RESP}" in
+        [vV]*) vim "${BODYFILE}"; ;;
+        [eE]*) emacs "${BODYFILE}"; ;;
+        [aA]*) _fatal "Aborted."; ;;
+      esac
+    fi
+
+    # Remove all comments from the description and squeeze multiple blank
+    # lines into single blank lines:
+    sed -E 's/^#.*//;/\S/,/^\s*$/!d' "${BODYFILE}" > "${TRIMMED}"
+
+    if grep --quiet -E "^\s*ABORT" "${TRIMMED}"; then
+      _fatal "Aborting creation of new PR, as requested."
+      exit 1
+    fi
+
+    if _check_pr_description "${TRIMMED}"; then
+      DONE=1
+    else
+      declare -g RESP=""
+      _choose_one "PR description needs a fix.  [R]e-edit or [a]bort?  " \ "rRaA" "r"
+      case "${RESP}" in
+        [aA]*) _fatal "Aborted."; ;;
+      esac
+    fi
+  done
+
+  # Parse metadata from PR description.
+  local TITLE
+  TITLE="$(head -1 "${TRIMMED}")"
+  # We remove the title from the body file to avoid "stuttering" the
+  # title when we eventually submit the PR:
+  sed -i '1{d};2{/^$/d}' "${TRIMMED}"
+
+  _push_to_origin "${CURRENT_BRANCH}"
+  # gh pr is arcane and confusing, but this works:
+  #  -R specifies the repo that we are pushing changes into.
+  #  -H specifies the branch that contains outstanding commits,
+  #     formatted username:branchname.
+  #  -B specifies the branch we want to merge to, defaults to ${UPSTREAM}:${MAIN}
+  local -a PR_ARGS
+  PR_ARGS+=(
+    --repo "${UPSTREAM}/${REPO}"
+    --title "${TITLE}"
+    -H "${GHUSER}:${CURRENT_BRANCH}"
+    --body-file "${TRIMMED}"
+    --base "${DEST_BRANCH#*/}"
+  )
+  local DRAFT=0
+  if grep --quiet -E "^\s*DRAFT" "${TRIMMED}"; then
+    sed -i '/^\s*DRAFT/d' "${TRIMMED}"
+    DRAFT=1
+    PR_ARGS+=( --draft )
+  fi
+  local AUTOMERGE=0
+  if grep --quiet -E "^\s*AUTOMERGE" "${TRIMMED}"; then
+    AUTOMERGE=1
+  fi
+
+  local ASSIGNEES=()
+  mapfile -t ASSIGNEES < <(grep ^ASSIGNEES: "${TRIMMED}" | xargs -n1 | grep -v ^ASSIGNEES:)
+  if [[ "${#ASSIGNEES[@]}" == 0 ]] && [[ "${DRAFT}" == 0 ]]; then
+    _warn "Every PR must have one or more assignees.  Assigning to you for now."
+    ASSIGNEES=( "@me" )
+  fi
+  sed -i '/^ASSIGNEES:/d' "${TRIMMED}"
+
+  local A
+  for A in "${ASSIGNEES[@]}"; do
+    PR_ARGS+=(--assignee "${A}")
+  done
+
+  PR_ARGS+=( "$@" )
+
+  _gh pr create "${PR_ARGS[@]}"
+
+  if (( DRAFT != 1 )); then
+    gee__codeowners --comment
+  fi
+
+  if (( AUTOMERGE == 1 )); then
+    sleep 1  # wait for github
+    _gh pr merge --auto --squash </dev/null
+  fi
+
+  # _gh pr checks  # These take a while to run, no point checking now.
+  _gh_pr_view
+
+  if (( DRAFT != 1 )); then
+    local NUM_REVIEWERS
+    NUM_REVIEWERS="$(gh pr view \
+      --repo "${UPSTREAM}/${REPO}" "${GHUSER}:${CURRENT_BRANCH}" \
+      --json reviewRequests --jq '.reviewRequests | length')"
+    if (( NUM_REVIEWERS == 0 )); then
+      _warn "Don't forget to add reviewers!"
+    fi
+  fi
+  rm "${BODYFILE}" "${TRIMMED}"
+}
+
+##########################################################################
+# pr_cancel command
+##########################################################################
+
+_register_help "pr_cancel" \
+  "Cancels any running gcloud builds associated with this branch." \
+  "cancel" "cancel_pr" <<'EOT'
+Usage: gee pr_cancel
+
+Cancels any pending (status = QUEUED or WORKING) gcloud builds jobs
+associated with this branch.  This command can be used to cancel
+a set of presubmits that were triggered by a change to this branch.
+EOT
+
+function gee__pr_cancel() {
+  local BR
+  local -a FIELDS=()
+  local COUNT
+  local FILTER
+  COUNT=0
+  BR="$(_get_current_branch)"
+  FILTER="substitutions.BRANCH_NAME=${BR}"  # filter by branch name
+  FILTER+=" AND substitutions._HEAD_REPO_URL:${GHUSER}"  # and filter by github username
+  FILTER+=" AND substitutions.TRIGGER_NAME:presubmit"
+  FILTER+=" AND (status=\"WORKING\" OR status=\"QUEUED\")"  # and by job status
+  while read -r -a FIELDS; do
+    local ID="${FIELDS[1]}"
+    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" --region us-west1 > /dev/null
+    COUNT=$((COUNT + 1))
+  done < <(_cmd gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds list \
+              --region us-west1 \
+              --format=yaml \
+              --filter="${FILTER}" \
+              | grep ^id:)
+  _info "Killed ${COUNT} job(s)."
+}
+
+##########################################################################
+# pr_check command
+##########################################################################
+
+_register_help "pr_check" \
+  "Checks the status of presubmit tests for a PR." \
+  "pr_checks" "check_pr" "check" "checks" <<'EOT'
+Usage: gee pr_check [--wait]
+
+Returns the state of presubmit checks.  If the --wait option is provided,
+this command will continue to report check status until all pending
+checks have completed.
+EOT
+
+function _push_will_trigger_presubmit() {
+  local BR="$1"
+  local LOCALHEAD ORIGINHEAD
+  if ! _remote_branch_exists origin "${BR}"; then
+    return 0  # true
+  fi
+  LOCALHEAD="$(git rev-parse "${BR}")"
+  ORIGINHEAD="$(git rev-parse "origin/${BR}")"
+  if [[ "${LOCALHEAD}" == "${ORIGINHEAD}" ]]; then
+    return 1  # false
+  else
+    return 0  # true
+  fi
+}
+
+function _parse_gh_pr_checks() {
+  # Usage: _parse_gh_pr_checks COUNTS BUILDS "${LINES[@]}"
+  # where:
+  #   COUNTS is the name of the associative array to populate with counts of each result type.
+  #   BUILDS is the name of the array to populate with the build identifiers of failed tests.
+  #   LINES is the output of `gh pr checks`, in array form.
+  #
+  # This function parses the output of "gh pr checks" and converts it to a more useful form.
+  #
+  # Example output of gh pr checks command:
+  #
+  #   $ gh pr checks | column -t
+  #   internal-bazel-presubmit             (cloud-build-290921)  fail      27m36s  https://console.cloud.google.com/cloud-build/builds/104e0ed9-6dd6-443d-8afd-1aa05c649fac?project=496137108493
+  #   linter-checks                        (cloud-build-290921)  pass      30s     https://console.cloud.google.com/cloud-build/builds/260f3b1a-b423-4ffc-a522-5eecc6480c28?project=496137108493
+  #   Pushes-preview-version-of-web-pages  (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/c731b7a4-47a4-4ee2-8d5e-e0f699da7568?project=496137108493
+  #   external-dependencies                (cloud-build-290921)  skipping  0       https://console.cloud.google.com/cloud-build/triggers/edit/4298bbb8-4289-4d32-be9e-5d0d69fe27de?project=496137108493
+
+  local -n CHECK_COUNTS_REF="$1"  # reference to an associative array
+  shift
+  local -n FAILED_BUILDS_REF="$1"  # reference to an array
+  shift
+  local -a LINES=( "$@" )
+  CHECK_COUNTS_REF=( [fail]=0 )
+  FAILED_BUILDS_REF=()
+
+  local LINE
+  local -a FIELDS=()
+  for LINE in "${LINES[@]}"; do
+    read -r -a FIELDS <<< "${LINE}"
+    (( CHECK_COUNTS_REF["${FIELDS[2]}"]++ )) || /bin/true
+    if [[ "${FIELDS[2]}" == "fail" ]]; then
+      if [[ "${FIELDS[4]}" =~ builds\;region=us-west1/([a-f0-9-]*)\?project ]]; then
+        FAILED_BUILDS_REF+=( "${BASH_REMATCH[1]}" )
+      else
+        _warn "Could not parse build number from URL: ${FIELDS[4]}"
+      fi
+    fi
+  done
+  return 0
+}
+
+function gee__check_pr() { gee__pr_check "$@"; }
+function gee__check() { gee__pr_check "$@"; }
+function gee__checks() { gee__pr_check "$@"; }
+function gee__pr_checks() { gee__pr_check "$@"; }
+function gee__pr_check() {
+  _startup_checks "pr_check"
+
+  local WAIT=0
+  if [[ " $* " == *" --wait "* ]]; then
+    WAIT=1
+  fi
+
+  local PREV_CHECKS=""
+  local -a CHECKS=()
+  local -A CHECK_COUNTS=()
+  local -a FAILED_BUILDS=()
+  local PENDING=1
+  local CHECKS_FAILED=0
+  printf >&2 "${_COLOR_CMD}CMD:%-${C}s${_COLOR_RST}\n" " ${GH} pr checks"  # show user what we're doing
+  while [[ "${PENDING}" -ne 0 ]]; do
+    if VERBOSE=0 DONT_WARN=1 GRAB_STDERR=1 _read_cmd CHECKS "${GH}" pr checks; then
+      printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
+      # no failures, nothing pending.
+      _info "All checks successful."
+      CHECKS_FAILED=0
+      PENDING=0
+    else
+      # Sometimes github takes a long time to start presubmit tasks, and "gh pr checks"
+      # will incorrectly return "success" when the checks simply haven't started yet.
+      # We check for that condition by making sure the CHECKS list isn't empty, and
+      # doesn't contain a string like:
+      #    "no checks reported on the 'gee_no_empty_checks' branch"
+      if [[ "${#CHECKS[@]}" == 0 ]] || [[ "${CHECKS[0]}" == "no checks "* ]]; then
+        # Sometimes gh pr check fails, sometimes it doesn't.
+        _info "Waiting for checks to start."
+        PENDING=1
+        CHECK_COUNTS=()
+      else
+        # something went wrong.  Is a test pending, or did we get a failure?
+        _parse_gh_pr_checks CHECK_COUNTS FAILED_BUILDS "${CHECKS[@]}"
+        # Only inform the user when a result changes:
+        if [[ "${PREV_CHECKS}" != "${CHECKS[*]}"  ]]; then
+          printf "%s\n" "${CHECKS[@]}" | sed 's/(.*)//' | column -t >&2
+          PREV_CHECKS="${CHECKS[*]}"
+          local REPORT="gh pr checks:"
+          local KEY
+          for KEY in "${!CHECK_COUNTS[@]}"; do
+            REPORT+="$(printf " %s=%d" "${KEY}" "${CHECK_COUNTS["${KEY}"]}")"
+          done
+          _info "${REPORT}"
+        fi
+        CHECKS_FAILED="${CHECK_COUNTS["fail"]}"
+        PENDING="${CHECK_COUNTS["pending"]}"
+      fi
+      if [[ "${PENDING}" -ne 0 ]]; then
+        if (( WAIT == 0 )); then
+          declare -g RESP=""
+          _choose_one "Some checks are still pending.  [W]ait, [r]etry, [a]bort, or [c]ontinue without waiting?  " \
+            "rRwWaAcC" "w"
+          case "${RESP}" in
+            [aA]*) _fatal "Aborted."; ;;
+            [cC]*) return 1; ;;
+            [wW]*)
+              _info "Waiting until all pending tests are complete."
+              WAIT=1
+              ;;
+          esac
+        fi
+        sleep 10
+      fi
+    fi
+  done
+  if [[ "${CHECKS_FAILED}" == "" ]]; then
+    CHECKS_FAILED=1
+  fi
+  if (( CHECKS_FAILED > 0 )); then
+    _warn "Some presubmit checks have failed."
+    if command -v gcloud &> /dev/null; then
+      local BUILD
+      for BUILD in "${FAILED_BUILDS[@]}"; do
+        _warn "Failed build: ${BUILD}"
+        gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds log "${BUILD}" --region us-west1  | grep -i -E "(failed:|error:|streaming build results to:)"
+      done
+    fi
+  fi
+  return "${CHECKS_FAILED}"
+}
+
+##########################################################################
+# pr_rerun command
+##########################################################################
+
+_register_help "pr_rerun" \
+  "Rerun presubmit checks." \
+  "pr_run" "rerun" "gcbrun" <<'EOT'
+Usage: gee pr_rerun
+
+Forces any presubmit checks associated with this PR to try again.
+
+This normally occurs whenever you push a new commit to your PR.  Sometimes,
+however, a presubmit will fail for reasons unrelated to your PR (for example, a
+transient infrastructure failure).  This command allows you to re-run the set
+of presubmit checks without changing your PR.
+EOT
+
+function gee__rerun() { gee__pr_rerun "$@"; }
+function gee__gcbrun() { gee__pr_rerun "$@"; }
+function gee__pr_run() { gee__pr_rerun "$@"; }
+function gee__pr_rerun() {
+  _startup_checks "pr_rerun"
+
+  _gh pr comment --body "/gcbrun"
+  _info "Give github about a minute to start running checks again."
+}
+
+##########################################################################
+# submit_pr command
+##########################################################################
+
+_register_help "pr_submit" \
+  "Merge the approved PR into the parent branch." \
+  "merge" "submit_pr" <<'EOT'
+Usage: gee submit_pr
+
+Merges an approved pull request.
+EOT
+function gee__submit_pr() { gee__pr_submit "$@"; }
+function gee__merge() { gee__pr_submit "$@"; }
+function gee__pr_submit() {
+  _startup_checks "pr_submit"
+
+  _check_cwd
+  _check_gh_auth
+
+  # Check the status of the PR.
+  local -a pr_vars=()
+  mapfile -t pr_vars < \
+    <("${GH}" pr view --json number,state,isDraft,baseRefName --jq '.number, .state, .isDraft, .baseRefName')
+  local pr_number="${pr_vars[0]}"
+  local pr_state="${pr_vars[1]}"
+  local pr_is_draft="${pr_vars[2]}"
+  local pr_base="${pr_vars[3]}"
+  if [[ "${pr_state}" == "MERGED" ]]; then
+    _fatal "Associated PR #${pr_number} has already been merged."
+  fi
+  if [[ "${pr_state}" != "OPEN" ]]; then
+    _gh pr view
+    _fatal "An open PR was not found."
+  fi
+  if [[ "${pr_is_draft}" == "true" ]]; then
+    _fatal "Open PR #${pr_number} is still a draft."
+  fi
+  # Presubmit check: does remote branch exist?
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  if ! _remote_branch_exists origin "${CURRENT_BRANCH}"; then
+    _fatal "Remote branch ${CURRENT_BRANCH} does not exist."
+  fi
+  # Presubmit check: Are there uncommitted local changes?
+  local DIFFS
+  DIFFS="$("${GIT}" diff --name-only | wc -l)"
+  if (( "${DIFFS}" != 0 )); then
+    _fatal "Will not submit: current branch has uncommitted changes."
+  fi
+  # Presubmit check: Is the remote branch in sync with the local branch:
+  local -a COUNTS
+  read -r -a COUNTS < \
+    <("${GIT}" rev-list --left-right --count "${CURRENT_BRANCH}...origin/${CURRENT_BRANCH}")
+  if [[ "${COUNTS[1]}" -gt 0 ]]; then
+    _warn "Remote origin/${CURRENT_BRANCH} is ${COUNTS[1]} commits ahead of local ${CURRENT_BRANCH}."
+    _fatal "Will not submit PR."
+  fi
+  if [[ "${COUNTS[0]}" -gt 0 ]]; then
+    _warn "Local ${CURRENT_BRANCH} is ${COUNTS[0]} commits ahead of remote origin/${CURRENT_BRANCH}."
+    _fatal "Will not submit PR."
+  fi
+
+  # Presubmit check: Are presubmit checks passing?
+  if ! gee__pr_check "$@"; then
+    if ! _confirm_default_no \
+      "Presubmit checks did not succeed.  Proceed anyway? (y/N)  "; then
+      _fatal "PR submission aborted."
+    fi
+  fi
+
+  # Get some information about this PR before we merge.
+  local MERGEBASE
+  MERGEBASE="$( "${GIT}" merge-base "upstream/${pr_base}" "origin/${CURRENT_BRANCH}" )"
+  _info "Merging into ${pr_base}, Merge base: ${MERGEBASE}"
+  local -a COMMITS
+  mapfile -t COMMITS < <( "${GIT}" log --pretty=oneline "${MERGEBASE}"..HEAD | awk '{print $1}' )
+  local -a FILES
+  mapfile -t FILES < <( "${GIT}" diff --name-only "${MERGEBASE}"..HEAD )
+  _info "PR contains ${#COMMITS[@]} commits, changing ${#FILES[@]} files."
+
+  # Extract the title and first comment as the commit message.
+  local BODYFILE
+  BODYFILE="$(mktemp -t pr.message.XXXXXX.txt)"
+  TEMPFILE="$(mktemp -t pr.temp.XXXXXX.txt)"
+  "${GH}" pr view > "${TEMPFILE}"
+  grep "^title:" "${TEMPFILE}" | sed 's/title:\s*//' >"${BODYFILE}"
+  echo "" >> "${BODYFILE}"
+  sed -n '/^--/,$p' "${TEMPFILE}" | tail +2 >> "${BODYFILE}"
+  rm "${TEMPFILE}"
+
+  _info "Commit message will be:"
+  cat "${BODYFILE}"
+
+  local FROM_BRANCH="${GHUSER}:${CURRENT_BRANCH}"
+  if [[ "${UPSTREAM}" == "${GHUSER}" ]]; then
+    # gh-cli treats this as a special case for some reason.
+    FROM_BRANCH="${CURRENT_BRANCH}"
+  fi
+  # Tag the old head commit so we can keep track after squashing:
+  _git tag --force "${CURRENT_BRANCH}-unsquashed" "${CURRENT_BRANCH}"
+
+  _gh pr merge \
+    --squash \
+    --body-file "${BODYFILE}" \
+    --repo "${UPSTREAM}/${REPO}" \
+    "${FROM_BRANCH}"
+  rm "${BODYFILE}"
+  _git fetch upstream
+
+  # This check is of low value (gr pr merge is reliable), and occasionally
+  # reports false negatives (ie. if two PRs changed the same file, but
+  # gh pr merge was able to merge the changes without requiring the user
+  # to update the source branch first).  This check is disabled for now:
+  #
+  # # Confirm that the merge was successful:
+  # mapfile -t DIFFS < <( "${GIT}" diff --name-only \
+  #     "upstream/${MAIN}..${CURRENT_BRANCH}" -- "${FILES[@]}" )
+  # if (( "${#DIFFS[@]}" != 0 )); then
+  #   # TODO(jonathan): should this be a warning?
+  #   _fatal "Uh oh!  Even after merge, these files have local changes:" \
+  #     "  ${DIFFS[*]}"
+  # fi
+
+  # Reset this branch to now contain the squash-merged commit:
+  _checkout_or_die "${CURRENT_BRANCH}"  # make sure we're in the right branch.
+  _git checkout -B "${CURRENT_BRANCH}" "upstream/${pr_base}"
+  _push_to_origin "+${CURRENT_BRANCH}"
+
+  # After a squash merge, we have a potential problem for child (and
+  # grandchild) branches of this one.  When they attempt to rebase, they will
+  # end up attempting to replay commits that were already squash-merged,
+  # leading to conflicts.  To avoid these conflicts, we rebase all branches of
+  # the current branch now.
+
+  # 1. Check for child branches of the change we just squash-merged.
+
+  # 1a. By using the "git branch --contains" command, we get all descendants
+  # (grandchildren, etc.), even if the branch isn't listed as a child in gee's
+  # branch ancestry metadata.  We look for branches that contain the first
+  # commit in the sequence of commits that were squash-merged, since all
+  # derived branches must at least contain that one commit.  (Note that COMMITS
+  # are in reverse chronological order, so COMMITS[-1] is the earliest commit.)
+  local FIRST_SQUASHED_COMMIT="${COMMITS[-1]}"
+  local -a GITKIDS=()
+  _read_cmd GITKIDS \
+    "${GIT}" branch --format "%(refname:short)" --contains "${FIRST_SQUASHED_COMMIT}"
+
+  # 1b. The above command can fail if a parent branch was rebased, and a child branch
+  # wasn't, in such as way that "FIRST_SQUASHED_COMMIT" is no longer part of that branch.
+  # This happens rarely but often enough that we should use gee's parents metadata as
+  # a fallback.  Better to rebase too many branches than too few.
+  local -a ALT_KIDS=()
+  _read_cmd ALT_KIDS _gee_get_all_children_of "${CURRENT_BRANCH}"
+
+  # 1c. Uniquify the list of kids, and also remove all branches that don't
+  # exist anymore.  TODO(jonathan): prune dead branches from parents file.
+  local -A UNIQUE_KIDS=()
+  local K
+  for K in "${GITKIDS[@]}" "${ALT_KIDS[@]}"; do
+    if _local_branch_exists "${K}"; then
+      UNIQUE_KIDS["${K}"]=1;
+    fi
+  done
+  local -a KIDS=()
+  KIDS+=( "${!UNIQUE_KIDS[@]}" )  # get keys of UNIQUE_KIDS
+
+  # 1d. Bail early if there are no kids.
+  if [[ "${#KIDS[@]}" -eq 0 ]]; then
+    # Our job is done here.
+    return 0
+  fi
+
+  # 2. Update all derived branches to be rebased onto the squash-merged commit.
+  _warn "The following branches contain the commits that were just" \
+        "squash-merged, and need to be rebased to avoid future" \
+        "merge conflicts: ${KIDS[*]}"
+  if _confirm_default_yes "Rebase child branches now? (Y/n)  "; then
+    local CHILD
+    _read_parents_file
+    for CHILD in "${KIDS[@]}"; do
+      _banner "Rebasing ${CHILD}"
+      # First make sure that child contains all the commits from the unsquashed version of the parent:
+      _safer_rebase "${CHILD}" "${CURRENT_BRANCH}-unsquashed"
+      # Then rebase the current branch onto the squashed current branch, using only the commits
+      # not present in the unsquashed parent branch:
+      _safer_rebase "${CHILD}" "${CURRENT_BRANCH}-unsquashed" "${CURRENT_BRANCH}"
+      # Simplify the tree.
+      PARENTS["${CHILD}"]="${MAIN}"
+      _info "Parent branch for \"${CHILD}\" has been set to \"${MAIN}\""
+    done
+    _write_parents_file
+  fi
+}
+
+##########################################################################
+# pr_rollback command
+##########################################################################
+
+_register_help "pr_rollback" \
+  "Create a rollback PR for a specified PR." <<'EOT'
+Usage: gee pr_rollback <PR>
+
+Creates a branch named `rollback_<PR>`, attempts to revert the commit
+associated with that PR, and if successful, creates a new PR that rolls
+back the specified PR.
+
+Example:
+
+    gee pr_rollback 1234
+EOT
+function gee__pr_rollback() {
+  _check_cwd
+  _check_gh_auth
+
+  local PR="$1"
+  if [[ -z "${PR}" ]]; then
+    _fatal "Must specify a PR number to roll back."
+  fi
+
+  _set_main
+  _checkout_or_die "${MAIN}"
+  local BR="rollback_${PR}"
+  if _local_branch_exists "${BR}"; then
+    _fatal "Branch ${BR} already exists, remove and try again?"
+  fi
+  gee__mkbr "${BR}"
+  _checkout_or_die "${BR}"
+
+  local -a LOGLINES=()
+  local RE='\(#'"${PR}"'\)$'
+  mapfile -t LOGLINES < \
+    <( "${GIT}" log --pretty=format:"%h %s" | grep -E "${RE}" )
+  if (( "${#LOGLINES[@]}" == 0 )); then
+    _fatal "Could not find any commits labelled \"${RE}\""
+  fi
+  if (( "${#LOGLINES[@]}" > 1 )); then
+    _fatal "When searching for \"${RE}\", found multiple possible commits:" \
+      "${LOGLINES[@]}"
+  fi
+
+  local COMMIT DESC
+  read -r COMMIT DESC <<< "${LOGLINES[0]}"
+  _info "Identified commit \"${COMMIT}\": ${DESC}"
+
+  _git revert --no-edit "${COMMIT}"  # creates a new commit
+  _git push --quiet -u origin "${BR}"
+  printf >&2 "\n"
+
+  local BODYFILE
+  BODYFILE="$(mktemp -t prbody.XXXXXX.txt)"
+  (
+    printf "gee-generated rollback of PR #%s (was commit %s).\n" "${PR}" "${COMMIT}"
+    printf "\n"
+    printf "Reason for rollback:\n"
+    printf "\n"
+    printf "Original commit message:\n"
+    printf "========================\n"
+    printf "\n"
+    git log --format=%B -n 1 "${COMMIT}"
+  ) >"${BODYFILE}"
+
+  _choose_one \
+    "Which editor do you want to use to edit the PR description? ([V]im, [e]macs, [a]bort)  " \
+    "VvEeAa" "v"
+  case "${RESP}" in
+    [vV]*) vim "${BODYFILE}"; ;;
+    [eE]*) emacs "${BODYFILE}"; ;;
+    [aA]*) _fatal "Aborted."; ;;
+  esac
+
+  local TITLE
+  TITLE="Rollback of PR #${PR}"
+
+  local -a PR_ARGS
+  PR_ARGS+=(
+    --repo "${UPSTREAM}/${REPO}"
+    --title "${TITLE}"
+    -H "${GHUSER}:${BR}"
+    --body-file "${BODYFILE}"
+  )
+
+  _gh pr create "${PR_ARGS[@]}"
+  gee__codeowners --comment
+  _gh_pr_view
+  rm "${BODYFILE}"
+}
+
+##########################################################################
+# remove_branch command
+##########################################################################
+
+_register_help "remove_branch" "Remove a branch." "rmbr" <<'EOT'
+Usage: gee remove_branch <branch-names...>
+
+Removes a branch and it's associated directory.
+EOT
+
+function _remove_a_branch() {
+  local BR="$1"
+  local STATE
+  local PARENT
+
+  _banner "Deleting ${BR}"
+  # if a local branch exists, or if the worktree directory exists:
+  if "${GIT}" show-ref --quiet "refs/heads/${BR}" || [[ -d "${GEE_REPO_DIR}/${BR}" ]]; then
+    _checkout_or_die "${BR}"
+    _set_main
+
+    # Check if branch is clean
+    PARENT="$(_get_parent_branch "${BR}")"
+    STATE=CLEAN
+    local -a  counts=()
+    read -r -a counts < <(_git_rev_list_counts "${PARENT}" "${BR}")
+    if (( counts[1] != 0 )); then
+      _warn "Branch \"${BR}\" is ${counts[1]} commit(s) ahead of ${PARENT}."
+      STATE=UNCLEAN
+    fi
+    if [[ -n "$("${GIT}" status --porcelain)" ]]; then
+      _warn "Branch \"${BR}\" contains uncommitted changes."
+      STATE=UNCLEAN
+    fi
+    if [[ "${STATE}" != "CLEAN" ]]; then
+      if _confirm_default_no "Are you sure you want to force-remove branch ${BR}? (y/N) "; then
+        _info "By your command."
+      else
+        _info "Skipping."
+        return 0
+      fi
+    fi
+
+    local SHA
+    SHA="$("${GIT}" reflog | head -n 1 | awk '{print $1}' )"
+
+    # delete the bazel cache associated with this worktree
+    if [[ -h ./bazel-out ]] && readlink -qf ./bazel-out; then
+      local BAZELCACHE
+      BAZELCACHE="$(readlink -f ./bazel-out)"
+      BAZELCACHE="${BAZELCACHE%/execroot/*/bazel-out}"
+      _info "Removing linked bazel cache directory \"${BAZELCACHE}\""
+      chmod -fR u+w "${BAZELCACHE}"
+      rm -rf "${BAZELCACHE}"
+    fi
+
+    _checkout_or_die "${MAIN}"
+    # --force is required for git v2.17.1, or the remove operation will always fail.
+    _git worktree remove --force "${BR}"
+    _git branch -D "${BR}"
+
+    _info "Deleted local branch ${BR}.  To undo: gee make_branch ${BR} ${SHA}"
+  else
+    _warn "Local branch \"${BR}\" not found: skipped."
+  fi
+
+  if _remote_branch_exists origin "${BR}"; then
+    _git_can_fail push --quiet origin --delete "${BR}" | cat
+    _info "Deleted remote branch origin/${BR}"
+  else
+    _info "Remote branch origin/${BR} not found: skipped."
+  fi
+
+  # Remove branch from parents file, and fix up children's parents.
+  _read_parents_file
+  local PREV_PARENT
+  PREV_PARENT="${PARENTS["${BR}"]}"
+  if [[ -z "${PREV_PARENT}" ]]; then PREV_PARENT="${MAIN}"; fi
+  unset PARENTS["${BR}"]
+  local K
+  for K in "${!PARENTS[@]}"; do
+    if [[ "${PARENTS["$K"]}" == "${BR}" ]]; then
+      PARENTS["$K"]="${PREV_PARENT}"
+    fi
+  done
+  _write_parents_file
+}
+
+function gee__rmbr() { gee__remove_branch "$@"; }
+function gee__remove_branch() {
+  _startup_checks "remove_branch"
+
+  local -a BRANCHES=( "$@" )
+
+  if (( ${#BRANCHES[@]} == 0 )); then
+    _fatal "Must specify at least one branch name to remove."
+  fi
+
+  local BR
+  for BR in "${BRANCHES[@]}"; do
+    _remove_a_branch "${BR}"
+  done
+}
+
+##########################################################################
+# fix command
+##########################################################################
+
+_register_help "fix" "Run automatic code formatters over changed files only." <<'EOT'
+Usage: gee fix [<files>]
+
+Looks for a "fix_format.sh" script in the root directory of the current branch,
+and runs it.  This script runs a set of language formatting tools over either:
+
+  - the files specified on the command line, or
+  - if no files are specified, all of the locally changed files in this
+    branch.
+
+Note: "gee fix" (which fixes code in a branch) is different from "gee repair"
+(which checks the gee directory for errors and repairs them).
+
+Note: "fix_format.sh" used to be integrated into gee, but has been separated
+out as formatting rules are highly project specific.
+EOT
+
+function gee__fix() {
+  _startup_checks "fix"
+
+  local BDIR
+  BDIR="$(_get_branch_rootdir)"
+  if [[ -x "${BDIR}/fix_format.sh" ]]; then
+    _cmd "${BDIR}/fix_format.sh" "$@"
+  else
+    _fatal "No fix_format.sh script exists in this repository."
+  fi
+}
+
+##########################################################################
+# gcd command
+##########################################################################
+# TODO(jonathan): add an option to make a branch if missing.
+# TODO(jonathan): make this work from outside a gee branch.
+# TODO(jonathan): add g4d-like functionality such as gcd branch/some/path
+#                 and gcd branch@? to find last-edited directory.
+# TODO(jonathan): Maybe "change_branch" (chb? cbr? chbr?) is a better name.
+
+_register_help "gcd" "Change directory to another branch." <<'EOT'
+Usage: gcd [-b] [-m] [-B <parent>] <branch>[/<path>]
+
+Print the path to an equivalent directory in another worktree (branch).
+This command is meant to be invoked from the "gcd" bash function, which
+invokes this command and then chdir's into that directory.
+
+The "gcd" bash function can be imported into your shell with gee's "bash_setup"
+command, like this:
+
+    eval "$(gee bash_setup)"
+
+(This command should be added to your .bashrc file.)
+
+Options:
+
+* "-b" causes gee to create a new branch if the specified branch doesn't
+  exist.  The new branch is a child of the current branch.
+* "-m" causes gee to create a new branch if the specified branch doesn't
+  exist.  The new branch is a child of the master (or main) branch.
+* "-B <parent>" causes gee to create a new branch if the specified branch
+  doesn't exist.  The new branch is a child of the specified parent branch.
+
+If only "<branch>" is specified, "gcd" will change directory to the same
+relative directory in another branch.  If "<branch>/<path>" is specified,
+"gcd" will change directory to the specified path beneath the specified
+branch.
+
+For example:
+
+    cd ~/gee/enkit/branch1/foo/bar
+    # now in ~/gee/enkit/branch1/foo/bar
+    gcd branch2
+    # now in ~/gee/enkit/branch2/foo/bar
+    gcd branch3/foo
+    # now in ~/gee/enkit/branch3/foo
+    gcd -b branch4
+    # now in branch4/foo, a child branch of branch3.
+    gcd -m new_feature
+    # now in new_feature/foo, a child branch of master.
+
+To create a new branch of a non-standard upstream master:
+
+    gcd -B upstream/master_a0 my_a0_feature_branch
+
+The "gcd" function also updates the following environment variables:
+
+* BROOT always contains the path to the root directory of the current branch.
+* BRBIN always contains the path to the bazel-bin directory beneath root.
+
+EOT
+
+function gee__gcd() {
+  local TARGET BRANCH REL_PATH OPT_B OPT_M PARENT
+  OPT_B=0
+  OPT_M=0
+  PARENT=""
+  while [[ "$1" == "-"* ]]; do
+    if [[ "$1" == "-b" ]]; then
+      OPT_B=1
+      shift
+    elif [[ "$1" == "-B" ]]; then
+      OPT_B=1
+      PARENT="$2"
+      shift
+      shift
+    elif [[ "$1" == "-m" ]]; then
+      OPT_M=1
+      shift
+    elif [[ "$1" == "--" ]]; then
+      shift
+      break
+    else
+      _fatal "gee gcd: unknown option \"${1}\""
+    fi
+  done
+  TARGET="$1"
+  if [[ "${TARGET}" == "" ]]; then
+    _fatal "gcd: target branch argument not specified."
+  fi
+  _set_main
+
+  if ! _in_gee_branch; then
+    cd "${GEE_REPO_DIR}/${MAIN}"
+  fi
+  if ! _in_gee_branch; then
+    _die "Can't find ${REPO}/${MAIN} branch.  Something is very wrong here."
+  fi
+
+  # Parse the TARGET specifier.
+  if [[ "${TARGET}" == *"/"* ]]; then
+    # TARGET is <branch>/<directory>:
+    BRANCH="${TARGET%%/*}"
+    REL_PATH="${TARGET#*/}"
+  else
+    # otherwise, target is just the branch name:
+    BRANCH="${TARGET}"
+    REL_PATH="$(git rev-parse --show-prefix)"
+  fi
+
+  # check whether BRANCH exists:
+  if ! _local_branch_exists "${BRANCH}"; then
+    if (( OPT_M == 1 )); then
+      # option -m is equivalent to "-B upstream/master"
+      PARENT="upstream/${MAIN}"
+      OPT_B=1
+    fi
+    if (( OPT_B == 1 )); then
+      if [[ -z "${PARENT}" ]]; then
+        PARENT="$(_get_current_branch)"
+      fi
+      gee__mkbr "${BRANCH}" "${PARENT}" >&2
+      if ! _local_branch_exists "${BRANCH}"; then
+        _fatal "Branch \"${REPO}/${BRANCH}\" could not be created."
+      fi
+    else
+      _fatal "Branch \"${REPO}/${BRANCH}\" does not exist.  Make use make_branch?"
+    fi
+  fi
+
+  local DIR
+  _update_branch_to_worktree
+  DIR="${BRANCH_TO_WORKTREE["${BRANCH}"]}"
+  if [[ -z "${DIR}" ]]; then
+    _die "Branch \"${REPO}/${BRANCH}\" exists but isn't in worktree?"
+  fi
+  if [[ ! -d "${DIR}" ]]; then
+    _die "Branch \"${REPO}/${BRANCH}\" exists but ${DIR} is missing."
+  fi
+
+  # Trim DIR to the longest path that exists in this branch.
+  local P PREV_IFS
+  PREV_IFS="${IFS}"
+  IFS="/"; for P in ${REL_PATH}; do
+    if [[ -d "${DIR}/${P}" ]]; then
+      DIR="${DIR}/${P}"
+    else
+      break
+    fi
+  done
+  IFS="${PREV_IFS}"
+  echo "${DIR}"
+}
+
+##########################################################################
+# hello command
+##########################################################################
+
+_register_help "hello" "Check connectivity to github." <<'EOT'
+Usage: gee hello
+
+Verifies that the user can communicate with github using ssh and the
+github cli interface.
+
+For more information:
+  https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh
+EOT
+
+function gee__hello() {
+  _get_ghuser_via_ssh
+  if [[ -z "${_QUIET}" ]]; then
+    _info "Hello, ${GHUSER}.  Connectivity to github is AOK."
+  fi
+  _gh_authenticate
+}
+
+function gee__debug_error_reporting() {
+  echo "About to run /bin/false, which should report an error:"
+  /bin/false
+  echo "We should not get here."
+}
+
+##########################################################################
+# create_ssh_key command
+##########################################################################
+
+_register_help "create_ssh_key" "Create and enroll an ssh key." <<'EOT'
+Usage: gee create_ssh_key
+
+This command will attempt to re-enroll you for ssh access to github.
+
+Normally, "gee init" will ensure that you have ssh access.  This command
+is only available if something else has gone wrong requiring that keys
+be updated.
+EOT
+
+function gee__create_ssh_key() {
+  _ssh_enroll
+  gee__hello
+}
+
+##########################################################################
+# copy command
+##########################################################################
+
+_register_help "copy" "Copy files (preserving history)." "cp" <<'EOT'
+Usage: gee copy <files...> <destination>
+
+Creates a copy of one or more files, preserving git history.  (Just
+copying a file using cp will cause git to assume a new file, and
+not preserve history.)
+
+This operation will create a new commit containing the copy operation.
+All files being copied should be "clean" (committed, not staged) for
+this to work correctly.
+
+Destination may either be a filename or a directory.  When copying
+more than one file, destination must be a directory.
+
+Examples:
+
+    gee copy foo.txt bar.txt
+    mkdir bardir
+    gee copy foo.txt bar.txt bardir/
+EOT
+function gee__cp() { gee__copy "$@"; }
+function gee__copy() {
+  _startup_checks "copy"
+
+  local -a DESTS=( "${@: -1}" )
+  local DEST="${DESTS[0]}"
+  local -a SRCS=( "$@" )
+  unset "SRCS[-1]"  # remove last element from list
+
+  local DEST_IS="dir"
+
+  # Check that all source files are clean.
+  local STATUS
+  STATUS="$(git status --porcelain "${SRCS[@]}")"
+  if [[ "${STATUS}" ]]; then
+    _warn "The following files have uncommitted changes:" "${STATUS}"
+    _die "You must commit these changes before using the copy operation."
+  fi
+
+  # Determine if we are copying to a file or a directory.
+  if [[ "${#SRCS[@]}" -gt 1 ]]; then
+    if [[ -f "${DEST}" ]]; then
+      DEST_IS="file"
+      _die "Multiple sources defined, but destination is a file."
+    else
+      DEST_IS="dir"
+    fi
+  else
+    if [[ -f "${DEST}" ]]; then
+      DEST_IS="file"
+      _warn "Destination exists: ${DEST}"
+    elif [[ -d "${DEST}" ]]; then
+      DEST_IS="dir"
+    elif [[ "${DEST}" == */ ]]; then
+      DEST_IS="dir"
+    else
+      DEST_IS="file"
+    fi
+  fi
+
+  # Make the destination directory, if necessary.
+  if [[ "${DEST_IS}" == "dir" ]] && [[ ! -d "${DEST}" ]]; then
+    _cmd mkdir -p "${DEST}"
+  fi
+
+  local CURRENT_BRANCH COPY_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  COPY_BRANCH="_GEE_TEMP_${CURRENT_BRANCH}"
+  _git checkout -b "${COPY_BRANCH}"
+
+  _git mv -v -f "${SRCS[@]}" "${DEST}"
+  _git commit -m "gee: Moved to ${DEST}: ${SRCS[*]}"
+
+  _git checkout HEAD~ "${SRCS[@]}"
+  _git commit -m "gee: Restored ${SRCS[*]}"
+
+  _git checkout "${CURRENT_BRANCH}"
+  _git merge --no-ff "${COPY_BRANCH}" -m "gee: Copy to ${DEST}: ${SRCS[*]}"
+
+  _git branch -d -f "${COPY_BRANCH}"
+
+  _info "Copied ${SRCS[*]} to ${DEST}"
+}
+
+##########################################################################
+# share command
+##########################################################################
+
+_register_help "share" "Share your branch." <<'EOT'
+Usage: gee share
+
+Displays URLs that you can paste into emails to share the contents of
+your branch with other users (in advance of sending out a PR).
+EOT
+
+function gee__share() {
+  _startup_checks "share"
+
+  local CURRENT_BRANCH PARENT_BRANCH
+  CURRENT_BRANCH="$(_get_current_branch)"
+  PARENT_BRANCH="$(_get_parent_branch)"
+  _info "These URLs are useful for sharing:"
+  echo  "  https://github.com/${GHUSER}/${REPO}/compare/${PARENT_BRANCH}...${CURRENT_BRANCH}"
+  echo  "  https://github.com/${GHUSER}/${REPO}/tree/${CURRENT_BRANCH}"
+}
+
+##########################################################################
+# bazelgc command
+##########################################################################
+
+_register_help "bazelgc" "Garbage collect your bazel cache." <<'EOT'
+Usage: gee bazelgc
+
+Identifies a set of bazel cache directories that are no longer associated with
+any worktree (branch) that gee knows about, and offers to delete them.
+EOT
+
+function gee__bazelgc() {
+  # Get a list of all unowned bazel directories
+  local -a EXPIRED=()
+  mapfile -t EXPIRED < \
+     <( (
+       # Emit a list of all existing cache directories:
+       readlink -f ~/.cache/bazel/*/????????????????????????????????;
+       # Emit a list of all actively used cache directories:
+       readlink -f "${GEE_REPO_DIR}"/*/*/bazel-out \
+         | sed 's/\/execroot\/.*\?\/bazel-out//';
+                ) | sort | uniq -c | awk '$1 == "1" {print $2}' )
+  if [[ "${#EXPIRED[@]}" == 0 ]]; then
+    _info "No ~/.cache/bazel directories to delete."
+  else
+    _info "About to delete the following ~/.cache/bazel directories:" "${EXPIRED[@]}"
+    if _confirm_default_no "Proceed? (y/N)  "; then
+      local USED1
+      USED1="$(df -k --output=used ~/.cache | tail -1)"
+      _cmd chmod -R u+w "${EXPIRED[@]}"
+      _cmd rm -rf "${EXPIRED[@]}"
+      USED2="$(df -k --output=used ~/.cache | tail -1)"
+      MBFREED="$(( (USED1 - USED2) / 1024 ))"
+      _info "Approximately ${MBFREED}MiB freed."
+    else
+      _info "Garbage collection of ~/.cache/bazel aborted, nothing was deleted."
+    fi
+  fi
+
+  if [[ -d ~/.cache/bazel-disk-cache ]]; then
+    local -a OLD=()
+    local i
+    mapfile -d '' OLD < \
+      <(find ~/.cache/bazel-disk-cache \( -type f -o -type l \) -atime +3 -print0)
+    if [[ "${#OLD[@]}" == 0 ]]; then
+      _info "No old ~/.cache/bazel-disk-cache entries to delete."
+    else
+      _info "About to delete ${#OLD[@]} old entries from ~/.cache/bazel-disk-cache"
+      if _confirm_default_no "Proceed? (y/N)  "; then
+        local USED1
+        USED1="$(df -k --output=used ~/.cache | tail -1)"
+        # Unfortunately the OLD list might be longer than ARG_MAX, so we break
+        # this list up to delete files in batches of 100.
+        for i in $(seq 0 100 ${#OLD[@]}); do
+          local -a OLD_SLICE
+          OLD_SLICE=( "${OLD[@]:${i}:100}" )
+          rm -f "${OLD_SLICE[@]}"
+        done
+        USED2="$(df -k --output=used ~/.cache | tail -1)"
+        MBFREED="$(( (USED1 - USED2) / 1024 ))"
+        _info "Approximately ${MBFREED}MiB freed."
+      else
+        _info "bazel-disk-cache garbage collection aborted, nothing was deleted."
+      fi
+    fi
+  else
+    _info "No ~/.cache/bazel-disk-cache directory to garbage collect."
+  fi
+}
+
+##########################################################################
+# bisect command
+##########################################################################
+
+_register_help "bisect" "Find a commit that caused a command to fail." <<'EOT'
+Usage: gee bisect [--good <commit-ish>] command...
+
+This command wraps the `git bisect` command, and attempts to discover
+a commit that causes the provided command to transition from a success
+to a failure.  During this process, gee will create a special branch
+named `bisect_<branchname>` to perform the bisect operation in.
+
+If "--good" is specified, gee will using the specified commit as the starting
+point for bisect (the first good commit, where the command is expected to
+succeed).  If "--good" is not used, gee will attempt to find a previous last
+good commit by testing a day, a week, a month, 3 months, and finally six months
+into the past.  Once a past good commit is found, the `git bisect` command will
+be used to identify the commit that caused a transition from a pass to a fail.
+
+gee assumes that the provided command will fail at the head revision.
+If this is not the case, the behavior of this command is undefined.
+
+EOT
+
+function gee__bisect() {
+  local CMD LAST_GOOD
+  LAST_GOOD=""
+  if [[ "$1" == "--good" ]]; then
+    LAST_GOOD="$2"
+    shift; shift;
+  fi
+  CMD=( "$@" )
+  local CUR_BRANCH BISECT_BRANCH
+  CUR_BRANCH="$(_get_current_branch)"
+  BISECT_BRANCH="BISECT_${CUR_BRANCH}_$$"
+  if _local_branch_exists "${BISECT_BRANCH}"; then
+    _fatal "Branch ${BISECT_BRANCH} already exists, cannot create it."
+  fi
+  gee__mkbr "${BISECT_BRANCH}"
+  _checkout_or_die "${BISECT_BRANCH}"
+  _git reset --hard "${CUR_BRANCH}"
+  _git bisect start
+  _git bisect bad
+
+  if [[ "${LAST_GOOD}" == "" ]]; then
+    local WHEN WHAT
+    LAST_GOOD=""
+    for WHEN in "yesterday" "last week" "last month" "3 months ago" "6 months ago"; do
+      WHAT="$(git log --since="${WHEN}" --pretty=format:%H | tail -1)"
+      if [[ -z "${WHAT}" ]]; then
+        _info "No commits since ${WHEN}."
+        continue
+      fi
+      _info "Checking commit from ${WHEN}: ${WHAT}"
+      _git checkout "${WHAT}"
+      if ( "${CMD[@]}" ); then
+        LAST_GOOD="${WHAT}"
+        _info "... passed: ${WHAT}"
+        _git bisect good
+        break
+      else
+        _info "... failed: ${WHAT}"
+      fi
+    done
+    if [[ -z "${LAST_GOOD}" ]]; then
+      _die "Could not find a commit within the past 6 months that passes."
+    fi
+  else
+    _info "Assuming a known good commit: ${LAST_GOOD}"
+    _git bisect good "${LAST_GOOD}"
+  fi
+  _git bisect run "${CMD[@]}"
+  _git checkout HEAD
+  _checkout_or_die "${CUR_BRANCH}"
+  gee__rmbr "${BISECT_BRANCH}"
+  return 0
+}
+
+##########################################################################
+# diagnose command
+##########################################################################
+
+_register_help "diagnose" "Capture diagnostics about your repository." <<'EOT'
+Usage: gee diagnose
+
+This command produces a `~/gee.diagnostics.txt` file that might
+be useful to share with the tool maintainers if something has gone
+wrong with your gee repository.
+EOT
+
+function gee__diagnose() {
+  # Save up to the last 9 non-empty diagnostics files:
+  savelog -n -c 9 -C -p ~/gee.diagnostics.txt
+  # Create a new diagnostic file:
+  (
+    set -x
+    set +e
+    echo "-------- version information --------"
+    echo "$(readlink -f "$0") version ${VERSION}"
+    echo "GIT=${GIT}"
+    "${GIT}" --version
+    echo "GH=${GH}"
+    "${GH}" --version
+    echo "JQ=${JQ}"
+    "${JQ}" --version
+    echo "ENKIT=${ENKIT}"
+    "${ENKIT}" version
+    echo "-------- env --------"
+    printf "%q\n" "${USER}"
+    printf "%q\n" "${PATH}"
+    printf "%q\n" "${SSH_AUTH_SOCK}"
+    printf "%q\n" "${SSH_AGENT_PID}"
+    echo "-------- ssh configuration --------"
+    cat ~/.ssh/config
+    timeout 2 ssh-add -l
+    ssh -v -T "${GIT_AT_GITHUB}"
+    echo "-------- gh connectivity --------"
+    "${GH}" auth status
+    "${GIT}" ls-remote | head -10
+    echo "-------- gee branches --------"
+    find ~/gee -maxdepth 2 -ls
+    echo "-------- gee branch configs --------"
+    for t in ~/gee/*/.gee/*; do echo ""; echo "file: $t"; cat "$t"; done
+    echo "-------- repo config --------"
+    for b in ~/gee/*/{main,master}; do
+      echo "b=$b"
+      cd "$b"
+      gh repo set-default --view
+      git remote -v
+      git worktree list --porcelain
+    done
+    echo "-------- status of each branch --------"
+    for b in ~/gee/*/*; do
+      echo "b=$b"
+      cd "$b"
+      git branch --show-current
+      git status -uall
+      git log --graph --pretty=format:'%h %d %s %cr %an' --abbrev-commit -n 10
+    done
+    echo "------ tail of gee.log --------"
+    tail -100 ~/gee.log
+  ) > ~/gee.diagnostics.txt 2>&1
+  _info "Diagnostics saved to ~/gee.diagnostics.txt"
+}
+
+##########################################################################
+# migrate_default_branch command
+##########################################################################
+
+_register_help "migrate_default_branch" "Migrate to a new default branch." <<'EOT'
+Usage: gee migrate_default_branch
+
+This command performs necessary local fix-ups after an upstream
+branch migrates their default branch from an old name (ie, "master")
+to a new name (ie, "main").
+EOT
+
+function gee__migrate_default_branch() {
+  _set_main  # ensure MAIN is set
+
+  local UPSTREAM_URL UPSTREAM_MAIN
+  UPSTREAM_URL="${GIT_AT_GITHUB}:${UPSTREAM}/${REPO}.git"
+  UPSTREAM_MAIN="$(
+    "${GIT}" remote show "${UPSTREAM_URL}" \
+      | awk '/HEAD branch/ {print $NF}'
+  )"
+  if [[ "${MAIN}" != "${UPSTREAM_MAIN}" ]]; then
+    _warn "Local repo's default branch is ${MAIN} but the upstream repo's default " \
+          "branch is ${UPSTREAM_MAIN}.  Correcting the local branch."
+    if _local_branch_exists "${UPSTREAM_MAIN}"; then
+      _warn "A local branch named \"${UPSTREAM_MAIN}\" already exists." \
+            "Proceeding will cause that branch to be reset."
+      _confirm_default_no "Do you want to proceed? (y/N)"
+      _checkout_or_die "${UPSTREAM_MAIN}"
+      _git reset --hard "${MAIN}"
+    else
+      _checkout_or_die "${MAIN}"
+      gee__mkbr "${UPSTREAM_MAIN}"
+    fi
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git push -u origin "${UPSTREAM_MAIN}"
+    _read_parents_file
+    local KEY VALUE
+    for KEY in "${!PARENTS[@]}"; do
+      VALUE="${PARENTS["${KEY}"]}"
+      if [[ "${VALUE}" == "${MAIN}" ]]; then
+        PARENTS["${KEY}"]="${UPSTREAM_MAIN}"
+      fi
+    done
+    _write_parents_file
+
+    _checkout_or_die "${UPSTREAM_MAIN}"
+    _git worktree remove --force "${MAIN}"
+    _git branch -D "${MAIN}"
+    if _remote_branch_exists origin "${MAIN}"; then
+      _git_can_fail push --quiet origin --delete "${MAIN}" | cat
+    fi
+
+    MAIN=""
+    _set_main
+    if [[ "${MAIN}" == "${UPSTREAM_MAIN}" ]]; then
+      _info "Successfully set default branch to ${MAIN}"
+    else
+      _fatal "Something went wrong setting default branch to ${UPSTREAM_MAIN}".
+    fi
+  else
+    _info "Local and upstream repos both use \"${MAIN}\" as the default branch."
+  fi
+}
+
+##########################################################################
+# repair command
+##########################################################################
+
+_register_help "repair" "Repair your gee workspace." <<'EOT'
+Usage: gee repair <command>
+
+Gee tries to control some metadata and attempts to file away some of the
+sharp edges from git.  Sometimes, bypassing gee to use git directly can
+cause some of gee's metadata to become stale.  This command fixes up
+any missing or incorrect metadata.
+
+Additionally, "gee repair" automatically invokes "gee diagnose," which
+produces a diagnostics file in `~/gee.diagnostics.txt`.
+EOT
+
+function _gee_fix_remote_origin_fetch_config() {
+  # An old version of gee incorrectly configured the remote.origin.fetch
+  # parameter.  This command checks for an incorrect value and corrects
+  # it.
+  local REMOTE_ORIGIN_FETCH CORRECT
+  CORRECT="+refs/heads/*:refs/remotes/origin/*"
+  REMOTE_ORIGIN_FETCH="$("${GIT}" config --get-all remote.origin.fetch)"
+  if [[ "${REMOTE_ORIGIN_FETCH}" != "${CORRECT}" ]]; then
+    _warn "remote.origin.fetch was incorrectly set to:" "${REMOTE_ORIGIN_FETCH}"
+    _git config --replace-all remote.origin.fetch "${CORRECT}"
+    _info "Fixed remote.origin.fetch configuration."
+  fi
+}
+
+function _gee_fix_gh_resolved_base() {
+  # Somehow, some users end up with a gh using "origin" as the gh-resolved base
+  # instead of "upstream".  I still need to figure out how this is happening,
+  # but in the meantime I'm adding this fix to our gee__repair flow.
+  local X
+  X="$(git config --local --get remote.origin.gh-resolved || /bin/true)"
+  if [[ -n "${X}" ]]; then
+    _warn "gh-resolved is pointing at origin, fixing:"
+    _git config --local --unset "remote.origin.gh-resolved"
+  fi
+  X="$(git config --local --get remote.upstream.gh-resolved || /bin/true)"
+  if [[ "$X" != "base" ]]; then
+    _warn "gh-resolved isn't pointing at upstream, fixing:"
+    _git config --local "remote.upstream.gh-resolved" base
+  fi
+}
+
+function gee__repair() {
+  # Make sure all tools are available
+  _install_tools
+
+  _gee_fix_remote_origin_fetch_config
+  _gee_fix_gh_resolved_base
+  if [[ "$(git config --global rerere.enabled || /bin/true)" != "true" ]]; then
+    _git config --global rerere.enabled true
+  fi
+
+  # check that we can connect to github via ssh
+  _check_ssh
+
+  _gh_authenticate
+
+  if ! _in_gee_repo; then
+    _fatal "Not in a gee repo directory, aborting further repairs."
+  fi
+
+  _set_main
+  (
+    cd "${GEE_REPO_DIR}/${MAIN}"
+    local -a DEFAULT_REPO
+    mapfile -t DEFAULT_REPO < <( "${GH}" repo set-default --view )
+    if [[ "${DEFAULT_REPO[0]}" != "${UPSTREAM}/"* ]]; then
+      _warn "Looks like \"gh repo set-default\" got misconfigured to ${DEFAULT_REPO[0]}.  Fixing:"
+      _gh repo set-default "${UPSTREAM}/${REPO}"
+    fi
+    # note: this fix is currently redundant with _gee_fix_gh_resolved_base, but defense in depth.
+  )
+
+  _git worktree prune
+
+  _info "Checking each directory in ${GEE_REPO_DIR}..."
+  local DIR BRANCH OBRANCH
+  for DIR in "${GEE_REPO_DIR}"/*; do
+    BRANCH="$(basename "${DIR}")"
+    cd "${DIR}"
+    if [[ ! -e ./.git ]]; then
+      _warn "Skipping non-git directory ${DIR}"
+      continue
+    fi
+    OBRANCH="$(_get_current_branch)"
+
+    # Give user opportunity to abort in-progress rebase operations:
+    if _is_rebase_in_progress; then
+      _warn "Rebase in progress on branch ${OBRANCH}"
+      local -a STATUS
+      mapfile -t STATUS < <( "${GIT}" status );
+      _info "${STATUS[@]}"
+      if _confirm_default_no "Do you want to abort this rebase operation now?"; then
+        _git rebase --abort
+        if _is_rebase_in_progress; then
+          _die "Error while aborting rebase operation."
+        fi
+      fi
+    fi
+
+    # Make sure the worktree directory points to the right branch:
+    if [[ "${OBRANCH}" != "${BRANCH}" ]]; then
+      _warn "${BRDIR} pointed to branch ${OBRANCH} instead of ${BRANCH}."
+      _git checkout "${BRANCH}"
+      _info "... Fixed."
+    fi
+
+  done
+
+  _info "Checking each branch in the local repository..."
+  local -a ALL_BRANCHES=()
+  mapfile -t ALL_BRANCHES < <( "${GIT}" branch --format="%(refname:short)" )
+  for BRANCH  in "${ALL_BRANCHES[@]}"; do
+    # make sure each branch has a worktree directory:
+    _checkout_or_die "${BRANCH}"
+  done
+
+  # Repair the PARENT file if it gets corrupted or removed, by attempting to
+  # guess the parent for each branch.
+  _info "Checking the parents file..."
+  _read_parents_file
+  local DIRTY=0
+  _set_main
+  for BRANCH  in "${ALL_BRANCHES[@]}"; do
+    if [[ "${BRANCH}" == "${MAIN}" ]]; then continue; fi
+    if [[ -z "${PARENTS["${BRANCH}"]}" ]]; then
+      _warn "${BRANCH} is missing \"parent\" metadata."
+      _checkout_or_die "${BRANCH}"
+      # Try to guess which branch is this branch's parent:
+      # TODO(jonathan): There is almost certainly a better way using rev-list.
+      local PARENT
+      PARENT="$(git show-branch | sed "s/].*//" | grep "\*" \
+        | grep -v -w "${BRANCH}" | head -n1 \
+        | perl -pe 'm/\[([a-zA-Z0-9_-]+?)(\^\d+)?(~\d+)?$/; $_ = $1;' )"
+      if [[ -z "${PARENT}" ]]; then
+        PARENT="${MAIN}"
+      fi
+      PARENTS["${BRANCH}"]="${PARENT}"
+      DIRTY=1
+      _info "Guessed that ${PARENT} is the parent of ${BRANCH}"
+    fi
+  done
+  if (( DIRTY )); then
+    _write_parents_file
+  fi
+
+  gee__migrate_default_branch
+
+  gee__bazelgc
+
+  _info "Done."
+}
+
+##########################################################################
+# restore_all_branches command
+##########################################################################
+
+_register_help "restore_all_branches" "Check out all remote branches." <<'EOT'
+Usage: gee restore_all_branches
+
+Gee looks up all branches on the origin remote, and makes sure an equivalent
+branch is checked out and updated locally.
+
+If you have the `dialog` utility installed, gee will let you interactively
+select which branches you want to restore.
+
+Alternately, if the user supplies a list of branches on the command line (for
+instance, "origin/test1 origin/test2"), restore_all_branches will only attempt
+to restore those branches.
+
+Note that gee isn't able to restore parentage metadata in this way.  Be
+sure to invoke `gee set_parent` in branches that benefit from this.
+EOT
+
+function gee__restore_all_branches() {
+  # Make sure all tools are available
+  _install_tools
+
+  # Make sure we're in a valid git repo
+  _startup_checks "restore_all_branches"
+
+  _gee_fix_remote_origin_fetch_config
+
+  local OLDEST_COMMIT
+  OLDEST_COMMIT="$(date --date="-${CLONE_DEPTH_MONTHS} months" +"%Y-%m-%d")"
+  _info "Fetching all commits in origin since ${OLDEST_COMMIT}"
+  _git fetch origin --shallow-since "${OLDEST_COMMIT}"
+
+  local -a BRANCHES=( "$@" )
+  if (( "${#BRANCHES[@]}" == 0 )); then
+    mapfile -t BRANCHES < <( \
+      git branch -r --format="%(refname:short)" | grep ^origin/ | grep -v HEAD )
+    if command -v dialog > /dev/null; then
+      local -a DIALOG_OPTS=(
+        --no-lines
+        --keep-tite
+        --backtitle "gee ${VERSION}"
+        --title "gee restore_all_branches"
+        --checklist
+        "Select which branches you want to restore:"
+        0 0 0
+      )
+      local B
+      for B in "${BRANCHES[@]}"; do
+        DIALOG_OPTS+=( "${B}" "" "off" )
+      done
+
+      local RESULT EXITCODE
+      set +e
+      exec 3>&1
+      RESULT="$(dialog "${DIALOG_OPTS[@]}" 2>&1 1>&3)"
+      EXITCODE=$?
+      exec 3>&-
+      set -e
+      if (( EXITCODE != 0  )); then
+        _warn "User cancelled operation."
+        return
+      fi
+      read -r -a BRANCHES <<< "${RESULT}"
+    fi
+  fi
+
+  _set_main
+  local RB
+  for RB in "${BRANCHES[@]}"; do
+    local B BDIR
+    B="$(basename "${RB}")"
+    BDIR="${GEE_REPO_DIR}/${B}"
+    if [[ -d "${BDIR}" ]]; then
+      _info "Branch ${B} already exists, skipping."
+    else
+      _info "Restoring ${B} from ${RB}"
+      _checkout_or_die "${B}"
+      local -a COUNTS
+      read -r -a COUNTS < <("${GIT}" rev-list --left-right --count "${B}...${RB}" | cat)
+      if (( COUNTS[1] != 0 )); then
+        _git reset --hard "${RB}"
+      else
+        _info "${B} is already up to date."
+      fi
+    fi
+  done
+
+  _info "Running \"gee repair\" to reconstruct parents information."
+  gee__repair
+
+  _info "Done."
+}
+
+##########################################################################
+# cherry-pick
+##########################################################################
+
+_register_help "pick" "Cherry-pick in commits from another branch." "cherrypick" \
+<<'EOT'
+Usage: pick <commit>...
+
+The gee wrapper around the git `cherry-pick` command that adds extra
+book-keeping in the `metadata` directory.
+
+The arguments to the pick command are supplied to `git rev-list --reverse` to
+produce a list of commits to integrate.  See `git help rev-list` for proper
+usage, but here are some examples of simple use cases:
+
+* `ABCD1234^..ABCD1234`: specify a single commit
+* `ABCD1234..master_b0`: specify all commits in master_b0 after ABCD1234.
+
+EOT
+
+function gee__cherrypick() { gee__pick "$@"; }
+function gee__pick() {
+  local CURRENT_BRANCH CURRENT_TOPLEVEL UPSTREAM_PARENT BASE_BRANCH METADATA_FILE
+  _update_branch_to_worktree
+  CURRENT_BRANCH="$(_get_current_branch)"
+  UPSTREAM_PARENT="$(_get_upstream_parent "${CURRENT_BRANCH}")"
+  BASE_BRANCH="${UPSTREAM_PARENT#*/}"
+  CURRENT_TOPLEVEL="${BRANCH_TO_WORKTREE["${CURRENT_BRANCH}"]}"
+  METADATA_FILE="${CURRENT_TOPLEVEL}/metadata/cherrypick.${BASE_BRANCH}.log"
+
+  mkdir -p "$(dirname "${METADATA_FILE}")"
+
+  # Read $METADATA_FILE to collect a list of all the commits already integrated.
+  local -a ALREADY_INTEGRATED=()
+  readarray -t ALREADY_INTEGRATED < <(
+    sed -e 's/\s*#.*//' "${METADATA_FILE}" | grep -v -e '^\s*$' | awk '{print $1}'
+  )
+  local -A ALREADY_INTEGRATED_MAP
+  local COMMIT
+  for COMMIT in "${ALREADY_INTEGRATED[@]}"; do
+    ALREADY_INTEGRATED_MAP["${COMMIT}"]=1
+  done
+  _info "Parsed ${#ALREADY_INTEGRATED[@]} commits from ${METADATA_FILE}"
+
+  local -a ALL_COMMITS=()
+  readarray -t ALL_COMMITS < <(_git rev-list --reverse "$@")
+  local -a COMMITS=()
+  for COMMIT in "${ALL_COMMITS[@]}"; do
+    if [[ -v ALREADY_INTEGRATED_MAP["${COMMIT}"] ]]; then
+      _warn "Skipping ${COMMIT}: already integrated according to ${METADATA_FILE}"
+      continue
+    else
+      COMMITS+=( "${COMMIT}" )
+    fi
+  done
+  if (( "${#COMMITS[@]}" == 0 )); then
+    _info "No new commits to integrate."
+    return 0
+  fi
+  echo "Picking: ${COMMITS[*]}"
+  if ! _confirm_default_yes "Do you want to proceed? (Y/n)  "; then
+    _info "Canceled."
+    exit 1
+  fi
+  (
+    printf "\n"
+    printf "# Cherry-picking %s\n" "$*"
+    printf "# User: %s\n" "${USER}"
+    printf "# Date: %s\n" "$(date)"
+  ) >> "${METADATA_FILE}"
+
+  for COMMIT in "${COMMITS[@]}"; do
+    DESC="$(_git show --quiet --pretty=oneline "${COMMIT}")"
+    _info "Merging: ${DESC}"
+    "${GIT}" stash push -- "${METADATA_FILE}"
+    if ! _git cherry-pick -x "${COMMIT}"; then
+      if ! _is_cherry_pick_in_progress; then
+        _die "cherry-pick operation failed, but cherry-pick not in progress.  Bug!"
+      fi
+      _warn "Cherry-pick operation had merge conflicts, entering subshell."
+      # TODO(jonathan): adapt _interactive_conflict_resolution for this.
+      _git mergetool
+      local -a STATUS=()
+      mapfile -t STATUS < <( _git status -s );
+      if [[ -z "${STATUS[*]}" ]]; then
+        _git commit --allow-empty  # This should complete the cherry-pick operation.
+      else
+        _git cherry-pick --continue # This should complete, we're just doing one commit at a time.
+      fi
+      if _is_cherry_pick_in_progress; then
+        echo "# FAILED: ${DESC}" >> "${METADATA_FILE}"
+        _fatal "cherry-pick ${COMMIT} operation did not succeed, aborting."
+      fi
+    fi
+    "${GIT}" stash pop
+    echo "${DESC}" >> "${METADATA_FILE}"
+  done
+}
+
+##########################################################################
+# recover_stashes
+##########################################################################
+
+_register_help "recover_stashes" "Recover identifiers for old, dropped stashes." \
+<<'EOT'
+Usage: recover_stashes <"optional string to search for">
+
+The `recover_stashes` command is useful if you accidentally dropped some
+stashed changes that you wanted to hold onto.  Even dropped stashes
+can be recovered if you know the right hash for the stash, and this
+command helps you discover them.
+
+By default, `recover_stashes` will print the hash ids for all stashes
+in your repo, sorted by author-date.  Any additional options are used
+to filter the commits (ie. by filename or file contents).
+
+Results are reported as a list of commits and their author-dates.
+
+For example:
+
+    $ gee recover_stashes enkit
+    Created temporary FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Searching your repo for discarded stash commits...
+    Checking object directories: 100% (256/256), done.
+    Checking objects: 100% (8266/8266), done.
+    Cached search results to FSCKFILE=/tmp/stashes-jonathan.0JTAXI
+    Found 58 commits.
+    Filtering candidate commits...
+    Found 4 matches.
+      914c9f7f2a43e34c8b1f8ac26f478d4a3ae66c46 Sat Sep 24 12:56:57 2022 -0700
+      7b81aec0ed7806963e79bd2b236523aba57405a7 Tue Oct 4 07:33:03 2022 +0000
+      b957986e8044e8b3097591bae25dfee04e567469 Tue Oct 4 09:32:05 2022 -0700
+      184e791a27fe0f2dd3a7c87a7a9ea4c384d498e7 Thu Oct 6 06:01:44 2022 +0000
+    Remove /tmp/stashes-jonathan.0JTAXI if you no longer need it.
+
+EOT
+
+function gee__recover_stashes() {
+  local SEARCH_FOR="$*"
+
+  if [[ -z "${FSCKFILE}"  ]]; then
+    FSCKFILE="$(mktemp /tmp/stashes-"$USER".XXXXXX)"
+    _info "Created temporary FSCKFILE=${FSCKFILE}"
+  fi
+
+  if [[ ! -s "${FSCKFILE}" ]]; then
+    _info "Searching your repo for discarded stash commits..."
+    git fsck --no-reflog | awk '/dangling commit/ {print $3}' > "${FSCKFILE}"
+    _info "Cached search results to FSCKFILE=${FSCKFILE}"
+  fi
+
+  local -a COMMITS
+  mapfile -t COMMITS < "${FSCKFILE}"
+  echo "Found ${#COMMITS[*]} commits."
+
+  _info "Filtering candidate commits..."
+  local -a MATCHES=()
+  i=0
+  while (( i < ${#COMMITS[@]} )); do
+    commit="${COMMITS[$i]}"
+    if git show "${commit}" | grep -q "${SEARCH_FOR}"; then
+      MATCHES+=("${commit}")
+    fi
+    i=$(( i + 1 ))
+  done
+
+  echo "Found ${#MATCHES[@]} matches."
+  for t in "${MATCHES[@]}"; do
+    git show --format=$'format:%at %H %ad\n' -s "${t}"
+  done | sort -n | awk '{$1=" "; print $0}'
+  _info "Remove ${FSCKFILE} if you no longer need it."
+}
+
+
+##########################################################################
+# bash_setup command
+##########################################################################
+
+_register_help "bash_setup" "Configure the bash environment for gee." \
+<<'EOT'
+Usage: eval "$(~/bin/gee bash_setup)"
+
+The "bash_setup" command emits a set of bash aliases and functions that
+streamline the use of gee.  The following functions are exported:
+
+  "gee": invokes "gee $@"
+  "gcd": rapidly change between gee branch directories.
+
+Additionally, the following functions can be used to customize your
+command prompt with useful information about your git work tree:
+  "gee_prompt_git_info": prints git-related information suitable for
+    integrating into your own prompt.
+  "gee_prompt_print": Prints a string suitable for using as a prompt.
+  "gee_prompt_set_ps1": Sets PS1 to the output of gee_prompt_print.
+
+This custom git-aware prompt will keep you apprised of which git branch you are
+in, and will also tell you important information about the status of your
+branch (whether or not you are in the middle of a merge or rebase operation,
+whether there are uncommitted changes, and more).
+
+The easiest way to make use of the git-aware prompt is to modify your .bashrc
+file to set PROMPT_COMMAND to "gee_prompt_set_ps1", as shown below:
+
+    export PROMPT_COMMAND="gee_prompt_set_ps1"
+
+This prompt can be customized by setting the following environment variables:
+
+*  GEE_PROMPT: The PS1-style prompt string to put at the end of every prompt.
+    Default:  `$' [\\!] \\w\033[0K\033[0m\n$ '`
+   More info: https://www.man7.org/linux/man-pages/man1/bash.1.html#PROMPTING
+*  GEE_PROMPT_BG_COLOR: The ANSI color to use as the background (default: 5).
+*  GEE_PROMPT_FG1_COLOR: The foreground color for git-related info (default: 9).
+*  GEE_PROMPT_FG2_COLOR: The foreground color for GEE_PROMPT (default: 3).
+
+Easter egg: Use the "gee_prompt_test_colors" command to view a test pattern
+of the basic 4-bit ANSI color set.
+
+If you need further customization, you are encouraged to write your own
+version of gee_prompt_set_ps1.
+
+Also sets GEE_BINARY to point to this copy of gee.
+EOT
+
+function gee__bash_setup() {
+  cat <<'END_OF_BASH_SETUP'
+# bash functions for gee
+#
+# This output is meant to be loaded into your shell with this command:
+#
+#   eval "$(~/bin/gee bash_setup)"
+
+function gee() {
+  # TODO(jonathan): now that gee isn't being invoked by enkit, perhaps
+  # this function isn't needed anymore?  But if I remove it, users with
+  # incorrect PATHs will break.
+  if [[ -n "${GEE_BINARY}" ]]; then
+    "${GEE_BINARY}" "$@";
+  elif [[ -x ~/bin/gee ]]; then
+    # use locally installed gee if available.
+    ~/bin/gee "$@";
+  else
+    # search the PATH for gee:
+    local path
+    path="$(which gee)"
+    if [[ -z "${path}" ]]; then
+      echo "I'm sorry, but I can't find gee anywhere!"
+      return
+    fi
+    "${path}" "$@";
+  fi
+}
+
+function gcd() {
+  if (( "$#" == 0 )); then
+    gee help gcd
+    return 1
+  fi
+
+  local D="$(gee gcd "$@")"
+  if [[ -n "${D}" ]]; then
+    cd "${D}"
+  fi
+  export BROOT="$(git rev-parse --show-toplevel)"
+  export BRBIN="${BROOT}/bazel-bin"
+}
+
+function grg() {
+  gee grep "$@"
+}
+
+function _gee_completion_branches() {
+  shift  # discard
+  local REPO="${GEE_REPO:-}"
+  local GD="${GEE_DIR:-"${HOME}/gee"}"
+  if [[ -z "${REPO}" ]]; then
+    local DIR="$(realpath --relative-base="${GD}" "${PWD}")"
+    if [[ -n "${DIR}" ]] && [[ "${DIR}" != "." ]] && [[ "${DIR}" != /* ]]; then
+      REPO="$(cut -d/ -f1 <<< "${DIR}")"
+    fi
+  fi
+  local GRD="${GEE_REPO_DIR:-"${GD}/${REPO:-internal}"}"
+  COMPREPLY=($(cd "${GRD}"; compgen -f -X \\.* "$@"))
+}
+
+END_OF_BASH_SETUP
+  # Note that we do the escaping differently for this second part:
+  cat <<END_OF_BASH_COMPLETION_SETUP
+# Command completions:
+function _gee_completion() {
+  local cur prev
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  case "\${COMP_CWORD}" in
+    1)
+      COMPREPLY=(\$(compgen -W "${!LONGHELP[*]}" -- "\${cur}"))
+      ;;
+    2)
+      prev="\${COMP_WORDS[COMP_CWORD-1]}"
+      case "\${prev}" in
+        diff|log|unpack|vimdiff|revert)
+          COMPREPLY=(\$(compgen -f -- "\${cur}"))
+          ;;
+        set_parent|gcd|rmbr|remove_branch)
+          _gee_completion_branches gcd "\${cur}"
+          ;;
+        help)
+          COMPREPLY=(\$(compgen -W "${!LONGHELP[*]}" -- "\${cur}"))
+          ;;
+      esac
+  esac
+}
+
+complete -F _gee_completion gee
+complete -F _gee_completion_branches gcd
+END_OF_BASH_COMPLETION_SETUP
+  cat <<'END_OF_GEE_PROMPT'
+# This git-aware prompt implementation owes a debt to Shawn O. Pearce's
+# "git-prompt.sh" implementation, found here:
+# https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh
+
+function gee_prompt_update_git_info() {
+  GEE_PROMPT_BRANCH=""
+  local git_dir="" is_inside_work_tree="" toplevel
+  read -r -d '' git_dir is_inside_work_tree toplevel < \
+    <( git rev-parse --git-dir \
+                     --is-inside-work-tree \
+                     --show-toplevel \
+                     2>/dev/null)
+  if [[ "true" != "${is_inside_work_tree}" ]]; then return 0; fi
+
+  local repo=""
+  if [[ "${toplevel}" =~ ^"${HOME}"/gee/(.+)/ ]]; then
+    repo="$(printf "%.3s:" "${BASH_REMATCH[1]}:")"
+  fi
+
+  local branch
+  read -r branch < <( git rev-parse --abbrev-ref HEAD )
+  GEE_PROMPT_BRANCH="${branch}"
+
+  local mode=""
+  local step=""
+  local total=""
+  if [[ -d "${git_dir}/rebase-merge" ]]; then
+    mode="REBASING:MERGE"
+    read -r step < "${git_dir}/rebase-merge/msgnum"
+    read -r total < "${git_dir}/rebase-merge/end"
+    read -r branch < "${git_dir}/rebase-merge/head-name"
+    branch="$(basename "${branch}")"
+  elif [[ -d "${git_dir}/rebase-apply" ]]; then
+    mode="REBASING:APPLY"
+    read -r step < "${git_dir}/rebase-apply/next"
+    read -r total < "${git_dir}/rebase-apply/last"
+    read -r branch < "${git_dir}/rebase-apply/head-name"
+    branch="$(basename "${branch}")"
+  elif [[ -f "${git_dir}/MERGE_HEAD" ]]; then
+    mode="MERGING"
+  elif [[ -f "${git_dir}/CHERRY_PICK_HEAD" ]]; then
+    mode="CHERRY_PICKING"
+  elif [[ -f "${git_dir}/REVERT_HEAD" ]]; then
+    mode="REVERTING"
+  elif [[ -f "${git_dir}/BISECT_LOG" ]]; then
+    mode="BISECTING"
+  elif [[ -f "${git_dir}/sequencer/todo" ]]; then
+    local todo
+    read -r todo < "${git_dir}/sequencer/todo"
+    if [[ "${todo}" =~ ^(p|pick)\  ]]; then
+      mode="CHERRY_PICKING"
+    elif [[ "${todo}" =~ ^revert\  ]]; then
+      mode="REVERTING"
+    fi
+  fi
+
+  # try some other ways to determine the branch name:
+  if [[ -z "${branch}" ]]; then
+    branch="$(git name-rev --name-only HEAD)"
+  fi
+
+  local complete_mode=""
+  if [[ -n "${mode}" ]]; then
+    complete_mode=":${mode}"
+  fi
+  if [[ -n "${step}" ]] && [[ -n "${total}" ]]; then
+    complete_mode+=" (step ${step}/${total})"
+  fi
+
+  local changes=""
+  git diff --no-ext-diff --quiet || changes="*"
+  local cached=""
+  git diff --no-ext-diff --cached --quiet || cached="+"
+  local stash_depth
+  read -r stash_depth < <(git stash list | wc -l)
+  if [[ "${stash_depth}" -eq 0 ]]; then
+    stash_depth=""
+  else
+    stash_depth=" S=${stash_depth}"
+  fi
+
+  local assigned=""
+  local assigned_count
+  assigned_count="$(gh pr list --search "assignee:@me" 2>/dev/null | grep -v "^no pull requests" | wc -l)"
+  if [[ "${assigned_count}" > 0 ]]; then
+    assigned=", ASSIGNED_PRs=${assigned_count}"
+  fi
+
+  GEE_PROMPT_INFO="$(printf "(%s%s%s%s%s%s%s)" \
+    "${repo}" "${branch}" "${complete_mode}" \
+    "${changes}" "${cached}" "${stash_depth}" "${assigned}" )"
+}
+
+function gee_prompt_git_info() {
+  gee_prompt_update_git_info
+  echo "${GEE_PROMPT_INFO}"
+}
+
+function __gee_prompt_set_colors() {
+  local fg="$1"
+  local bg="$2"
+  local bold="$3"
+  local code=$'\033[0'
+  if [[ "${bold}" == "1" ]]; then
+    code+=";1"
+  fi
+  if (( "${fg}" > 7 )); then
+    code+=";$(( fg - 8 + 90 ))"
+  else
+    code+=";$(( fg + 30 ))"
+  fi
+  if (( "${bg}" > 7 )); then
+    code+=";$(( bg - 8 + 100 ))"
+  else
+    code+=";$(( bg + 40 ))"
+  fi
+  code+="m"
+  printf "%s" "${code}"
+}
+
+function __gee_prompt_set_window_title() {
+  local title="$1"
+
+  # if window title is supported...
+  if [[ "${TERM}" == screen* ]] || [[ "${TERM}" == tmux* ]]; then
+    local ESC=$'\033'
+    local SLASH=$'\134'
+    printf "\\[\033k%s\033\\\\]" "$1"
+  fi
+}
+
+function gee_prompt_test_colors() {
+  local fg bg bold
+  for bg in $(seq 0 15); do
+    for bold in 0 1; do
+      printf "%02d: " "${bg}"
+      for fg in $(seq 0 15); do
+        __gee_prompt_set_colors "${fg}" "${bg}" "${bold}"
+        printf " %02d " "${fg}"
+      done
+      printf $'\033[0m %s\n' "${bold}"
+    done
+  done
+}
+
+function gee_prompt_print() {
+  gee_prompt_update_git_info
+  local p="${GEE_PROMPT}"
+  if [[ -z "${p}" ]]; then
+    p=" [\!] \w\[\e[0K\e[0m\]\n$ "
+  fi
+
+  local bg="${GEE_PROMPT_BG_COLOR:-1}"
+  local fg1="${GEE_PROMPT_FG1_COLOR:-15}"
+  local bold1="${GEE_PROMPT_FG1_BOLD:-1}"
+  local fg2="${GEE_PROMPT_FG2_COLOR:-0}"
+  local bold2="${GEE_PROMPT_FG2_BOLD:-0}"
+
+  printf "%s" \
+    "$(__gee_prompt_set_window_title "${GEE_PROMPT_BRANCH:-bash}")" \
+    "\\[$(__gee_prompt_set_colors "${fg1}" "${bg}" "${bold1}" )\\]" \
+    "${GEE_PROMPT_INFO}" \
+    "\\[$(__gee_prompt_set_colors "${fg2}" "${bg}" "${bold2}" )\\]" \
+    "${p}" \
+    "\[\e[0m\]"
+}
+
+function gee_prompt_set_ps1() {
+  export PS1
+  PS1="$(gee_prompt_print)"
+}
+
+# To enable this prompt, the user must opt-in by setting:
+# export PROMPT_COMMAND="gee_prompt_set_ps1"
+
+END_OF_GEE_PROMPT
+  echo "export GEE_BINARY=\"$(readlink -f "$0")\""  # make this gee the default gee.
+}
+
+##########################################################################
+# upgrade command
+##########################################################################
+
+_register_help "upgrade" "Upgrade the gee tool." <<'EOT'
+Usage: gee upgrade [--check]
+EOT
+
+function gee__upgrade() {
+  local GEE_PATH
+  GEE_PATH="$(readlink -f "$0")"
+  if _check_gee_version_is_current; then
+    _info "${GEE_PATH} is already up-to-date."
+  else
+    if _confirm_default_yes "A new version of gee is available.  Install? (Y/n)  "; then
+      # make a backup
+      mv -f "${GEE_PATH}"{,.backup}
+      cd "$(dirname "${GEE_PATH}")"
+      _cmd enkit astore download "${GEE_ON_ASTORE}"
+      if ! [[ -f "${GEE_PATH}" ]]; then
+        _warn "Could not create \"${GEE_PATH}\", restoring backup."
+        _cmd mv -f "${GEE_PATH}"{.backup,}
+        if ! [[ -f "${GEE_PATH}" ]]; then
+          _die "Could not even restore backup."
+        fi
+      fi
+      chmod +x "${GEE_PATH}"
+      if [[ -f "${GEE_PATH}".backup ]]; then
+        rm -f "${GEE_PATH}".backup
+      fi
+      _info "${GEE_PATH} has been upgraded."
+    fi
+  fi
+}
+
+##########################################################################
+# version command
+##########################################################################
+
+_register_help "version" "Print tool version information." <<'EOT'
+Usage: gee version
+EOT
+
+function gee__version() {
+  echo "$0: version ${VERSION}"
+  md5sum "$0"
+  local TOOL_ERROR=0
+  for tool in "${GIT}" "${GH}" "${JQ}"; do
+    if ! [[ -x "${tool}" ]]; then
+      _warn "${tool}: not installed!"
+      TOOL_ERROR=1
+    else
+      "${tool}" --version
+    fi
+  done
+  if (( TOOL_ERROR )); then
+    _info "Run \"gee repair\" to fix."
+  fi
+  if ! _check_gee_version_is_current; then
+    _warn "A newer version of gee is available.  Run \"gee upgrade\" to install."
+  fi
+}
+
+##########################################################################
+# help command
+##########################################################################
+
+_register_help "help" "Print more help about a command." <<'EOT'
+Usage: gee help [<command>|usage|commands|markdown]
+
+The "usage" option produces gee's manual.
+
+The "commands" option shows a summary of all available commands.
+
+The "markdown" option produce's gee's manual, in markdown format.
+EOT
+
+function _render_markdown_manual() {
+  local -a U=()
+  mapfile -t U <<< "${USAGE//\{\{VERSION\}\}/"${VERSION}"}"
+  local LINE
+  local CODEBLOCK=1
+  echo '```'
+  for LINE in "${U[@]}"; do
+    if [[ "${CODEBLOCK}" == 1 ]]; then
+      if [[ "${LINE}" == "" ]]; then
+        echo '```'
+        CODEBLOCK=0
+      fi
+    else
+      if [[ "${LINE}" == "    "* ]]; then
+        echo '```shell'
+        CODEBLOCK=1
+      fi
+    fi
+    echo "${LINE}"
+  done
+  if [[ "${CODEBLOCK}" == 1 ]]; then
+    echo '```'
+  fi
+  echo ""
+  echo "## Command Summary"
+  echo ""
+  echo "| Command | Summary |"
+  echo "| ------- | ------- |"
+  local h h_cmd h_desc
+  local BT='`'
+  for h in "${HELP[@]}"; do
+    IFS=": " read -r h_cmd h_desc <<< "${h}"
+    echo "| <a href=\"#${h_cmd}\">${BT}${h_cmd}${BT}</a> | ${h_desc} |"
+  done | sort --dictionary-order
+  echo ""
+  echo "## Commands"
+  echo ""
+  for h in "${HELP[@]}"; do
+    read -r -d ":" h_cmd h_desc <<< "${h}"
+    echo "### ${h_cmd}"
+    echo ""
+    echo "${LONGHELP["${h_cmd}"]}" \
+      | perl -p -e 's/^Usage: (.*?)$/Usage: `$1`/gmso'
+    echo ""
+  done
+}
+
+function gee__help() {
+  if [[ "$1" == "html" ]]; then
+    _render_html_manual
+  elif [[ "$1" == "markdown" ]]; then
+    _render_markdown_manual
+  else
+    (
+      if (( "$#" == 0 )); then
+        set -- "usage"
+      fi
+      if [[ "$1" == "usage" ]]; then
+        echo "${USAGE//\{\{VERSION\}\}/"${VERSION}"}"
+        echo ""
+      fi
+      if [[ ("$1" == "usage") || ("$1" == "commands") ]]; then
+        echo "## Commands:"
+        echo ""
+        for h in "${HELP[@]}"; do
+          echo "  $h"
+        done | sort | column -t -s ":"
+        shift;
+      fi
+      while (( "$#" )); do
+        local COMMAND="$1"
+        shift
+        if [ "${LONGHELP[${COMMAND}]+_}" ]; then
+          echo "${LONGHELP[${COMMAND}]}"
+        else
+          echo "${COMMAND}: there is no help for this."
+        fi
+      done
+    ) | "${PAGER}"
+  fi
+}
+
+function gee__banner() {
+  _banner "$@"
+}
+
+function _print_color_block() {
+  local C="$1"
+  FG=15
+
+  if (( C < 16 )); then
+    if (( C != 0 )); then
+      FG=0
+    fi
+  elif (( C < 232 )); then
+    # 6x6x6 color cube
+    if (( (( C - 16 ) % 36 ) / 6 > 2 )); then
+      FG=0
+    fi
+  elif (( C < 256 )); then
+    # grayscale from 232 to 255
+    if (( C > 245 )); then
+      FG=0
+    fi
+  fi
+  printf " %s%3d%s" "$(tput setaf "${FG}"; tput setab "${C}")" "$C" "${_COLOR_RST}"
+}
+
+function gee__colortest() {
+  echo "Color table:"
+  for t in $(seq 0 255); do
+    _print_color_block "${t}"
+    if (( (t % 16) == 15 )); then
+      printf "\n"
+    fi
+  done
+  printf "\n"
+
+  echo "| Class  | FG | BG |"
+  echo "| ------ | -- | -- |"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "BANNER" \
+      "${GEE_COLOR_BANNER_FG}" "${GEE_COLOR_BANNER_BG}" "${_COLOR_BANNER}" "${_COLOR_RST}"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "CMD" \
+      "${GEE_COLOR_CMD_FG}" "${GEE_COLOR_CMD_BG}" "${_COLOR_CMD}" "${_COLOR_RST}"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "DBG" \
+      "${GEE_COLOR_DBG_FG}" "${GEE_COLOR_DBG_BG}" "${_COLOR_DBG}" "${_COLOR_RST}"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "DIE" \
+      "${GEE_COLOR_DIE_FG}" "${GEE_COLOR_DIE_BG}" "${_COLOR_DIE}" "${_COLOR_RST}"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "WARN" \
+      "${GEE_COLOR_WARN_FG}" "${GEE_COLOR_WARN_BG}" "${_COLOR_WARN}" "${_COLOR_RST}"
+  printf "| %-6.6s | %2d | %2d | %s example %s\n" "INFO" \
+      "${GEE_COLOR_INFO_FG}" "${GEE_COLOR_INFO_BG}" "${_COLOR_INFO}" "${_COLOR_RST}"
+  DEBUG=1
+  _banner "This is a banner."
+  _debug "This is _debug"
+  _info "This is _info"
+  _warn "This is _warn"
+  DRYRUN=1 _cmd run --a --command
+  (_fatal "This is _fatal") || /bin/true
+  (_die "This is _die") || /bin/true
+  _cmd /bin/true
+  _cmd /bin/false
+  _info "We should not get here."
+}
+
+##########################################################################
+# main
+##########################################################################
+
+function main() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    shift
+    set -- "help" "$@"
+  fi
+  if (( "$#" == 0 )); then
+    gee__help usage
+    exit 0
+  fi
+  _rotate_gee_log
+  (
+    printf "%s" "$(readlink -f "$0")"
+    printf " %q" "$@"
+    printf "\n"
+  ) | _to_gee_log
+  local cmdname="$1"; shift
+  # Let's make pr-submit and pr_submit equivalent:
+  cmdname="$(tr '-' '_' <<< "${cmdname}")"
+  if type "gee__${cmdname}" >/dev/null 2>&1; then
+    set +e
+    (set -eE; "gee__${cmdname}" "$@");
+    RC=$?
+    set -e
+    ABNORMAL=0
+    echo "  exit rc=$RC" | _to_gee_log
+    exit $RC
+  else
+    echo "Unknown command ${cmdname}"
+    echo ""
+    gee__help commands
+    ABNORMAL=0
+    exit 2
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.56"
+readonly VERSION="0.2.57"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___
@@ -4495,9 +4495,10 @@ function gee__pr_cancel() {
   FILTER+=" AND (status=\"WORKING\" OR status=\"QUEUED\")"  # and by job status
   while read -r -a FIELDS; do
     local ID="${FIELDS[1]}"
-    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" > /dev/null
+    _cmd gcloud --project "${GEE_BUILDLOGS_PROJECT}" builds cancel "${ID}" --region us-west1 > /dev/null
     COUNT=$((COUNT + 1))
   done < <(_cmd gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds list \
+              --region us-west1 \
               --format=yaml \
               --filter="${FILTER}" \
               | grep ^id:)
@@ -4655,7 +4656,7 @@ function gee__pr_check() {
       local BUILD
       for BUILD in "${FAILED_BUILDS[@]}"; do
         _warn "Failed build: ${BUILD}"
-        gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds log "${BUILD}" | grep -i -E "(failed:|error:|streaming build results to:)"
+        gcloud --project="${GEE_BUILDLOGS_PROJECT}" builds log "${BUILD}" --region us-west1  | grep -i -E "(failed:|error:|streaming build results to:)"
       done
     fi
   fi

--- a/scripts/gee.changelog.md
+++ b/scripts/gee.changelog.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### 0.2.57
+
+* `gee pr_cancel`: Add missing `--region us-west1` flag to all gcloud commands.
+
 ### 0.2.56
 
 * `gee lsbr`: fix bug in traversing upstream branches.

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.56
+gee version: 0.2.57
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
I noticed that the `gee pr_cancel` functionality (that cancels running
presubmit jobs automatically when users push new commits into their PRs) was
not working.  Opened INFRA-11657 and learned that the gcloud configuration
had changed in a way that now required an additional `--region us-west1`
flag for our gcloud commands.

I added the `--region` flag and now all is well.

Tested:

```
$ gee commit --amend
CMD: /usr/bin/git add --all
Amending previous commit.
CMD: /usr/bin/git fetch
CMD: /usr/bin/git commit --amend
[mcu_channels 3a0fb73bd4] fix apb4_if names, excise non-existant feedthroughs
 Date: Fri Apr 18 12:17:55 2025 -0700
 2 files changed, 102 insertions(+), 100 deletions(-)
Killing any previous presubmit jobs.
CMD: gcloud --project=cloud-build-290921 builds list --region us-west1 --format=yaml --filter=substitutions.BRANCH_NAME=mcu_channels\ AND\ substitutions._HEAD_REPO_URL:jonathan-enf\ AND\ substitutions.TRIGGER_NAME:presubmit\ AND\ \(status=\"WORKING\"\ OR\ status=\"QUEUED\"\)
CMD: gcloud --project cloud-build-290921 builds cancel 99b46e74-e3da-4ad3-aa4e-2579c445357e --region us-west1
Cancelled [https://cloudbuild.googleapis.com/v1/projects/cloud-build-290921/locations/us-west1/builds/99b46e74-e3da-4ad3-aa4e-2579c445357e].
CMD: gcloud --project cloud-build-290921 builds cancel 9028786b-b6a5-44ba-b967-f48a1b5fe3c8 --region us-west1
Cancelled [https://cloudbuild.googleapis.com/v1/projects/cloud-build-290921/locations/us-west1/builds/9028786b-b6a5-44ba-b967-f48a1b5fe3c8].
Killed 2 job(s).
CMD: /usr/bin/git push --quiet -u origin +mcu_channels
```


