### PR TITLE
Fixup astore_upload rule

### DIFF
--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@enkit_pip_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 bzl_library(
     name = "defs_bzl",
@@ -10,3 +12,26 @@ exports_files([
     "astore_upload_file.sh",
     "astore_upload_dir.sh",
 ])
+
+py_binary(
+    name = "astore_upload_files",
+    srcs = ["astore_upload_files.py"],
+    main = "astore_upload_files.py",
+    deps = [
+        requirement("absl-py"),
+        # requirement("toml"),
+    ],
+)
+
+py_test(
+    name = "astore_upload_files_test",
+    srcs = ["astore_upload_files_test.py"],
+    # driver = "absltest",
+    deps = [
+        ":astore_upload_files",
+        requirement("absl-py"),
+        # requirement("pytest"),
+        # requirement("toml"),
+    ],
+)
+

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -16,8 +16,12 @@ exports_files([
 py_binary(
     name = "astore_upload_files",
     srcs = ["astore_upload_files.py"],
+    data = [
+        "@net_enfabrica_binary_astore//file",
+    ],
     main = "astore_upload_files.py",
     deps = [
+        "@rules_python//python/runfiles",
         requirement("absl-py"),
     ],
 )

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -30,4 +30,3 @@ py_test(
         requirement("absl-py"),
     ],
 )
-

--- a/bazel/astore/BUILD.bazel
+++ b/bazel/astore/BUILD.bazel
@@ -19,19 +19,15 @@ py_binary(
     main = "astore_upload_files.py",
     deps = [
         requirement("absl-py"),
-        # requirement("toml"),
     ],
 )
 
 py_test(
     name = "astore_upload_files_test",
     srcs = ["astore_upload_files_test.py"],
-    # driver = "absltest",
     deps = [
         ":astore_upload_files",
         requirement("absl-py"),
-        # requirement("pytest"),
-        # requirement("toml"),
     ],
 )
 

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -21,7 +21,7 @@ test ${#ASTORE_CMD[@]} -eq 1
 # "${ASTORE_CMD[@]}" --help
 
 if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
-  exec echo "${ASTORE_CMD[@]}" \
+  exec "${PY_WRAPPER[@]}" \
 --astore "${ASTORE_CMD[0]}" \
 --file "${FILE}" \
 --output_format "${OUTPUT_FORMAT}" \

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -1,83 +1,10 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
-FILE="{file}"
-TARGETS=( {targets} )
-UIDFILE="{uidfile}"
-UPLOAD_TAG="{upload_tag}"
-OUTPUT_FORMAT="{output_format}"
-ASTORE_CMD=( {astore} )
-PY_WRAPPER=( {py_wrapper} )
-
-# file $(realpath "${PY_WRAPPER[@]}")
-# sha256sum "${PY_WRAPPER[@]}"
-
-"${PY_WRAPPER[@]}" --help >&2 || true
-
-test ${#ASTORE_CMD[@]} -eq 1
-
-# "${ASTORE_CMD[@]}" --help
-
-if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
-  ls -lh "${PY_WRAPPER[@]}"
-  "${PY_WRAPPER[@]}" --help >&2 || true
-
-  exec echo "${PY_WRAPPER[@]}" \
---astore "${ASTORE_CMD[0]}" \
---file "${FILE}" \
---output_format "${OUTPUT_FORMAT}" \
---upload_tag "${UPLOAD_TAG}" \
-"${TARGETS[@]}"
-
-  exit 1
-fi
-
-TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
-trap 'rm -f "${TEMPTOML}"' EXIT
-
-function update_starlark_version_file() {
-  local UIDFILE="$1"
-  local TARGET="$2"
-  local FILE_UID="$3"
-  local FILE_SHA="$4"
-
-  if [[ ! -f "${UIDFILE}" ]]; then
-    echo >&2 "Error: ${UIDFILE}: file not found"
-    exit 3
-  fi
-  UIDFILE="$(readlink -f "${UIDFILE}")"
-  local VARNAME="$(basename "${TARGET}" | tr a-z A-Z | tr -c A-Z0-9\\r\\n _ )"
-  local UID_VARNAME="UID_${VARNAME}"
-  local SHA_VARNAME="SHA_${VARNAME}"
-  local UID_SEDSCRIPT="s/^${UID_VARNAME} = \".*\"/${UID_VARNAME} = \"${FILE_UID}\"/"
-  local SHA_SEDSCRIPT="s/^${SHA_VARNAME} = \".*\"/${SHA_VARNAME} = \"${FILE_SHA}\"/"
-  if ! sed -i -e "${UID_SEDSCRIPT}" -e "${SHA_SEDSCRIPT}" "${UIDFILE}"; then
-    echo >&2 "Error: sed command failed to execute script:"
-    echo >&2 "  ${UID_SEDSCRIPT}"
-    echo >&2 "  ${SHA_SEDSCRIPT}"
-    exit 4
-  fi
-  if ! grep "^${UID_VARNAME} = \"${FILE_UID}\"" "${UIDFILE}" >&2 ; then
-    echo >&2 "Error: failed to update ${UID_VARNAME} in ${UIDFILE}"
-    echo >&2 "       Is this variable missing from this file?"
-    exit 5
-  fi
-  echo >&2 "Updated ${UID_VARNAME} in ${UIDFILE}"
-}
-
-# astore doesn't tell us which metadata entry corresponds to which target, so
-# we work around the issue by uploading the targets sequentially:
-for TARGET in "${TARGETS[@]}"; do
-  {astore} upload ${UPLOAD_TAG} -G -f "${FILE}" "${TARGET}" -m "${TEMPTOML}" --console-format "${OUTPUT_FORMAT}"
-  FILE_UID="$(grep -E "^  Uid = " "${TEMPTOML}" | awk '{print $3}' | tr -d \")"
-  FILE_SHA="$(sha256sum "${TARGET}" | awk '{print $1}')"
-  if [[ -z "${FILE_UID}" ]]; then
-    echo >&2 "Error: no UID found for ${TARGET} uploaded as ${FILE}".
-    exit 2
-  fi
-  if [[ -n "${UIDFILE}"  ]]; then
-    update_starlark_version_file "${UIDFILE}" "${TARGET}" "${FILE_UID}" "${FILE_SHA}"
-  fi
-done
+exec {wrapper} \
+  {upload_file_flags} \
+  {astore_path_flag} \
+  {uidfile_flag} \
+  {tag_flags} \
+  {output_format_flag}

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -21,6 +21,9 @@ test ${#ASTORE_CMD[@]} -eq 1
 # "${ASTORE_CMD[@]}" --help
 
 if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
+  ls -lh "${PY_WRAPPER[@]}"
+  "${PY_WRAPPER[@]}" --help >&2 || true
+
   exec echo "${PY_WRAPPER[@]}" \
 --astore "${ASTORE_CMD[0]}" \
 --file "${FILE}" \
@@ -34,7 +37,7 @@ fi
 TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
 trap 'rm -f "${TEMPTOML}"' EXIT
 
-function update_build_file() {
+function update_starlark_version_file() {
   local UIDFILE="$1"
   local TARGET="$2"
   local FILE_UID="$3"
@@ -75,6 +78,6 @@ for TARGET in "${TARGETS[@]}"; do
     exit 2
   fi
   if [[ -n "${UIDFILE}"  ]]; then
-    update_build_file "${UIDFILE}" "${TARGET}" "${FILE_UID}" "${FILE_SHA}"
+    update_starlark_version_file "${UIDFILE}" "${TARGET}" "${FILE_UID}" "${FILE_SHA}"
   fi
 done

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -1,12 +1,35 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 FILE="{file}"
 TARGETS=( {targets} )
 UIDFILE="{uidfile}"
 UPLOAD_TAG="{upload_tag}"
 OUTPUT_FORMAT="{output_format}"
+ASTORE_CMD=( {astore} )
+PY_WRAPPER=( {py_wrapper} )
+
+# file $(realpath "${PY_WRAPPER[@]}")
+# sha256sum "${PY_WRAPPER[@]}"
+
+"${PY_WRAPPER[@]}" --help >&2 || true
+
+test ${#ASTORE_CMD[@]} -eq 1
+
+# "${ASTORE_CMD[@]}" --help
+
+if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
+  exec echo "${ASTORE_CMD[@]}" \
+--astore "${ASTORE_CMD[0]}" \
+--file "${FILE}" \
+--output_format "${OUTPUT_FORMAT}" \
+--upload_tag "${UPLOAD_TAG}" \
+"${TARGETS[@]}"
+
+  exit 1
+fi
 
 TEMPTOML="$(mktemp /tmp/astore.XXXXX.toml)" || exit 1
 trap 'rm -f "${TEMPTOML}"' EXIT

--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -21,7 +21,7 @@ test ${#ASTORE_CMD[@]} -eq 1
 # "${ASTORE_CMD[@]}" --help
 
 if [[ "${OUTPUT_FORMAT}" == "json" ]]; then
-  exec "${PY_WRAPPER[@]}" \
+  exec echo "${PY_WRAPPER[@]}" \
 --astore "${ASTORE_CMD[0]}" \
 --file "${FILE}" \
 --output_format "${OUTPUT_FORMAT}" \

--- a/bazel/astore/astore_upload_files.py
+++ b/bazel/astore/astore_upload_files.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""This is a replacement for the functionality of the @enkit/bazel/astore/astore_upload_file.sh
+Original file will only have arguments parsing and passing them down to this script.
+"""
+
+# standard libraries
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# third party libraries
+import toml
+from absl import app, flags
+from absl import logging as logger
+
+FLAGS = flags.FLAGS
+
+# Define command-line flags
+flags.DEFINE_string("file", "", "Remote file name where to store all files")
+flags.DEFINE_string("uidfile", "", "File to update with UID information")
+flags.DEFINE_string("upload_tag", "", "Tag to add to the upload")
+# FIXME: technically it's just a switch, only json data will be updated with the target
+#        anything else just passed as is.
+flags.DEFINE_enum("output_format", "table", ["table", "json"], "Output format")
+flags.DEFINE_string("astore", "astore", "Path to astore binary")
+
+
+def sha256sum(filename):
+    """Calculate SHA256 hash of a file."""
+    h = hashlib.sha256()
+    with open(filename, "rb") as f:
+        for block in iter(lambda: f.read(4096), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def update_build_file(uidfile, target, file_uid, file_sha):
+    """Update UID and SHA variables in the build file."""
+    if not os.path.isfile(uidfile):
+        logger.error("Error: %s: file not found", uidfile)
+        sys.exit(3)
+
+    uidfile = os.path.realpath(uidfile)
+    varname = os.path.basename(target).translate(
+        str.maketrans(
+            "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "".join(c for c in map(chr, range(256)) if not c.isalnum() and c not in "\r\n")
+        )
+    )
+
+    uid_varname = f"UID_{varname}"
+    sha_varname = f"SHA_{varname}"
+
+    with open(uidfile, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    new_content = re.sub(f'^{uid_varname} = ".*"', f'{uid_varname} = "{file_uid}"', content, flags=re.MULTILINE)
+    new_content = re.sub(f'^{sha_varname} = ".*"', f'{sha_varname} = "{file_sha}"', new_content, flags=re.MULTILINE)
+
+    with open(uidfile, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    # Verify the update was successful
+    with open(uidfile, "r", encoding="utf-8") as f:
+        if not re.search(f'^{uid_varname} = "{file_uid}"', f.read(), re.MULTILINE):
+            logger.error("Error: failed to update %s in %s", uid_varname, uidfile)
+            logger.error("       Is this variable missing from this file?")
+            sys.exit(5)
+
+    logger.info("Updated %s in %s", uid_varname, uidfile)
+
+
+def main(argv):
+    # Get targets from command line arguments (after the script name)
+    targets = argv[1:]
+
+    # Check if we have any targets to process
+    if not targets:
+        logger.error("No targets specified. Please provide targets as command line arguments.")
+        sys.exit(1)
+
+    if len(targets) > 1 and FLAGS.uidfile:
+        logger.error("Error: cannot update uidfile when uploading multiple targets")
+        sys.exit(1)
+
+    # Log the targets we're going to process
+    logger.info("Processing targets: %s", targets)
+
+    # Create temporary file for metadata
+    with tempfile.NamedTemporaryFile(prefix="astore.", suffix=".toml", delete=False) as temp:
+        temp_toml = temp.name
+
+    try:
+        if FLAGS.astore == "astore":
+            astore_cmd = ["enkit", "astore", "upload"]
+        else:
+            astore_cmd = [FLAGS.astore, "upload"]
+
+        json_data = dict()
+        # Process each target sequentially
+        for target in targets:
+            cmd = astore_cmd.copy()
+
+            if FLAGS.upload_tag:
+                # FIXME astore_upload_file.sh has -t provided by the bazel rule
+                cmd.extend(FLAGS.upload_tag.split())
+
+            cmd.extend(["-G", "-f", FLAGS.file, "-m", temp_toml, "--console-format", FLAGS.output_format, target])
+            logger.info("Running command: %s", cmd)
+
+            # Run the upload command
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                logger.error("Error uploading %s: %s", target, result.stderr)
+                sys.exit(1)
+
+            # Print output based on format
+            if FLAGS.output_format == "json":
+                data = json.loads(result.stdout)
+                data["Artifacts"][0]["Target"] = target
+                if not json_data:
+                    json_data = data
+                else:
+                    json_data["Artifacts"].append(data["Artifacts"][0])
+            else:
+                print(result.stdout)
+
+            # Update build file if specified
+            if FLAGS.uidfile:
+                # Extract UID from metadata file
+                with open(temp_toml, "r", encoding="utf-8") as f:
+                    toml_data = toml.load(f)
+
+                file_uid = toml_data["Artifacts"][0]["Uid"]
+                if not file_uid:
+                    logger.error("Error: no UID found for %s uploaded as %s", target, FLAGS.file)
+                    sys.exit(2)
+
+                update_build_file(FLAGS.uidfile, target, file_uid, sha256sum(target))
+
+        if FLAGS.output_format == "json":
+            print(json.dumps(json_data))
+    finally:
+        # Clean up temporary file
+        if os.path.exists(temp_toml):
+            os.unlink(temp_toml)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/bazel/astore/astore_upload_files.py
+++ b/bazel/astore/astore_upload_files.py
@@ -108,7 +108,7 @@ def main(argv):
                 # FIXME astore_upload_file.sh has -t provided by the bazel rule
                 cmd.extend(FLAGS.upload_tag.split())
 
-            cmd.extend(["-G", "-f", FLAGS.file, "-m", temp_json, "--console-format", FLAGS.output_format, target])
+            cmd.extend(["--disable-git", "--file", FLAGS.file, "--meta-file", temp_json, "--console-format", FLAGS.output_format, target])
             logger.info("Running command: %s", cmd)
 
             # Run the upload command

--- a/bazel/astore/astore_upload_files.py
+++ b/bazel/astore/astore_upload_files.py
@@ -14,7 +14,6 @@ import sys
 import tempfile
 
 # third party libraries
-import toml
 from absl import app, flags
 from absl import logging as logger
 
@@ -91,8 +90,8 @@ def main(argv):
     logger.info("Processing targets: %s", targets)
 
     # Create temporary file for metadata
-    with tempfile.NamedTemporaryFile(prefix="astore.", suffix=".toml", delete=False) as temp:
-        temp_toml = temp.name
+    with tempfile.NamedTemporaryFile(prefix="astore.", suffix=".json", delete=False) as temp:
+        temp_json = temp.name
 
     try:
         if FLAGS.astore == "astore":
@@ -109,7 +108,7 @@ def main(argv):
                 # FIXME astore_upload_file.sh has -t provided by the bazel rule
                 cmd.extend(FLAGS.upload_tag.split())
 
-            cmd.extend(["-G", "-f", FLAGS.file, "-m", temp_toml, "--console-format", FLAGS.output_format, target])
+            cmd.extend(["-G", "-f", FLAGS.file, "-m", temp_json, "--console-format", FLAGS.output_format, target])
             logger.info("Running command: %s", cmd)
 
             # Run the upload command
@@ -132,10 +131,10 @@ def main(argv):
             # Update build file if specified
             if FLAGS.uidfile:
                 # Extract UID from metadata file
-                with open(temp_toml, "r", encoding="utf-8") as f:
-                    toml_data = toml.load(f)
+                with open(temp_json, "r", encoding="utf-8") as f:
+                    json_data = json.load(f)
 
-                file_uid = toml_data["Artifacts"][0]["Uid"]
+                file_uid = json_data["Artifacts"][0]["Uid"]
                 if not file_uid:
                     logger.error("Error: no UID found for %s uploaded as %s", target, FLAGS.file)
                     sys.exit(2)
@@ -146,8 +145,8 @@ def main(argv):
             print(json.dumps(json_data))
     finally:
         # Clean up temporary file
-        if os.path.exists(temp_toml):
-            os.unlink(temp_toml)
+        if os.path.exists(temp_json):
+            os.unlink(temp_json)
 
 
 if __name__ == "__main__":

--- a/bazel/astore/astore_upload_files_test.py
+++ b/bazel/astore/astore_upload_files_test.py
@@ -134,8 +134,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
         # self.assertEqual(cmd_args[1], "upload")
 
         self.assertIn("test_tag", cmd_args)
-        self.assertIn("-G", cmd_args)
-        self.assertIn("-f", cmd_args)
+        self.assertIn("--disable-git", cmd_args)
+        self.assertIn("--file", cmd_args)
         self.assertIn(self.test_file, cmd_args)
         self.assertIn(self.test_target, cmd_args)
 
@@ -214,8 +214,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
         cmd_args = mock_subprocess_run.call_args[0][0]
 
         self.assertIn("test_tag", cmd_args)
-        self.assertIn("-G", cmd_args)
-        self.assertIn("-f", cmd_args)
+        self.assertIn("--disable-git", cmd_args)
+        self.assertIn("--file", cmd_args)
         self.assertIn(self.test_file, cmd_args)
         self.assertIn(self.test_target, cmd_args)
         self.assertNotIn("console-format", cmd_args)
@@ -289,8 +289,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
         cmd_args = mock_subprocess_run.call_args[0][0]
 
         self.assertIn("test_tag", cmd_args)
-        self.assertIn("-G", cmd_args)
-        self.assertIn("-f", cmd_args)
+        self.assertIn("--disable-git", cmd_args)
+        self.assertIn("--file", cmd_args)
         self.assertIn(self.test_file, cmd_args)
         self.assertIn(self.test_target, cmd_args)
         self.assertIn("--console-format", cmd_args)
@@ -372,8 +372,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
         cmd_args_second = mock_subprocess_run.call_args_list[1][0][0]
 
         self.assertIn("test_tag", cmd_args)
-        self.assertIn("-G", cmd_args)
-        self.assertIn("-f", cmd_args)
+        self.assertIn("--disable-git", cmd_args)
+        self.assertIn("--file", cmd_args)
         self.assertIn(self.test_file, cmd_args)
         self.assertIn(self.test_target, cmd_args)
         self.assertIn(self.test_second_target, cmd_args_second)
@@ -438,8 +438,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
         cmd_args_second = mock_subprocess_run.call_args_list[1][0][0]
 
         self.assertIn("test_tag", cmd_args)
-        self.assertIn("-G", cmd_args)
-        self.assertIn("-f", cmd_args)
+        self.assertIn("--disable-git", cmd_args)
+        self.assertIn("--file", cmd_args)
 
         self.assertIn(self.test_file, cmd_args)
         self.assertIn(self.test_target, cmd_args)

--- a/bazel/astore/astore_upload_files_test.py
+++ b/bazel/astore/astore_upload_files_test.py
@@ -147,11 +147,16 @@ class TestAstoreUploadFiles(absltest.TestCase):
         self.assertEqual(uid, "test_uid_123")
         self.assertIn(uid, mock_result.stdout)
 
-    @absltest.skip("Not implemented")
     @mock.patch("subprocess.run")
     @mock.patch("tempfile.NamedTemporaryFile")
-    def test_main_success_flextape(self, mock_temp_file, mock_subprocess_run):
+    @mock.patch("os.unlink")
+    def test_main_success_flextape(self, mock_unlink, mock_temp_file, mock_subprocess_run):
         """Test successful execution of main function."""
+
+        # Keep temp.json file
+        mock_unlink = mock.MagicMock()
+        mock_unlink.returncode = 0
+
         # Mock the temporary file
         mock_temp = mock.MagicMock()
         mock_temp.name = os.path.join(self.temp_dir.name, "temp.json")
@@ -159,19 +164,28 @@ class TestAstoreUploadFiles(absltest.TestCase):
 
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
-            f.write(
-                """[[Artifacts]]
-  Architecture = "all"
-  Created = 1747686104596565327
-  Creator = "roman@enfabrica.net"
-  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
-  Note = ""
-  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
-  Size = 18067
-  Tag = ["latest"]
-  Uid = "kz6uksgwtwpfjofvj22jyptfsc4g3nm6"
-"""
-            )
+            f.write(textwrap.dedent("""
+                {
+                "Artifacts": [
+                    {
+                    "Architecture": "all",
+                    "Created": "1747686104596565327",
+                    "Creator": "roman@enfabrica.net",
+                    "MD5": [
+                        129,
+                        47
+                    ],
+                    "Note": "",
+                    "Sid": "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c",
+                    "Size": 18067,
+                    "Tag": [
+                        "latest"
+                    ],
+                    "Uid": "kz6uksgwtwpfjofvj22jyptfsc4g3nm6"
+                    }
+                ]
+                }"""
+            ))
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -179,7 +193,7 @@ class TestAstoreUploadFiles(absltest.TestCase):
         # FIXME: is this correct table output?
         # pylint: disable=line-too-long
         mock_result.stdout = """| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
-| 2025-05-19 18:16:43.026 roman@enfabrica.net            amd64-linux    4ca03f0e6a70a2e3fc925955ab301e5d ym2wvcei7j2ihhvh7sauzgipxcvdtsvr 12 MB   [latest]
+| 2025-05-19 18:16:43.026 roman@enfabrica.net            amd64-linux    4ca03f0e6a70a2e3fc925955ab301e5d kz6uksgwtwpfjofvj22jyptfsc4g3nm6 12 MB   [latest]
 """
         mock_subprocess_run.return_value = mock_result
 
@@ -208,17 +222,14 @@ class TestAstoreUploadFiles(absltest.TestCase):
         with self.assertRaises(json.decoder.JSONDecodeError):
             _ = json.loads(mock_result.stdout)
 
-
         with open(mock_temp.name, "r", encoding="utf-8") as f:
             content = f.read()
 
         uid = json.loads(content)["Artifacts"][0]["Uid"]
-        self.assertEqual(uid, "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr")
-        self.assertEqual(1, 2)
+        self.assertEqual(uid, "kz6uksgwtwpfjofvj22jyptfsc4g3nm6")
         self.assertIn(uid, mock_result.stdout)
 
 
-    @absltest.skip("Not implemented")
     @mock.patch("subprocess.run")
     @mock.patch("tempfile.NamedTemporaryFile")
     def test_main_success_flextape_json(self, mock_temp_file, mock_subprocess_run):
@@ -230,20 +241,24 @@ class TestAstoreUploadFiles(absltest.TestCase):
 
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
-            f.write(
-                """
-[[Artifacts]]
-  Architecture = "all"
-  Created = 1747686104596565327
-  Creator = "roman@enfabrica.net"
-  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
-  Note = ""
-  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
-  Size = 18067
-  Tag = ["latest"]
-  Uid = "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
-                    """
-            )
+            f.write(textwrap.dedent("""
+                {
+                "Artifacts": [
+                    {
+                    "Architecture": "all",
+                    "Created": "1747686104596565327",
+                    "Creator": "roman@enfabrica.net",
+                    "Note": "",
+                    "Sid": "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c",
+                    "Size": 18067,
+                    "Tag": [
+                        "latest"
+                    ],
+                    "Uid": "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
+                    }
+                ]
+                }"""
+                                            ))
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -302,19 +317,28 @@ class TestAstoreUploadFiles(absltest.TestCase):
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
             f.write(
-                """
-[[Artifacts]]
-  Architecture = "all"
-  Created = 1747686104596565327
-  Creator = "roman@enfabrica.net"
-  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
-  Note = ""
-  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
-  Size = 18067
-  Tag = ["latest"]
-  Uid = "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
+                textwrap.dedent(
                     """
-            )
+                    {
+                    "Artifacts": [
+                        {
+                        "Architecture": "all",
+                        "Created": "1747686104596565327",
+                        "Creator": "roman@enfabrica.net",
+                        "MD5": [
+                            129,
+                            47
+                        ],
+                        "Note": "",
+                        "Sid": "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c",
+                        "Size": 18067,
+                        "Tag": [
+                            "latest"
+                        ],
+                        "Uid": "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
+                        }
+                    ]
+                    }""" )           )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -379,10 +403,15 @@ class TestAstoreUploadFiles(absltest.TestCase):
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
             f.write(
-                """[[Artifacts]]
-  Uid = "test_uid_123"
+                textwrap.dedent(
                     """
-            )
+                    {
+                    "Artifacts": [
+                        {
+                        "Uid": "test_uid_123"
+                        }
+                    ]
+                    }""")            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -428,9 +457,15 @@ class TestAstoreUploadFiles(absltest.TestCase):
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
             f.write(
-                """[[Artifacts]]
-  Uid = "test_uid_123"
+                textwrap.dedent(
                     """
+                    {
+                    "Artifacts": [
+                        {
+                        "Uid": "test_uid_123"
+                        }
+                    ]
+                    }""" )
             )
 
         # Mock the subprocess run result

--- a/bazel/astore/astore_upload_files_test.py
+++ b/bazel/astore/astore_upload_files_test.py
@@ -97,7 +97,9 @@ class TestAstoreUploadFiles(absltest.TestCase):
 
         # Create the temp JSON file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent(
+                    """
                     {
                     "Artifacts": [
                         {
@@ -105,7 +107,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
                         }
                     ]
                     }"""
-            ))
+                )
+            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -164,7 +167,9 @@ class TestAstoreUploadFiles(absltest.TestCase):
 
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent(
+                    """
                 {
                 "Artifacts": [
                     {
@@ -185,7 +190,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
                     }
                 ]
                 }"""
-            ))
+                )
+            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -229,7 +235,6 @@ class TestAstoreUploadFiles(absltest.TestCase):
         self.assertEqual(uid, "kz6uksgwtwpfjofvj22jyptfsc4g3nm6")
         self.assertIn(uid, mock_result.stdout)
 
-
     @mock.patch("subprocess.run")
     @mock.patch("tempfile.NamedTemporaryFile")
     def test_main_success_flextape_json(self, mock_temp_file, mock_subprocess_run):
@@ -241,7 +246,9 @@ class TestAstoreUploadFiles(absltest.TestCase):
 
         # Create the temp TOML file with test content
         with open(mock_temp.name, "w", encoding="utf-8") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent(
+                    """
                 {
                 "Artifacts": [
                     {
@@ -258,7 +265,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
                     }
                 ]
                 }"""
-                                            ))
+                )
+            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -338,7 +346,9 @@ class TestAstoreUploadFiles(absltest.TestCase):
                         "Uid": "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
                         }
                     ]
