### PR TITLE
gee: disable token scope checks

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # (due to https://github.com/koalaman/shellcheck/issues/817)
 
-readonly VERSION="0.2.58"
+readonly VERSION="0.2.59"
 
 if read -r -d '' USAGE <<'EOT'
 . __ _  ___  ___
@@ -860,20 +860,22 @@ function _gh_auth_check() {
   else
     return 1
   fi
-  # Check if we have the right token scopes:
-  local SCOPES=""
-  SCOPES="$("${GH}" api --verbose / | grep X-Oauth-Scopes: )"
-  MISSING=""
-  for S in "read:org" "repo" "admin:public_key" "admin:ssh_signing_key"; do
-    if ! [[ "${SCOPES}" == *"${S}"* ]]; then
-      MISSING+=" ${S}"
-    fi
-  done
-  if [[ -n "${MISSING}" ]]; then
-    _error "Your github API token is missing the following permissions: ${MISSING}"
-    return 1
-  fi
-  _info "All github API permissions present."
+  ### TODO(jonathan): the following breaks with 2023 version of gh.  Find a way
+  ###    to fail functional.
+  ### # Check if we have the right token scopes:
+  ### local SCOPES=""
+  ### SCOPES="$("${GH}" api --verbose / | grep X-Oauth-Scopes: )"
+  ### MISSING=""
+  ### for S in "read:org" "repo" "admin:public_key" "admin:ssh_signing_key"; do
+  ###   if ! [[ "${SCOPES}" == *"${S}"* ]]; then
+  ###     MISSING+=" ${S}"
+  ###   fi
+  ### done
+  ### if [[ -n "${MISSING}" ]]; then
+  ###   _error "Your github API token is missing the following permissions: ${MISSING}"
+  ###   return 1
+  ### fi
+  ### _info "All github API permissions present."
   return 0
 }
 

--- a/scripts/gee
+++ b/scripts/gee
@@ -900,6 +900,7 @@ function _gh_authenticate() {
       "   * \"repo\" (enables the whole sub-tree of permissions)" \
       "   * \"read:org\" (below the \"admin:org\" permission tree)" \
       "   * \"admin:public_key\" (enables the whole sub-tree of permissions)" \
+      "   * \"admin:ssh_signing_key\"" \
       "6. Finally, click \"Generate token\" at the bottom of the form." \
       ""
     local TOKEN=""

--- a/scripts/gee.md
+++ b/scripts/gee.md
@@ -6,7 +6,7 @@
  |___/
 ```
 
-gee version: 0.2.58
+gee version: 0.2.59
 
 gee is a user-friendly wrapper (aka "porcelain") around the "git" and "gh-cli"
 tools  gee is an opinionated tool that implements a specific, simple, powerful


### PR DESCRIPTION
This code required a modern version of gh, but is not supported by the 2023
version of gh that is part of the dev container.

Tested: 


