### PR TITLE
Update default path for bash in gee

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 


### PR DESCRIPTION
Update the default path for bash to gee so that it is dynamically determined by `/usr/bin/env` because the Rocky Linux container used by the PD team uses bash 5.2 built from source defined under `/usr/enfabrica/bin/bash` since the default version of bash is too old to support gee.

Tested:
- Manually modified the gee script in a Rocky Linux 8 container and executed some basic gee commands

JIRA: ENGPROD-1086