-                    }""" )           )
+                    }"""
+                )
+            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -411,7 +421,9 @@ class TestAstoreUploadFiles(absltest.TestCase):
                         "Uid": "test_uid_123"
                         }
                     ]
-                    }""")            )
+                    }"""
+                )
+            )
 
         # Mock the subprocess run result
         mock_result = mock.MagicMock()
@@ -465,7 +477,8 @@ class TestAstoreUploadFiles(absltest.TestCase):
                         "Uid": "test_uid_123"
                         }
                     ]
-                    }""" )
+                    }"""
+                )
             )
 
         # Mock the subprocess run result
@@ -515,6 +528,7 @@ class TestAstoreUploadFiles(absltest.TestCase):
             with self.assertRaises(SystemExit) as cm:
                 astore_upload_files.main(["astore_upload_files.py", self.test_target])
             self.assertEqual(cm.exception.code, 1)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/bazel/astore/astore_upload_files_test.py
+++ b/bazel/astore/astore_upload_files_test.py
@@ -65,13 +65,13 @@ class TestAstoreUploadFiles(absltest.TestCase):
         result = astore_upload_files.sha256sum(self.test_file)
         self.assertEqual(result, expected_hash)
 
-    def test_update_build_file(self):
+    def test_update_starlark_version_file(self):
         """Test updating UID and SHA in build file."""
         test_uid = "test_new_uid_123"
         test_sha = "test_new_sha_456"
 
         # Call the function
