### PR TITLE
Return tarballs from oci_load targets by default

### DIFF
--- a/bazel/utils/container/container.bzl
+++ b/bazel/utils/container/container.bzl
@@ -410,10 +410,15 @@ def container_push(*args, **kwargs):
         )
     local_image_path = "{}/{}:latest".format(native.package_name(), target_basename)
     oci_load(
-        name = "{}_tarball".format(target_basename),
+        name = "{}_load".format(target_basename),
         image = kwargs.get("image"),
         repo_tags = [local_image_path],
         tags = tags,
+    )
+    native.filegroup(
+        name = "{}_tarball".format(target_basename),
+        srcs = [":{}_load".format(target_basename)],
+        output_group = "tarball",
     )
     container_pusher(
         name = target_basename,


### PR DESCRIPTION
This change adapts the `container_push` custom bazel rule to consume tarballs produced the new way from the latest version of `rules_oci`.

Tested:
- `bazel query --override_repository=enkit=$HOME/enkit "kind(oci_load, //...)" > $HOME/oci_load_targets.txt` from the internal repo
- `bazel build --override_repository=enkit=$HOME/enkit --target_pattern_file=$HOME/oci_load_targets.txt --keep_going` from the internal repo

JIRA: ENGPROD-1151