### PR TITLE
Update rules_oci to the latest version

### DIFF
--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -232,9 +232,9 @@ def stage_1():
     maybe(
         name = "rules_oci",
         repo_rule = http_archive,
-        strip_prefix = "rules_oci-1.7.5",
-        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.5/rules_oci-v1.7.5.tar.gz",
-        sha256 = "56d5499025d67a6b86b2e6ebae5232c72104ae682b5a21287770bd3bf0661abf",
+        strip_prefix = "rules_oci-2.2.6",
+        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/rules_oci-v2.2.6.tar.gz",
+        sha256 = "5994ec0e8df92c319ef5da5e1f9b514628ceb8fc5824b4234f2fe635abb8cc2e",
     )
 
     maybe(

--- a/bazel/init/stage_3.bzl
+++ b/bazel/init/stage_3.bzl
@@ -9,7 +9,7 @@ load("@com_github_bazelbuild_remote_apis//:repository_rules.bzl", "switched_rule
 load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
 load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
-load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 load("@rules_proto_grpc//python:repositories.bzl", rules_proto_grpc_python_repos = "python_repos")
 load("@rules_python//python:pip.bzl", "pip_parse")
@@ -44,10 +44,7 @@ def stage_3():
 
     jsonnet_go_dependencies()
 
-    oci_register_toolchains(
-        name = "oci",
-        crane_version = LATEST_CRANE_VERSION,
-    )
+    oci_register_toolchains(name = "oci")
 
     # Begin buildbarn ecosystem dependencies
     nodejs_register_toolchains(

--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -2,7 +2,7 @@ load("//bazel/utils:files.bzl", "write_to_file")
 load("//bazel/dive:dive.bzl", "oci_dive")
 load("//bazel/utils:merge_kwargs.bzl", "add_tag")
 load("@enkit//bazel/utils:merge_kwargs.bzl", "merge_kwargs")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_load")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
@@ -377,7 +377,7 @@ def container_image(*args, **kwargs):
     oci_image(*args, **kwargs)
 
 def container_tarball(*args, **kwargs):
-    oci_tarball(*args, **kwargs)
+    oci_load(*args, **kwargs)
 
 def container_push(*args, **kwargs):
     # TODO: This forces targets to be `manual`, since the base images they
@@ -416,7 +416,7 @@ def container_push(*args, **kwargs):
             tags = tags,
         )
     local_image_path = "{}/{}:latest".format(native.package_name(), target_basename)
-    oci_tarball(
+    oci_load(
         name = "{}_tarball".format(target_basename),
         image = kwargs.get("image"),
         repo_tags = [local_image_path],
@@ -488,7 +488,7 @@ container_pusher = rule(
             mandatory = True,
         ),
         "image_tarball": attr.label(
-            doc = "Image tarball returned by the oci_tarball rule to validate image tags",
+            doc = "Image tarball returned by the oci_load rule to validate image tags",
             allow_single_file = [".tar"],
             mandatory = True,
         ),


### PR DESCRIPTION
This change updates rules_oci to the latest version to build containers.

Tested:
- `bazel test //...`
- `bazel build //...`
- Update `oci_tarball` references in the internal repo

JIRA: ENGPROD-1151