### PR TITLE
chore(kernel): rebuild aarch64 kernel with the different compiler

### DIFF
--- a/kbuild/v2/scripts/build-kernel-tree.sh
+++ b/kbuild/v2/scripts/build-kernel-tree.sh
@@ -202,7 +202,7 @@ echo "$kernel_version" > "${build_dir}/enf-kernel-version.txt"
 
 case "$RT_ARCH" in
     arm64)
-        arch_args="ARCH=$RT_ARCH CROSS_COMPILE=aarch64-linux-gnu-"
+        arch_args="ARCH=$RT_ARCH CROSS_COMPILE=aarch64-none-linux-gnu-"
         arch_image="Image"
         output_image="arch/arm64/boot/Image"
         ;;


### PR DESCRIPTION
This change updates arm64 kernel build to our toolchain compiler.

JIRA: REL-241
Must be merged together with: https://github.com/enfabrica/internal/pull/57095

Tested:
[Ubuntu24.04](https://console.cloud.google.com/cloud-build/builds;region=global/22d60708-9dc8-47c9-8dc4-07411dd22785?inv=1&invt=AbyonQ&project=cloud-build-290921)
[Ubuntu20.04](https://console.cloud.google.com/cloud-build/builds;region=global/a5977576-1b35-4e4c-a644-b993fb643fdc?inv=1&invt=Abyong&project=cloud-build-290921)