### PR TITLE
gee: fix runaway rebase operations

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -1612,7 +1612,7 @@ function _interactive_conflict_resolution() {
     SKIP=0
     RESTART=0
     if [[ "${#STATUS[@]}" -eq 0 ]]; then
-      _warn "Empty commit, skipping automatically."
+      _info "Empty commit, skipping automatically."
       SKIP=1
     fi
     for STATUS_LINE in "${STATUS[@]}"; do
@@ -1902,15 +1902,13 @@ function _safer_rebase() {
 }
 
 function _is_rebase_in_progress() {
-  local RC
-  NOFAIL=1 "${GIT}" rev-parse --verify REBASE_HEAD >/dev/null 2>/dev/null
-  RC=$?
-  if [[ "${RC}" == 0 ]]; then
-    return 0  # rebase is in progress
-  elif [[ "${RC}" == 128 ]]; then
-    return 1  # rebase is not in progress
+  # Is this branch currently in the middle of a rebase operation?
+  local G
+  G="$(git rev-parse --git-dir)"
+  if compgen -G "${G}/rebase*" > /dev/null; then
+    return 0  # 0=true
   else
-    _die "git rev-parse --verify REBASE_HEAD failed with unexpected code: ${RC}"
+    return 1  # 1=false
   fi
 }
 


### PR DESCRIPTION
A month ago, I introduced a bug into gee that caused an infinite loop while
doing a `gee update` operation.

The problem turned out to be a change to the `_is_rebase_in_progress` function
that I learned about on stackoverflow.  Turns out the author was wrong, and
that the function would sometimes return false positives.

I reverted to my earlier implementation of this function to fix the issue.

Tested:

I had a branch that reproduced the issue.  I used `git reset --hard branch.REBASE_BACKUP` to
go back to the initial state, and re-tried `gee up` with the patched gee.  The problem was
resolved.


