### PR TITLE
Remove rules_docker

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,8 @@ run --incompatible_strict_action_env
 try-import %workspace%/.bazelrc.user
 
 common --noenable_bzlmod
+
+# Manually authenticate for oci_pull to download container images from
+# Google Artifact Registry
+common --credential_helper=us-docker.pkg.dev=%workspace%/tools/artifact_registry_auth.sh
+common --repo_env=OCI_GET_TOKEN_ALLOW_FAIL=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,5 +30,6 @@ common --noenable_bzlmod
 
 # Manually authenticate for oci_pull to download container images from
 # Google Artifact Registry
+# https://github.com/bazel-contrib/rules_oci/blob/main/docs/pull.md#authentication-using-credential-helpers
 common --credential_helper=us-docker.pkg.dev=%workspace%/tools/artifact_registry_auth.sh
 common --repo_env=OCI_GET_TOKEN_ALLOW_FAIL=1

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -238,18 +238,6 @@ def stage_1():
     )
 
     maybe(
-        name = "io_bazel_rules_docker",
-        repo_rule = http_archive,
-        sha256 = "27d53c1d646fc9537a70427ad7b034734d08a9c38924cc6357cc973fed300820",
-        strip_prefix = "rules_docker-0.24.0",
-        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.24.0/rules_docker-v0.24.0.tar.gz"],
-        patches = [
-            "@enkit//bazel/dependencies:rules_docker_no_init_go.patch",
-        ],
-        patch_args = ["-p1"],
-    )
-
-    maybe(
         name = "com_google_googleapis",
         repo_rule = http_archive,
         urls = ["https://github.com/googleapis/googleapis/archive/f5ed6db308e6ce3f9bcdc3afcbf2ab8b50d905d6.zip"],

--- a/bazel/init/stage_2.bzl
+++ b/bazel/init/stage_2.bzl
@@ -11,10 +11,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@com_github_atlassian_bazel_tools//multirun:deps.bzl", "multirun_dependencies")
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
-load("@io_bazel_rules_docker//go:image.bzl", rules_docker_go_dependencies = "repositories")
-load("@io_bazel_rules_docker//python:image.bzl", rules_docker_python_dependencies = "repositories")
-load("@io_bazel_rules_docker//repositories:deps.bzl", rules_docker_container_dependencies = "deps")
-load("@io_bazel_rules_docker//repositories:repositories.bzl", rules_docker_dependencies = "repositories")
 load("@io_bazel_rules_go//extras:embed_data_deps.bzl", "go_embed_data_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
@@ -100,11 +96,6 @@ def stage_2():
     # You must manually update boringssl when grpc is updated. If ARM support is added upstream, we may
     # be able to remove the patches and the work here.
     grpc_deps()
-
-    rules_docker_dependencies()
-    rules_docker_go_dependencies()
-    rules_docker_python_dependencies()
-    rules_docker_container_dependencies()
 
     rules_oci_dependencies()
 

--- a/bazel/init/stage_4.bzl
+++ b/bazel/init/stage_4.bzl
@@ -6,7 +6,6 @@ See README.md for more information.
 load("@enkit_pip_deps//:requirements.bzl", python_deps = "install_deps")
 load("@npm//:repositories.bzl", "npm_repositories")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
-load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 
 def stage_4():
     """Stage 4 initialization for WORKSPACE.
@@ -21,16 +20,14 @@ def stage_4():
 
     npm_repositories()
 
-    container_pull(
+    oci_pull(
         name = "container_golang_base",
         digest = "sha256:a4eefd667af74c5a1c5efe895a42f7748808e7f5cbc284e0e5f1517b79721ccb",
-        registry = "us-docker.pkg.dev",
-        repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
+        image = "us-docker.pkg.dev/enfabrica-container-images/third-party-prod/distroless/base/golang",
     )
 
-    container_pull(
+    oci_pull(
         name = "golang_base",
         digest = "sha256:a4eefd667af74c5a1c5efe895a42f7748808e7f5cbc284e0e5f1517b79721ccb",
-        registry = "us-docker.pkg.dev",
-        repository = "enfabrica-container-images/third-party-prod/distroless/base/golang",
+        image = "us-docker.pkg.dev/enfabrica-container-images/third-party-prod/distroless/base/golang",
     )

--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -347,13 +347,6 @@ def container_image(*args, **kwargs):
     output = "{}_labels.txt".format(name)
     tags = kwargs.get("tags", [])
 
-    # The 'image' field in oci_pull does not need the //image target
-    # while the container_pull rule does. Modify this wrapper script
-    # to insert the //image target when using container_pull.
-    # Remove once oci_pull doesn't have auth errors anymore.
-    if kwargs.get("base", "").startswith("@"):
-        kwargs["base"] = "{}//image".format(kwargs.get("base"))
-
     # Always include user-defined container labels in addition to build metadata from bazel --stamp
     # https://bazel.build/docs/user-manual#workspace-status
     # Container labels for oci_image can be a dictionary or file of key-value pairs with '=' as delimiters

--- a/tools/artifact_registry_auth.sh
+++ b/tools/artifact_registry_auth.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+cat >/dev/null
+TOKEN="$(gcloud auth --quiet print-access-token)"
+jq -n --arg t "$TOKEN" '{headers:{"Authorization":[ "Bearer " + $t ]}}'


### PR DESCRIPTION
This change removes the `rules_docker` package in favor of `rules_oci` as the default method to pull containers from Google Artifact Registry. The gcloud auth token must be explicitly supplied to `rules_oci` via the `--credential_helper` mechanism or else there will be an auth error.

Tested:
- Pull containers from Google Artifact Registry using `oci_pull`
- `bazel build @container_golang_base @golang_base`

JIRA: ENGPROD-1151