### PR TITLE
astore: Error when token not present in requests to `/gt` endpoint

### DIFF
--- a/astore/server/astore/BUILD.bazel
+++ b/astore/server/astore/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//astore/client/astore",
         "//astore/rpc/astore",
         "//lib/errdiff",
+        "//lib/logger",
         "//lib/testutil",
         "@com_github_golang_jwt_jwt_v5//:jwt",
         "@com_github_golang_protobuf//ptypes/wrappers",

--- a/astore/server/astore/retrieve.go
+++ b/astore/server/astore/retrieve.go
@@ -80,6 +80,10 @@ func (s *Server) DownloadArtifact(prefix string, ehandler DownloadHandler, auth 
 					return
 				}
 			}
+		} else {
+			s.options.logger.Errorf("Request for uid %q: no token on request requiring token auth", uid)
+			ehandler(upath, nil, status.Errorf(codes.Unauthenticated, "missing required token in request parameters"), w, r)
+			return
 		}
 	}
 

--- a/astore/server/astore/retrieve_test.go
+++ b/astore/server/astore/retrieve_test.go
@@ -529,6 +529,15 @@ func TestServerDownloadArtifact(t *testing.T) {
 				Order: []*dpb.PropertyOrder{descendingBy("Created")},
 			}),
 		},
+		{
+			desc:   "path and uid using token auth with no token",
+			prefix: "/gt/",
+			auth:   AuthTypeToken,
+			req: &http.Request{
+				URL: mustParseURL(t, `https://astore.corp.enfabrica.net/gt/test/package?u=buhi7q8isp7ttm7q3h6qnhwwzm3tjqiw`),
+			},
+			wantErr: "missing required token in request parameters",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/astore/server/astore/util_test.go
+++ b/astore/server/astore/util_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/require"
 	dpb "google.golang.org/genproto/googleapis/datastore/v1"
+
+	"github.com/enfabrica/enkit/lib/logger"
 )
 
 // testDatastore is a mock Datastore object that captures queries made.
@@ -96,7 +98,7 @@ func serverForTest() (*Server, *testDatastore) {
 		gcs:     nil,
 		bkt:     nil,
 		ds:      ds,
-		options: Options{},
+		options: Options{logger: logger.Nil},
 	}, ds
 }
 


### PR DESCRIPTION
The `/gt` astore URL endpoint performs authentication via a token in the request parameters, but currently allows access when the token is completely missing. This change causes an error to be returned instead, so that we don't allow unauthenticated access to astore artifacts.

Tested: added unit test

Jira: REL-272