### PR TITLE
feat(astore): add bazel rule for the multiple astore files upload

### DIFF
--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -1,12 +1,35 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 FILE="{file}"
 TARGETS=( {targets} )
 UIDFILE="{uidfile}"
 UPLOAD_TAG="{upload_tag}"
 OUTPUT_FORMAT="{output_format}"
+ASTORE_CMD=( {astore} )
+PY_WRAPPER=( {py_wrapper} )
+
+# file $(realpath "${PY_WRAPPER[@]}")
+# sha256sum "${PY_WRAPPER[@]}"
+
+"${PY_WRAPPER[@]}" --help >&2 || true
+
+test ${#ASTORE_CMD[@]} -eq 1
+
+# "${ASTORE_CMD[@]}" --help
+
+if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
+  exec echo "${ASTORE_CMD[@]}" \
+--astore "${ASTORE_CMD[0]}" \
+--file "${FILE}" \
+--output_format "${OUTPUT_FORMAT}" \
+--upload_tag "${UPLOAD_TAG}" \
+"${TARGETS[@]}"
+
+  exit 1
+fi
 
 TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
 trap 'rm -f "${TEMPTOML}"' EXIT

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -6,6 +6,7 @@ FILE="{file}"
 TARGETS=( {targets} )
 UIDFILE="{uidfile}"
 UPLOAD_TAG="{upload_tag}"
+OUTPUT_FORMAT="{output_format}"
 
 TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
 trap 'rm -f "${TEMPTOML}"' EXIT
@@ -43,14 +44,13 @@ function update_build_file() {
 # astore doesn't tell us which metadata entry corresponds to which target, so
 # we work around the issue by uploading the targets sequentially:
 for TARGET in "${TARGETS[@]}"; do
-  {astore} upload ${UPLOAD_TAG} -G -f "${FILE}" "${TARGET}" -m "${TEMPTOML}"
+  {astore} upload ${UPLOAD_TAG} -G -f "${FILE}" "${TARGET}" -m "${TEMPTOML}" --console-format "${OUTPUT_FORMAT}"
   FILE_UID="$(grep -E "^  Uid = " "${TEMPTOML}" | awk '{print $3}' | tr -d \")"
   FILE_SHA="$(sha256sum "${TARGET}" | awk '{print $1}')"
   if [[ -z "${FILE_UID}" ]]; then
     echo >&2 "Error: no UID found for ${TARGET} uploaded as ${FILE}".
     exit 2
   fi
-  echo >&2 "${TARGET} uploaded as ${FILE}: assigned UID ${FILE_UID}"
   if [[ -n "${UIDFILE}"  ]]; then
     update_build_file "${UIDFILE}" "${TARGET}" "${FILE_UID}" "${FILE_SHA}"
   fi

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -36,7 +36,8 @@ def _astore_upload(ctx):
     if ctx.attr.dir and ctx.attr.file:
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
-    files = [ctx.executable._astore_client]
+    files = [ctx.executable._astore_client, ctx.executable._astore_py_wrapper]
+    print(files)
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
@@ -62,6 +63,7 @@ def _astore_upload(ctx):
         output = ctx.outputs.executable,
         substitutions = {
             "{astore}": ctx.executable._astore_client.short_path,
+            "{py_wrapper}": ctx.executable._astore_py_wrapper.short_path,
             "{targets}": " ".join(targets),
             "{file}": ctx.attr.file,
             "{dir}": ctx.attr.dir,
@@ -118,6 +120,12 @@ astore_upload = rule(
         ),
         "_astore_client": attr.label(
             default = Label("@net_enfabrica_binary_astore//file"),
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "_astore_py_wrapper": attr.label(
+            default = Label("@net_enfabrica_binary_astore_py//file"),
             allow_single_file = True,
             executable = True,
             cfg = "host",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -292,6 +292,17 @@ filegroup(
         executable = True,
     )
 
+    # Do we need to make it public? Yes!
+    maybe(
+        name = "net_enfabrica_binary_astore_py",
+        repo_rule = http_file,
+        sha256 = "b0c857e8f5cd90d977d0b66f96ba08b9bcf5db76fb3a038872a0860b24029faa",
+        # what is the meaning of d and l?
+                #  https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e
+        urls = ["https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e"],
+        executable = True,
+    )
+
     maybe(
         name = "libz",
         repo_rule = http_archive,

--- a/f/astore/BUILD.bazel
+++ b/f/astore/BUILD.bazel
@@ -1,7 +1,13 @@
-load("//bazel/astore:defs.bzl", "astore_tag")
+load("//bazel/astore:defs.bzl", "astore_output_format", "astore_tag")
 
 astore_tag(
     name = "upload_tag",
     build_setting_default = [],
+    visibility = ["//bazel/astore:__pkg__"],
+)
+
+astore_output_format(
+    name = "output_format",
+    build_setting_default = "table",
     visibility = ["//bazel/astore:__pkg__"],
 )

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -26,7 +26,7 @@ go_binary(
 
 astore_upload(
     name = "astore_push",
-    file = "infra/flextape/flextape_server",
+    file = "home/scott/test/flextape",
     targets = [
         ":flextape",
     ],


### PR DESCRIPTION
This change is intended to move most of the functionality from the script https://github.com/enfabrica/enkit/blob/master/bazel/astore/astore_upload_file.sh
into the python code.
It also outputs on the stdout a single json data of the multiple uploaded targets with the target file name being added.