-        astore_upload_files.update_build_file(self.test_uidfile, self.test_target, test_uid, test_sha)
+        astore_upload_files.update_starlark_version_file(self.test_uidfile, self.test_target, test_uid, test_sha)
 
         # Verify the file was updated correctly
         with open(self.test_uidfile, "r", encoding="utf-8") as f:

--- a/bazel/astore/astore_upload_files_test.py
+++ b/bazel/astore/astore_upload_files_test.py
@@ -1,0 +1,451 @@
+"""Unit tests for astore_upload_files.py"""
+
+# standard libraries
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from unittest import mock
+
+# third party libraries
+from absl import flags
+from absl.testing import absltest, flagsaver
+
+# enfabrica libraries
+from release.internal import astore_upload_files
+
+
+class TestAstoreUploadFiles(absltest.TestCase):
+    """astore upload test"""
+
+    @classmethod
+    def setUpClass(cls):
+        # Parse flags to avoid UnparsedFlagAccessError
+        # We need to do this before accessing any flags
+        if not flags.FLAGS.is_parsed():
+            flags.FLAGS(sys.argv)
+
+    def setUp(self):
+        # Create temporary files for testing
+        # pylint: disable=consider-using-with
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.test_file = os.path.join(self.temp_dir.name, "test_file.txt")
+        self.test_target = os.path.join(self.temp_dir.name, "test_target.txt")
+        self.test_second_target = os.path.join(self.temp_dir.name, "test_second_target.txt")
+        self.test_uidfile = os.path.join(self.temp_dir.name, "test_uidfile.txt")
+
+        # Create test files
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write("Test file content")
+
+        with open(self.test_target, "w", encoding="utf-8") as f:
+            f.write("Test target content")
+
+        with open(self.test_second_target, "w", encoding="utf-8") as f:
+            f.write("Test second target content")
+
+        with open(self.test_uidfile, "w", encoding="utf-8") as f:
+            f.write('UID_TESTTARGETTXT = "old_uid"\n')
+            f.write('SHA_TESTTARGETTXT = "old_sha"\n')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_sha256sum(self):
+        """Test SHA256 hash calculation."""
+        # Calculate expected hash
+
+        h = hashlib.sha256()
+        h.update(b"Test file content")
+        expected_hash = h.hexdigest()
+
+        # Test the function
+        result = astore_upload_files.sha256sum(self.test_file)
+        self.assertEqual(result, expected_hash)
+
+    def test_update_build_file(self):
+        """Test updating UID and SHA in build file."""
+        test_uid = "test_new_uid_123"
+        test_sha = "test_new_sha_456"
+
+        # Call the function
+        astore_upload_files.update_build_file(self.test_uidfile, self.test_target, test_uid, test_sha)
+
+        # Verify the file was updated correctly
+        with open(self.test_uidfile, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn(f'UID_TESTTARGETTXT = "{test_uid}"', content)
+        self.assertIn(f'SHA_TESTTARGETTXT = "{test_sha}"', content)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_success(self, mock_temp_file, mock_subprocess_run):
+        """Test successful execution of main function."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """[[Artifacts]]
+  Uid = "test_uid_123"
+                    """
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Uid    1 2 3 4                               test_uid_123"
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            astore_upload_files.FLAGS.uidfile = self.test_uidfile
+            astore_upload_files.FLAGS.upload_tag = "test_tag"
+            astore_upload_files.FLAGS.output_format = "table"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function with target as command line argument
+            astore_upload_files.main(["astore_upload_files.py", self.test_target])
+
+        # Verify subprocess was called with correct arguments
+        mock_subprocess_run.assert_called_once()
+        cmd_args = mock_subprocess_run.call_args[0][0]
+
+        # TODO: how to test? do we call astore or enkit astore?
+        # self.assertEqual(cmd_args[0], "astore")
+        # self.assertEqual(cmd_args[1], "upload")
+
+        self.assertIn("test_tag", cmd_args)
+        self.assertIn("-G", cmd_args)
+        self.assertIn("-f", cmd_args)
+        self.assertIn(self.test_file, cmd_args)
+        self.assertIn(self.test_target, cmd_args)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_success_flextape(self, mock_temp_file, mock_subprocess_run):
+        """Test successful execution of main function."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """[[Artifacts]]
+  Architecture = "all"
+  Created = 1747686104596565327
+  Creator = "roman@enfabrica.net"
+  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
+  Note = ""
+  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
+  Size = 18067
+  Tag = ["latest"]
+  Uid = "kz6uksgwtwpfjofvj22jyptfsc4g3nm6"
+"""
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        # FIXME: is this correct table output?
+        # pylint: disable=line-too-long
+        mock_result.stdout = """| Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
+| 2025-05-19 18:16:43.026 roman@enfabrica.net            amd64-linux    4ca03f0e6a70a2e3fc925955ab301e5d ym2wvcei7j2ihhvh7sauzgipxcvdtsvr 12 MB   [latest]
+"""
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            astore_upload_files.FLAGS.uidfile = self.test_uidfile
+            astore_upload_files.FLAGS.upload_tag = "test_tag"
+            astore_upload_files.FLAGS.output_format = "table"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function
+            astore_upload_files.main(["astore_upload_files.py", self.test_target])
+
+        # Verify subprocess was called with correct arguments
+        mock_subprocess_run.assert_called_once()
+        cmd_args = mock_subprocess_run.call_args[0][0]
+
+        self.assertIn("test_tag", cmd_args)
+        self.assertIn("-G", cmd_args)
+        self.assertIn("-f", cmd_args)
+        self.assertIn(self.test_file, cmd_args)
+        self.assertIn(self.test_target, cmd_args)
+        self.assertNotIn("console-format", cmd_args)
+        with self.assertRaises(json.decoder.JSONDecodeError):
+            _ = json.loads(mock_result.stdout)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_success_flextape_json(self, mock_temp_file, mock_subprocess_run):
+        """Test successful execution of main function."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """
+[[Artifacts]]
+  Architecture = "all"
+  Created = 1747686104596565327
+  Creator = "roman@enfabrica.net"
+  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
+  Note = ""
+  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
+  Size = 18067
+  Tag = ["latest"]
+  Uid = "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
+                    """
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+
+        # pylint: disable=line-too-long
+        data = """{"Artifacts":[{"sid":"tf/mj/7rjhuz86szyg7xkd2fepqxhf576c","uid":"kz6uksgwtwpfjofvj22jyptfsc4g3nm6","tag":["latest"],"MD5":"JC0fdAdtfj3lBMReC/qBLw==","size":18067,"creator":"roman@enfabrica.net","created":1747686104596565327,"architecture":"all"}],"Elements":null}"""
+        data = json.loads(data)
+        data["Artifacts"][0]["Target"] = self.test_target
+        mock_result.stdout = json.dumps(data)
+
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            astore_upload_files.FLAGS.uidfile = self.test_uidfile
+            astore_upload_files.FLAGS.upload_tag = "test_tag"
+            astore_upload_files.FLAGS.output_format = "json"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function
+            astore_upload_files.main(["astore_upload_files.py", self.test_target])
+
+        # Verify subprocess was called with correct arguments
+        mock_subprocess_run.assert_called_once()
+        cmd_args = mock_subprocess_run.call_args[0][0]
+
+        self.assertIn("test_tag", cmd_args)
+        self.assertIn("-G", cmd_args)
+        self.assertIn("-f", cmd_args)
+        self.assertIn(self.test_file, cmd_args)
+        self.assertIn(self.test_target, cmd_args)
+        self.assertIn("--console-format", cmd_args)
+        self.assertIn("json", cmd_args)
+        self.assertEqual(cmd_args.index("--console-format"), cmd_args.index("json") - 1)
+        data = json.loads(mock_result.stdout)
+        artifacts = data["Artifacts"]
+        self.assertEqual(artifacts[0]["MD5"], "JC0fdAdtfj3lBMReC/qBLw==")
+        self.assertEqual(artifacts[0]["uid"], "kz6uksgwtwpfjofvj22jyptfsc4g3nm6")
+
+        # must be list of dicts
+        self.assertEqual(1, len(artifacts))
+        self.assertEqual(artifacts[0]["Target"], self.test_target)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_success_flextape_two_json(self, mock_temp_file, mock_subprocess_run):
+        """Test successful execution of main function."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """
+[[Artifacts]]
+  Architecture = "all"
+  Created = 1747686104596565327
+  Creator = "roman@enfabrica.net"
+  MD5 = [36, 45, 31, 116, 7, 109, 126, 61, 229, 4, 196, 94, 11, 250, 129, 47]
+  Note = ""
+  Sid = "tf/mj/7rjhuz86szyg7xkd2fepqxhf576c"
+  Size = 18067
+  Tag = ["latest"]
+  Uid = "ym2wvcei7j2ihhvh7sauzgipxcvdtsvr"
+                    """
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+
+        # pylint: disable=line-too-long
+        data = """{"Artifacts":[{"sid":"tf/mj/7rjhuz86szyg7xkd2fepqxhf576c","uid":"kz6uksgwtwpfjofvj22jyptfsc4g3nm6","tag":["latest"],"MD5":"JC0fdAdtfj3lBMReC/qBLw==","size":18067,"creator":"roman@enfabrica.net","created":1747686104596565327,"architecture":"all"}],"Elements":null}"""
+        data = json.loads(data)
+        data["Artifacts"][0]["Target"] = self.test_target
+        data["Artifacts"].append(data["Artifacts"][0].copy())
+        data["Artifacts"][1]["Target"] = self.test_second_target
+        mock_result.stdout = json.dumps(data)
+
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            # astore_upload_files.FLAGS.uidfile = self.test_uidfile
+            astore_upload_files.FLAGS.upload_tag = "test_tag"
+            astore_upload_files.FLAGS.output_format = "json"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function
+            astore_upload_files.main(["astore_upload_files.py", self.test_target, self.test_second_target])
+
+        # Verify subprocess was called with correct arguments
+        self.assertEqual(mock_subprocess_run.call_count, 2)
+        cmd_args = mock_subprocess_run.call_args_list[0][0][0]
+        cmd_args_second = mock_subprocess_run.call_args_list[1][0][0]
+
+        self.assertIn("test_tag", cmd_args)
+        self.assertIn("-G", cmd_args)
+        self.assertIn("-f", cmd_args)
+        self.assertIn(self.test_file, cmd_args)
+        self.assertIn(self.test_target, cmd_args)
+        self.assertIn(self.test_second_target, cmd_args_second)
+        self.assertIn("--console-format", cmd_args)
+        self.assertIn("json", cmd_args)
+        self.assertEqual(cmd_args.index("--console-format"), cmd_args.index("json") - 1)
+        data = json.loads(mock_result.stdout)
+
+        artifacts = data["Artifacts"]
+        self.assertEqual(len(artifacts), 2)
+        self.assertEqual(artifacts[0]["MD5"], "JC0fdAdtfj3lBMReC/qBLw==")
+        self.assertEqual(artifacts[0]["uid"], "kz6uksgwtwpfjofvj22jyptfsc4g3nm6")
+
+        # must be list of dicts
+        self.assertEqual(artifacts[0]["Target"], self.test_target)
+        self.assertEqual(artifacts[1]["Target"], self.test_second_target)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_success_two_targets(self, mock_temp_file, mock_subprocess_run):
+        """Test successful execution of main function."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """[[Artifacts]]
+  Uid = "test_uid_123"
+                    """
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Uid    1 2 3 4                               test_uid_123"
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            # FIXME add test: no uidfile when multiple targets
+            # astore_upload_files.FLAGS.uidfile = self.test_uidfile
+            astore_upload_files.FLAGS.upload_tag = "test_tag"
+            astore_upload_files.FLAGS.output_format = "table"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function
+            astore_upload_files.main(["astore_upload_files.py", self.test_target, self.test_second_target])
+
+        # Verify subprocess was called with correct arguments
+        self.assertEqual(mock_subprocess_run.call_count, 2)
+        cmd_args = mock_subprocess_run.call_args_list[0][0][0]
+        cmd_args_second = mock_subprocess_run.call_args_list[1][0][0]
+
+        self.assertIn("test_tag", cmd_args)
+        self.assertIn("-G", cmd_args)
+        self.assertIn("-f", cmd_args)
+
+        self.assertIn(self.test_file, cmd_args)
+        self.assertIn(self.test_target, cmd_args)
+        self.assertIn(self.test_second_target, cmd_args_second)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_json_output(self, mock_temp_file, mock_subprocess_run):
+        """Test main function with JSON output format."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Create the temp TOML file with test content
+        with open(mock_temp.name, "w", encoding="utf-8") as f:
+            f.write(
+                """[[Artifacts]]
+  Uid = "test_uid_123"
+                    """
+            )
+
+        # Mock the subprocess run result
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"Artifacts":[{"uid": "test_uid_123"}]}'
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            astore_upload_files.FLAGS.output_format = "json"
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function
+            astore_upload_files.main(["astore_upload_files.py", self.test_target])
+
+        # Verify subprocess was called with correct arguments
+        mock_subprocess_run.assert_called_once()
+        cmd_args = mock_subprocess_run.call_args[0][0]
+        self.assertEqual(cmd_args[-3], "--console-format")
+        self.assertEqual(cmd_args[-2], "json")
+
+    @mock.patch("subprocess.run")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_main_upload_error(self, mock_temp_file, mock_subprocess_run):
+        """Test main function when upload fails."""
+        # Mock the temporary file
+        mock_temp = mock.MagicMock()
+        mock_temp.name = os.path.join(self.temp_dir.name, "temp.toml")
+        mock_temp_file.return_value.__enter__.return_value = mock_temp
+
+        # Mock the subprocess run result with error
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Upload failed"
+        mock_subprocess_run.return_value = mock_result
+
+        # Set up flags for this test
+        with flagsaver.flagsaver():
+            # Manually set the flags
+            astore_upload_files.FLAGS.file = self.test_file
+            astore_upload_files.FLAGS.astore = "astore"
+
+            # Call the main function and expect sys.exit(1)
+            with self.assertRaises(SystemExit) as cm:
+                astore_upload_files.main(["astore_upload_files.py", self.test_target])
+            self.assertEqual(cm.exception.code, 1)

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -37,7 +37,6 @@ def _astore_upload(ctx):
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
     files = [ctx.executable._astore_client, ctx.executable._astore_py_wrapper]
