### PR TITLE
astore/auth server: Update Go runtime

### DIFF
--- a/astore/server/deploy/app.yaml
+++ b/astore/server/deploy/app.yaml
@@ -1,5 +1,5 @@
 env: standard
-runtime: go119
+runtime: go121
 instance_class: F1
 automatic_scaling:
   max_instances: 1


### PR DESCRIPTION
The Go runtime is currently set at 1.19, which is no longer supported and prevents us from deploying new versions. This change updates to Go 1.21, which is supported (though not the latest Go version available).

Jira: REL-180