### PR TITLE
Detect cycles in affected target dependency graphs

### DIFF
--- a/lib/bazel/affected_targets_test.go
+++ b/lib/bazel/affected_targets_test.go
@@ -127,6 +127,62 @@ func TestCalculateAffected(t *testing.T) {
 			},
 		},
 		{
+			desc: "dependency cycle",
+			startResults: &QueryResult{
+				Targets: map[string]*Target{
+					"//test/target:foo": mustNewTarget(t, &bpb.Target{
+						Type: bpb.Target_RULE.Enum(),
+						Rule: &bpb.Rule{
+							Name: proto.String("//test/target:foo"),
+							RuleInput: []string{
+								"//test/target:bar",
+							},
+						},
+					}),
+					"//test/target:bar": mustNewTarget(t, &bpb.Target{
+						Type: bpb.Target_RULE.Enum(),
+						Rule: &bpb.Rule{
+							Name: proto.String("//test/target:bar"),
+							RuleInput: []string{
+								"//test/target:foo.txt",
+							},
+						},
+					}),
+					"//test/target:foo.txt": mustNewTarget(t, &bpb.Target{
+						Type: bpb.Target_SOURCE_FILE.Enum(),
+						SourceFile: &bpb.SourceFile{
+							Name: proto.String("//test/target:foo.txt"),
+						},
+					}),
+				},
+				workspace: testWorkspace(t),
+			},
+			endResults: &QueryResult{
+				Targets: map[string]*Target{
+					"//test/target:foo": mustNewTarget(t, &bpb.Target{
+						Type: bpb.Target_RULE.Enum(),
+						Rule: &bpb.Rule{
+							Name: proto.String("//test/target:foo"),
+							RuleInput: []string{
+								"//test/target:bar",
+							},
+						},
+					}),
+					"//test/target:bar": mustNewTarget(t, &bpb.Target{
+						Type: bpb.Target_RULE.Enum(),
+						Rule: &bpb.Rule{
+							Name: proto.String("//test/target:bar"),
+							RuleInput: []string{
+								"//test/target:foo",
+							},
+						},
+					}),
+				},
+				workspace: testWorkspace(t),
+			},
+			wantErr: "dependency cycle",
+		},
+		{
 			desc: "attribute change detection",
 			startResults: &QueryResult{
 				Targets: map[string]*Target{


### PR DESCRIPTION
`bazel query` is resilient to circular dependencies, meaning it will still run and not report them (https://github.com/bazelbuild/bazel/issues/12204#issuecomment-1154017067).  This is unfortunate, because our "affected targets" code is not able to handle a cycle and will blow up with a stack overflow.

Detect cycles when querying deps, and print the first dep that led to the cycle being discovered.  This should help debug the issue when it occurs.  Unit test included.

 Context: https://chat.google.com/room/AAAAuo7llA8/LVt5EN1qWXg/LVt5EN1qWXg?cls=10