### PR TITLE
Remove .gitHub/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-/bestie/ @minor-fixes @msgoldflam @gpaussaenf
-
-# Changes to //third_party must be done exclusively via Copybara for imported
-# files. Reviewers should ensure this is the case.
-/third_party/ @minor-fixes


### PR DESCRIPTION
Only the top level one is valid.

Jira: INFRA-11726