### PR TITLE
enkit_credential_helper: Add arm64 build

### DIFF
--- a/bazel/enkit_credential_helper/BUILD.bazel
+++ b/bazel/enkit_credential_helper/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("//bazel/astore:defs.bzl", "astore_upload")
 
 go_binary(
     name = "enkit_credential_helper",
@@ -21,5 +22,26 @@ go_library(
         "//lib/khttp/kcookie",
         "//lib/stamp",
         "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_cross_binary(
+    name = "enkit_credential_helper_arm64",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    target = ":enkit_credential_helper",
+)
+
+go_cross_binary(
+    name = "enkit_credential_helper_amd64",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_amd64",
+    target = ":enkit_credential_helper",
+)
+
+astore_upload(
+    name = "enkit_credential_helper_upload",
+    file = "tools/enkit_credential_helper",
+    targets = [
+        ":enkit_credential_helper_amd64",
+        ":enkit_credential_helper_arm64",
     ],
 )


### PR DESCRIPTION
This change adds a target to build an arm64 build for ARM-powered Linux machines.

A second target is created to ensure that we have an amd64 build (usually implied because most machines we build on are, but this is implicit behavior made explicit here). Both targets are combined into a single `astore_upload` target to build + upload both architectures in one command.

Tested: Ran the upload target; `enkit astore ls --all tools/enkit_credential_helper` shows the built artifacts

Jira: none