### PR TITLE
ENGPROD-1075: Implement `astore get-url` command in enkit to retirieve  download URLs for artifacts by path|uid.

### DIFF
--- a/astore/client/astore/formatter.go
+++ b/astore/client/astore/formatter.go
@@ -9,6 +9,7 @@ import (
 
 type Formatter interface {
 	Artifact(*astore.Artifact)
+	RetrieveResponse(*astore.RetrieveResponse)
 	Element(*astore.Element)
 	Flush()
 }
@@ -28,6 +29,11 @@ func (uf *UglyFormatter) File() *os.File {
 
 func (uf *UglyFormatter) Artifact(art *astore.Artifact) {
 	fmt.Fprintf(uf.File(), "%s\t%s\t%s\t%x\t%s\t%s\t%s\n", time.Unix(0, art.Created), art.Creator, art.Architecture, art.MD5, art.Uid, art.Tag, art.Note)
+}
+
+func (uf *UglyFormatter) RetrieveResponse(resp *astore.RetrieveResponse) {
+	fmt.Fprintf(uf.File(), "%s\t%s\t", resp.GetPath(), resp.GetUrl())
+	uf.Artifact(resp.GetArtifact())
 }
 
 func (uf *UglyFormatter) Element(el *astore.Element) {

--- a/astore/client/test/regression_test.go
+++ b/astore/client/test/regression_test.go
@@ -186,8 +186,10 @@ func TestSimple(t *testing.T) {
 
 	// Download one of the files.
 	arts, err = ac.Download([]astore.FileToDownload{{
-		Remote: name,
-		Local:  "result.txt",
+		Descriptor: astore.FileToDownloadDescriptor{
+			Remote: name,
+		},
+		Local: "result.txt",
 	}}, astore.DownloadOptions{
 		Context: ctx,
 	})
@@ -200,8 +202,10 @@ func TestSimple(t *testing.T) {
 	// Download it again. Should fail, no overwrite allowed.
 	arts, err = ac.Download([]astore.FileToDownload{
 		{
-			Remote: name,
-			Local:  "result.txt",
+			Descriptor: astore.FileToDownloadDescriptor{
+				Remote: name,
+			},
+			Local: "result.txt",
 		},
 	}, astore.DownloadOptions{
 		Context: ctx,
@@ -210,10 +214,12 @@ func TestSimple(t *testing.T) {
 
 	// Download it one more time. Set ovewrite. Pick a different tag.
 	arts, err = ac.Download([]astore.FileToDownload{{
-		Remote:    name,
+		Descriptor: astore.FileToDownloadDescriptor{
+			Remote: name,
+			Tag:    &[]string{"simple"},
+		},
 		Local:     "result.txt",
 		Overwrite: true,
-		Tag:       &[]string{"simple"},
 	}}, astore.DownloadOptions{
 		Context: ctx,
 	})
@@ -226,10 +232,12 @@ func TestSimple(t *testing.T) {
 
 	// Try to download something that does not exist.
 	arts, err = ac.Download([]astore.FileToDownload{{
-		Remote:    name,
+		Descriptor: astore.FileToDownloadDescriptor{
+			Remote: name,
+			Tag:    &[]string{"simple", "latest"},
+		},
 		Local:     "result.txt",
 		Overwrite: true,
-		Tag:       &[]string{"simple", "latest"},
 	}}, astore.DownloadOptions{
 		Context: ctx,
 	})
@@ -238,10 +246,12 @@ func TestSimple(t *testing.T) {
 	// Try to download the oldest file by UID.
 	// Specify no name, just for fun.
 	arts, err = ac.Download([]astore.FileToDownload{{
-		Remote:    allarts[0].Uid,
+		Descriptor: astore.FileToDownloadDescriptor{
+			Remote: allarts[0].Uid,
+			// Should be ignored, when querying by Uid.
+			Tag: &[]string{"simple", "latest"},
+		},
 		Overwrite: true,
-		// Should be ignored, when querying by Uid.
-		Tag: &[]string{"simple", "latest"},
 	}}, astore.DownloadOptions{
 		Context: ctx,
 	})


### PR DESCRIPTION
This is the first step to migrate a store rules to `repository_ctx`.