-    print(files)
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
@@ -125,7 +124,7 @@ astore_upload = rule(
             cfg = "host",
         ),
         "_astore_py_wrapper": attr.label(
-            default = Label("@net_enfabrica_binary_astore_py//file"),
+            default = Label("//bazel/astore:astore_upload_files"),
             allow_single_file = True,
             executable = True,
             cfg = "host",

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -36,8 +36,7 @@ def _astore_upload(ctx):
     if ctx.attr.dir and ctx.attr.file:
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
-    files = [ctx.executable._astore_client, ctx.executable._astore_py_wrapper]
-    files.extend(ctx.files._astore_py_wrapper)
+    files = [ctx.executable._astore_wrapper]
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
@@ -47,36 +46,34 @@ def _astore_upload(ctx):
     if ctx.attr.dir:
         template = ctx.file._astore_upload_dir
 
-    uidfile = ""
+    uidfile_flag = ""
     if ctx.attr.uidfile:
-        uidfile = ctx.files.uidfile[0].short_path
+        uidfile_flag = "--uidfile=" + ctx.files.uidfile[0].short_path
         files.append(ctx.files.uidfile[0])
 
     tags = []
     if ctx.attr.upload_tag:
         tags.append(ctx.attr.upload_tag)
     tags.extend(ctx.attr._cmdline_upload_tag[AstoreMetadataProvider].tags)
-    upload_tag = " ".join(["--tag={}".format(tag) for tag in tags])
-
-    print(ctx.files._astore_py_wrapper)
-    print(ctx.executable._astore_py_wrapper)
+    tag_flags = " ".join(["--tag={}".format(tag) for tag in tags])
 
     ctx.actions.expand_template(
         template = template,
         output = ctx.outputs.executable,
         substitutions = {
-            "{astore}": ctx.executable._astore_client.short_path,
-            "{py_wrapper}": ctx.executable._astore_py_wrapper.short_path,
-            "{targets}": " ".join(targets),
-            "{file}": ctx.attr.file,
+            "{wrapper}": ctx.executable._astore_wrapper.short_path,
+            "{upload_file_flags}": " ".join(["--upload_file={}".format(t) for t in targets]),
+            "{astore_path_flag}": "--astore_base_path=" + ctx.attr.file,
             "{dir}": ctx.attr.dir,
-            "{uidfile}": uidfile,
-            "{upload_tag}": upload_tag,
-            "{output_format}": ctx.attr._cmdline_upload_output_format[AstoreMetadataProvider].output_format,
+            "{uidfile_flag}": uidfile_flag,
+            "{tag_flags}": tag_flags,
+            "{output_format_flag}": ctx.attr._cmdline_upload_output_format[AstoreMetadataProvider].output_format,
         },
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = files)
+    runfiles = ctx.runfiles(files = files).merge_all([
+        ctx.attr._astore_wrapper[DefaultInfo].default_runfiles,
+    ])
     return [DefaultInfo(runfiles = runfiles)]
 
 astore_upload = rule(
@@ -121,18 +118,12 @@ astore_upload = rule(
             default = Label("//bazel/astore:astore_upload_dir.sh"),
             allow_single_file = True,
         ),
-        "_astore_client": attr.label(
-            default = Label("@net_enfabrica_binary_astore//file"),
-            allow_single_file = True,
-            executable = True,
-            cfg = "host",
-        ),
-        "_astore_py_wrapper": attr.label(
+        "_astore_wrapper": attr.label(
             default = Label("//bazel/astore:astore_upload_files"),
             # allow_single_file = True,
             # allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     executable = True,

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -37,6 +37,7 @@ def _astore_upload(ctx):
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
     files = [ctx.executable._astore_client, ctx.executable._astore_py_wrapper]
+    files.extend(ctx.files._astore_py_wrapper)
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
@@ -56,6 +57,9 @@ def _astore_upload(ctx):
         tags.append(ctx.attr.upload_tag)
     tags.extend(ctx.attr._cmdline_upload_tag[AstoreMetadataProvider].tags)
     upload_tag = " ".join(["--tag={}".format(tag) for tag in tags])
+
+    print(ctx.files._astore_py_wrapper)
+    print(ctx.executable._astore_py_wrapper)
 
     ctx.actions.expand_template(
         template = template,
@@ -125,7 +129,8 @@ astore_upload = rule(
         ),
         "_astore_py_wrapper": attr.label(
             default = Label("//bazel/astore:astore_upload_files"),
-            allow_single_file = True,
+            # allow_single_file = True,
+            # allow_files = True,
             executable = True,
             cfg = "host",
         ),

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -36,7 +36,8 @@ def _astore_upload(ctx):
     if ctx.attr.dir and ctx.attr.file:
         fail("in '%s' rule for an astore_upload in %s - you can only set dir or file, not both" % (ctx.attr.name, ctx.build_file_path), "dir")
 
-    files = [ctx.executable._astore_client]
+    files = [ctx.executable._astore_client, ctx.executable._astore_py_wrapper]
+    print(files)
     targets = []
     for target in ctx.attr.targets:
         targets.extend([t.short_path for t in target.files.to_list()])
@@ -62,6 +63,7 @@ def _astore_upload(ctx):
         output = ctx.outputs.executable,
         substitutions = {
             "{astore}": ctx.executable._astore_client.short_path,
+            "{py_wrapper}": ctx.executable._astore_py_wrapper.short_path,
             "{targets}": " ".join(targets),
             "{file}": ctx.attr.file,
             "{dir}": ctx.attr.dir,
@@ -118,6 +120,12 @@ astore_upload = rule(
         ),
         "_astore_client": attr.label(
             default = Label("@net_enfabrica_binary_astore//file"),
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "_astore_py_wrapper": attr.label(
+            default = Label("@net_enfabrica_binary_astore_py//file"),
             allow_single_file = True,
             executable = True,
             cfg = "host",

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -292,20 +292,6 @@ filegroup(
         executable = True,
     )
 
-    # Do we need to make it public? Yes!
-    maybe(
-        name = "net_enfabrica_binary_astore_py",
-        repo_rule = http_file,
-        # Why it is different from the local checksum?
-        # $ sha256sum bazel-bin/release/internal/astore_upload_files_upload
-        # f3d2185a2ab74e8119e84d349d231665b01f775453d06053b388968ae8decd71  bazel-bin/release/internal/astore_upload_files_upload
-        sha256 = "9da6a5873923e85d2d4d7b6e121d7cf096114a8f83c309dc1c2e5d58bd736fec",
-        # what is the meaning of d and l?
-                #  https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e
-        urls = ["https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=b4gg6r8k2fgvuiecy3subjzy43263mri"],
-        executable = True,
-    )
-
     maybe(
         name = "libz",
         repo_rule = http_archive,

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -296,10 +296,13 @@ filegroup(
     maybe(
         name = "net_enfabrica_binary_astore_py",
         repo_rule = http_file,
-        sha256 = "b0c857e8f5cd90d977d0b66f96ba08b9bcf5db76fb3a038872a0860b24029faa",
+        # Why it is different from the local checksum?
+        # $ sha256sum bazel-bin/release/internal/astore_upload_files_upload
+        # f3d2185a2ab74e8119e84d349d231665b01f775453d06053b388968ae8decd71  bazel-bin/release/internal/astore_upload_files_upload
+        sha256 = "9da6a5873923e85d2d4d7b6e121d7cf096114a8f83c309dc1c2e5d58bd736fec",
         # what is the meaning of d and l?
                 #  https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e
-        urls = ["https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e"],
+        urls = ["https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=b4gg6r8k2fgvuiecy3subjzy43263mri"],
         executable = True,
     )
 

--- a/bazel/init/stage_1.bzl
+++ b/bazel/init/stage_1.bzl
@@ -292,6 +292,17 @@ filegroup(
         executable = True,
     )
 
+    # Do we need to make it public? Yes!
+    maybe(
+        name = "net_enfabrica_binary_astore_py",
+        repo_rule = http_file,
+        sha256 = "b0c857e8f5cd90d977d0b66f96ba08b9bcf5db76fb3a038872a0860b24029faa",
+        # what is the meaning of d and l?
+                #  https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e
+        urls = ["https://astore.corp.enfabrica.net/d/roivanov/test/astore_upload_files?u=uixzsp6fxeac6p6xbsxbfehzx5hs5s7e"],
+        executable = True,
+    )
+
     maybe(
         name = "libz",
         repo_rule = http_archive,

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -26,7 +26,7 @@ go_binary(
 
 astore_upload(
     name = "astore_push",
-    file = "home/scott/test/flextape",
+    file = "roivanov/temp/test/flextape",
     targets = [
         ":flextape",
     ],


### PR DESCRIPTION
Tested: `bazel run //flextape/server:astore_push` successfully pushes to
astore