### PR TITLE
kernel: Add version info to `uname -r`

### DIFF
--- a/kbuild/v2/scripts/build-debs.sh
+++ b/kbuild/v2/scripts/build-debs.sh
@@ -59,6 +59,9 @@ fi
 
 abi_suffix="${kernel_version}${dirty}"
 
+# Add version info to kernel version string as reported by `uname -r`
+export DEBIAN_KERNEL_LOCALVERSION="${kernel_version}${dirty}"
+
 if [ "$RT_BUILD_CLEAN" = "yes" ] ; then
     fakeroot debian/rules distclean
 fi


### PR DESCRIPTION
This change adds the same version string that controls the generated .deb filenames to the version string reported by `uname -r` via the `DEBIAN_KERNEL_LOCALVERSION` environment variable.

Tested: TODO

Jira: REL-303