### PR TITLE
codeowners: Define root owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+/* @ccontavalli @mhallmark @jrp-enf
 *.sh @jonathan-enf @ccontavalli @ahungrynacho @mhallmark
 /scripts @jonathan-enf @ccontavalli @mhallmark
 allocation_manager/ @kjw-enf @ccontavalli @moksh-enf @roivanov


### PR DESCRIPTION
This PR adds myself, carlo and jason as root owners of the enkit repo. The CODEOWNERS seems to be acting a little odd on this repo, assigning people who don't exist in this file as CODEOWNERS. I'm hoping that kicking this file a bit here will get the CODEOWNERS working.
