### PR TITLE
astore: Revive e2e test

### DIFF
--- a/astore/BUILD.bazel
+++ b/astore/BUILD.bazel
@@ -26,7 +26,10 @@ go_test(
         "//lib/progress",
         "//lib/srand",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//test/bufconn",
     ],
 )

--- a/astore/atesting/BUILD.bazel
+++ b/astore/atesting/BUILD.bazel
@@ -2,10 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "atesting",
+    testonly = True,
     srcs = ["mocks.go"],
     importpath = "github.com/enfabrica/enkit/astore/atesting",
     visibility = ["//visibility:public"],
-    deps = ["//lib/knetwork"],
+    deps = ["@com_github_stretchr_testify//require"],
 )
 
 alias(

--- a/astore/e2e_test.go
+++ b/astore/e2e_test.go
@@ -17,11 +17,11 @@ import (
 
 // TODO(aaahrens): fix client so that its signed urls can depend on an interface for actual e2e testing.
 func TestServer(t *testing.T) {
-	astoreDescriptor, killFuncs, err := RunAStoreServer()
+	astoreDescriptor, killFuncs := RunAStoreServer(t)
 	if killFuncs != nil {
 		defer killFuncs.KillAll()
 	}
-	assert.Nil(t, err)
+
 	// Running this as test ping feature.
 	client := astore.New(astoreDescriptor.Connection)
 	res, _, err := client.List("/test", astore.ListOptions{})

--- a/astore/server_test.go
+++ b/astore/server_test.go
@@ -3,17 +3,21 @@ package astore_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
 
 	"github.com/enfabrica/enkit/astore/atesting"
 	apb "github.com/enfabrica/enkit/astore/rpc/astore"
 	"github.com/enfabrica/enkit/astore/server/astore"
 	"github.com/enfabrica/enkit/lib/srand"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -23,56 +27,59 @@ type AStoreDescriptor struct {
 }
 
 // RunAStoreServer will spin up an emulated datastore along with an instance of the astore grpc server.
-func RunAStoreServer() (*AStoreDescriptor, atesting.KillAbleProcess, error) {
+func RunAStoreServer(t *testing.T) (*AStoreDescriptor, atesting.KillAbleProcess) {
+	t.Helper()
+
 	killFunctions := atesting.KillAbleProcess{}
-	emulatorDescriptor, emulatorKill, err := atesting.RunEmulatedDatastore()
+	emulatorDescriptor, emulatorKill := atesting.RunEmulatedDatastore(t)
 	killFunctions.AddKillable(emulatorKill)
-	if err != nil {
-		return nil, killFunctions, err
-	}
+
 	// Causes the google-could-go/storage library to use a local emulator rather than the real endpoint.
-	err = os.Setenv(
+	err := os.Setenv(
 		"STORAGE_EMULATOR_HOST",
-		fmt.Sprintf("localhost:%d", emulatorDescriptor.Addr.Port))
-	if err != nil {
-		return nil, killFunctions, err
-	}
+		fmt.Sprintf("localhost:%d", emulatorDescriptor.Addr.Port),
+	)
+
 	buffListener := bufconn.Listen(2048 * 2048)
 	bufDialer := func(context.Context, string) (net.Conn, error) {
 		return buffListener.Dial()
 	}
 	grpcServer := grpc.NewServer()
-	credentialString, err := ioutil.ReadFile("./testdata/credentials.json")
-	if err != nil {
-		return nil, nil, err
-	}
+	credsPath, err := runfiles.Rlocation("enkit/astore/testdata/credentials.json")
+	require.NoError(t, err)
 
-	server, err := astore.New(rand.New(srand.Source),
+	credentialString, err := os.ReadFile(credsPath)
+	require.NoError(t, err)
+
+	server, err := astore.New(
+		rand.New(srand.Source),
 		astore.WithCredentialsJSON(credentialString),
 		astore.WithSigningJSON(credentialString),
-		astore.WithBucket("example-bucket"))
+		astore.WithBucket("example-bucket"),
+	)
+	require.NoError(t, err)
 
-	if err != nil {
-		return nil, killFunctions, err
-	}
 	apb.RegisterAstoreServer(grpcServer, server)
-	if err := grpcServer.Serve(buffListener); err != nil {
-		return nil, killFunctions, err
-	}
+
+	go func() {
+		_ = grpcServer.Serve(buffListener)
+	}()
+
 	killGrpcFunc := func() {
 		grpcServer.Stop()
 	}
 	killFunctions.Add(killGrpcFunc)
 
-	conn, err := grpc.DialContext(context.Background(),
-		"empty", grpc.WithContextDialer(bufDialer),
-		grpc.WithInsecure())
-	if err != nil {
-		return nil, killFunctions, err
-	}
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"empty",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
 	return &AStoreDescriptor{
 		Connection: conn,
 		Server:     server,
-	}, killFunctions, nil
+	}, killFunctions
 }
-

--- a/astore/testdata/README.md
+++ b/astore/testdata/README.md
@@ -1,1 +1,20 @@
-pleace credentials.json here for testing
+# Initialization
+
+1. **Fetch service account key** for testing:
+
+   ```
+   gcloud \
+     --project=astore-284118 \
+     secrets \
+     versions \
+     access \
+     latest \
+     --secret=astore_testing_service_account_key_json \
+     > astore/testdata/credentials.json
+   ```
+
+1. **Run end-to-end tests**:
+
+   ```
+   bazel test //astore:astore_test
+   ```


### PR DESCRIPTION
This change heavily modifies the E2E test, which appears to be broken even locally.

Jira: REL-192