### PR TITLE
astore: Print warnings to stderr

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,8 @@
-load("//bazel/enkit:defs.bzl", "multirun")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-
+load("//bazel/enkit:defs.bzl", "multirun")
 
 # To update and generate the BUILD.bazel files, run:
 #     bazelisk run //:gazelle
@@ -118,4 +117,3 @@ config_setting(
     flag_values = {":kernel_dir": "placeholder"},
     visibility = ["//visibility:public"],
 )
-

--- a/astore/client/commands/commands.go
+++ b/astore/client/commands/commands.go
@@ -314,7 +314,7 @@ func (l *List) Run(cmd *cobra.Command, args []string) error {
 		formatter.Artifact(art)
 	}
 	if !l.All && len(arts) >= 1 {
-		fmt.Printf("(only showing artifacts with %d tags: %v - use --all or -l to show all)\n", len(l.Tag), l.Tag)
+		l.root.Log.Warnf("(only showing artifacts with %d tags: %v - use --all or -l to show all)\n", len(l.Tag), l.Tag)
 	}
 
 	for _, el := range els {

--- a/astore/client/commands/guess.go
+++ b/astore/client/commands/guess.go
@@ -2,14 +2,17 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/enfabrica/enkit/astore/client/astore"
 	"github.com/enfabrica/enkit/lib/kflags"
+
 	"github.com/spf13/cobra"
 )
 
 type Remote struct {
 	*cobra.Command
 
+	root *Root
 	Suggest SuggestFlags
 }
 
@@ -20,6 +23,7 @@ func NewRemote(root *Root) *Remote {
 			Short:   "Guesses the remote name that will be used for a file",
 			Aliases: []string{"guess", "file"},
 		},
+		root: root,
 	}
 	command.Command.RunE = command.Run
 	command.Suggest.Register(command.Flags())
@@ -35,8 +39,9 @@ func (uc *Remote) Run(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		local, remote, err := astore.SuggestRemote(arg, *uc.Suggest.Options())
 		if err != nil {
-			fmt.Printf("%s: error - %s\n", arg, err)
+			uc.root.Log.Errorf("%s: error - %s\n", arg, err)
 		} else {
+			// TODO(scott): Get this command to obey --console-format flag
 			fmt.Printf("%s: %s %s\n", arg, local, remote)
 		}
 	}
@@ -46,6 +51,7 @@ func (uc *Remote) Run(cmd *cobra.Command, args []string) error {
 
 type Arch struct {
 	*cobra.Command
+	root *Root
 }
 
 func NewArch(root *Root) *Arch {
@@ -55,6 +61,7 @@ func NewArch(root *Root) *Arch {
 			Short:   "Guesses the architecture of an artifact",
 			Aliases: []string{"guess", "file"},
 		},
+		root: root,
 	}
 	command.Command.RunE = command.Run
 	return command
@@ -68,11 +75,12 @@ func (uc *Arch) Run(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		arch, err := astore.GuessArchOS(arg)
 		if err != nil {
-			fmt.Printf("%s: error - %s\n", arg, err)
+			uc.root.Log.Errorf("%s: error - %s\n", arg, err)
 			continue
 		}
 
 		for _, a := range arch {
+			// TODO(scott): Get this command to obey --console-format flag
 			fmt.Printf("%s: %s %s\n", arg, a.Cpu, a.Os)
 		}
 	}

--- a/bazel/astore/tests/BUILD.bazel
+++ b/bazel/astore/tests/BUILD.bazel
@@ -10,10 +10,10 @@ astore_upload(
         "testdata.txt",
     ],
     uidfile = "BUILD.bazel",
+    upload_tag = "//bazel/astore/tests",
     visibility = [
         "//developer:__subpackages__",
     ],
-    upload_tag = "//bazel/astore/tests"
 )
 
 UID_TESTDATA_TXT = "i8o3rkarrqgf4ekprz2gdih2eymxsoa4"

--- a/bazel/utils/container/muk/BUILD.bazel
+++ b/bazel/utils/container/muk/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
-load("@rules_python//python:defs.bzl", "py_library", "py_binary", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json")
 

--- a/infra/postsubmit/proto/BUILD.bazel
+++ b/infra/postsubmit/proto/BUILD.bazel
@@ -11,8 +11,8 @@ proto_library(
 
 py_proto_library(
     name = "postsubmit_py_proto",
-    deps = [":postsubmit_proto"],
     visibility = ["//visibility:public"],
+    deps = [":postsubmit_proto"],
 )
 
 go_proto_library(

--- a/kbuild/v2/BUILD.bazel
+++ b/kbuild/v2/BUILD.bazel
@@ -2,6 +2,7 @@ load("@//bazel:shellutils.bzl", "shellcheck_test")
 
 shellcheck_test(
     name = "shellcheck_test",
+    srcs = glob(["scripts/*.sh"]) + glob(["template/*.sh"]) + ["kpub-astore"],
     extra_args = [
         # SC2086: Double quote to prevent globbing and word splitting.
         # SC2034: pkg_name appears unused. Verify use (or export if used externally).
@@ -19,5 +20,4 @@ shellcheck_test(
         "-e",
         "SC2086,SC2034,SC2046,SC2006,SC2003,SC1090,SC2230,SC2039,SC2155,SC2002,SC2166,SC2060,SC2038",
     ],
-    srcs = glob(["scripts/*.sh"]) + glob(["template/*.sh"]) + ["kpub-astore"],
 )

--- a/machinist/cmd/BUILD.bazel
+++ b/machinist/cmd/BUILD.bazel
@@ -32,4 +32,3 @@ astore_upload(
     ],
     targets = [":cmd"],
 )
-

--- a/tools/codegen/BUILD.bazel
+++ b/tools/codegen/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_library", "py_test", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 bzl_library(
     name = "codegen_bzl",


### PR DESCRIPTION
This change ensures that `astore` subcommands print warnings to stderr by using the logger present on the root subcommand.

This should remove most `fmt.Printf`s from the astore subcommands; the only ones remaining are:
* ones printing formatted output to stdout
* ones in the `guess` subcommand, which don't (yet) use a formatter.

Tested: `bazel run //enkit -- astore ls home/scott/bin/delta --console-format=json 2>/dev/null | jq '.'` successfully allows jq to parse the output

Jira: INFRA-11623