### PR TITLE
Allow existing directory in muk mkdir

### DIFF
--- a/bazel/utils/container/muk/muk.py
+++ b/bazel/utils/container/muk/muk.py
@@ -69,7 +69,7 @@ def load_tars(build_dir: pathlib.Path) -> None:
     for t in tar_files:
         t = t.replace(os.getcwd() + "/", "")
         targetpath = build_dir / t
-        targetpath.parent.mkdir(parents=True)
+        targetpath.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(t, build_dir / t)
 
 def generate_dockerfile(


### PR DESCRIPTION
Don't error out on an existing directory in the mkdir in muk

Jira: ENGPROD-1198

Tested: not yet