### PR TITLE
astore_upload: Add path_prefix bazel flag

### DIFF
--- a/bazel/astore/astore_upload_file.sh
+++ b/bazel/astore/astore_upload_file.sh
@@ -5,4 +5,5 @@ exec {wrapper} \
   {astore_path_flag} \
   {uidfile_flag} \
   {tag_flags} \
-  {output_format_flag}
+  {output_format_flag} \
+  {path_prefix}

--- a/bazel/astore/astore_upload_files.py
+++ b/bazel/astore/astore_upload_files.py
@@ -31,6 +31,7 @@ flags.DEFINE_multi_string("tag", None, "Tags to add to the upload")
 # FIXME: technically it's just a switch, only json data will be updated with the local_file
 #        anything else just passed as is.
 flags.DEFINE_enum("output_format", "table", ["table", "json"], "Output format")
+flags.DEFINE_string("path_prefix", "", "Path segment to prepend to all astore paths")
 
 
 def sha256sum(filename):
@@ -123,7 +124,11 @@ def main(argv):
             if FLAGS.tag:
                 cmd.extend(f"--tag={t}" for t in FLAGS.tag)
 
-            if FLAGS.astore_base_path.endswith("/"):
+            astore_path = FLAGS.astore_base_path
+            if FLAGS.path_prefix:
+                astore_path = os.path.join(FLAGS.path_prefix, astore_path)
+
+            if astore_path.endswith("/"):
                 dest = "--directory"
             else:
                 dest = "--file"
@@ -132,7 +137,7 @@ def main(argv):
                 [
                     "--disable-git",
                     dest,
-                    FLAGS.astore_base_path,
+                    astore_path,
                     "--meta-file",
                     temp_json,
                     "--console-format",

--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -1,4 +1,5 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 AstoreMetadataProvider = provider(fields = ["tags", "output_format"])
 
@@ -96,6 +97,7 @@ def _astore_upload(ctx):
             "{uidfile_flag}": uidfile_flag,
             "{tag_flags}": " ".join(["--tag={}".format(tag) for tag in tags]),
             "{output_format_flag}": "--output_format=" + ctx.attr._cmdline_upload_output_format[AstoreMetadataProvider].output_format,
+            "{path_prefix}": "--path_prefix=" + ctx.attr._cmdline_path_prefix[BuildSettingInfo].value,
         },
         is_executable = True,
     )
@@ -137,6 +139,9 @@ astore_upload = rule(
         "_cmdline_upload_output_format": attr.label(
             providers = [[AstoreMetadataProvider]],
             default = "//f/astore:output_format",
+        ),
+        "_cmdline_path_prefix": attr.label(
+            default = "//f/astore:path_prefix",
         ),
         "_astore_upload_file": attr.label(
             default = Label("//bazel/astore:astore_upload_file.sh"),

--- a/f/astore/BUILD.bazel
+++ b/f/astore/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel/astore:defs.bzl", "astore_output_format", "astore_tag")
 
 astore_tag(
@@ -9,5 +10,11 @@ astore_tag(
 astore_output_format(
     name = "output_format",
     build_setting_default = "table",
+    visibility = ["//bazel/astore:__pkg__"],
+)
+
+string_flag(
+    name = "path_prefix",
+    build_setting_default = "",
     visibility = ["//bazel/astore:__pkg__"],
 )

--- a/flextape/server/BUILD.bazel
+++ b/flextape/server/BUILD.bazel
@@ -32,24 +32,3 @@ astore_upload(
     ],
     visibility = ["//:__pkg__"],
 )
-
-# $ bazel run //flextape/server:astore_push_file --@enkit//f/astore:upload_tag=mytag --@enkit//f/astore:output_format=json
-astore_upload(
-    name = "astore_push_file",
-    file = "roivanov/temp/test/flextape",
-    targets = [
-        ":flextape",
-        ":server_lib",
-    ],
-    visibility = ["//:__pkg__"],
-)
-
-# $ bazel run //flextape/server:astore_push_dir --@enkit//f/astore:upload_tag=mytag --@enkit//f/astore:output_format=json
-astore_upload(
-    name = "astore_push_dir",
-    dir = "roivanov/temp/test/dir",
-    targets = [
-        ":flextape",
-        ":server_lib",
-    ],
-)


### PR DESCRIPTION
This change adds a bazel flag that, when set, will prefix all astore paths used by `astore_upload` rules with the specified prefix.

Tested: manually:

* normal upload:

  ```
  scott-> bazel run //flextape/server:astore_push
  # bazel output omitted
  | Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
  | 2025-07-24 14:19:35.376 scott@enfabrica.net            amd64-linux    f11582e0138fe6a851ca6e40dd07d1c6 o78fvrn7kkhyvyoffuawrqemzxmt5gex 14 MB   [latest]

  scott-> enkit astore ls infra/flextape/flextape_server
  Directly downloadable
   | Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
   | 2025-07-24 14:19:35.376 scott@enfabrica.net            amd64-linux    f11582e0138fe6a851ca6e40dd07d1c6 o78fvrn7kkhyvyoffuawrqemzxmt5gex 14 MB   [latest]
  ```

* modified path prefix:

  ```
  scott-> bazel run //flextape/server:astore_push --//f/astore:path_prefix=home/scott
  # bazel output omitted
  | Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
  | 2025-07-24 14:25:56.947 scott@enfabrica.net            amd64-linux    f11582e0138fe6a851ca6e40dd07d1c6 zqyonoextdrfiagabep2u6gcf824xvbd 14 MB   [latest]

  scott-> enkit astore ls home/scott/infra/flextape/flextape_server
  Directly downloadable
   | Created                 Creator                        Arch           MD5                              UID                              Size    TAGs
   | 2025-07-24 14:25:56.947 scott@enfabrica.net            amd64-linux    f11582e0138fe6a851ca6e40dd07d1c6 zqyonoextdrfiagabep2u6gcf824xvbd 14 MB   [latest]
  ```