### PR TITLE
astore_upload: Make wrapper tool switchable on the commandline

### DIFF
--- a/bazel/astore/defs.bzl
+++ b/bazel/astore/defs.bzl
@@ -148,9 +148,7 @@ astore_upload = rule(
             allow_single_file = True,
         ),
         "_astore_wrapper": attr.label(
-            default = Label("//bazel/astore:astore_upload_files"),
-            # allow_single_file = True,
-            # allow_files = True,
+            default = "//f/astore:uploader",
             executable = True,
             cfg = "exec",
         ),

--- a/f/astore/BUILD.bazel
+++ b/f/astore/BUILD.bazel
@@ -18,3 +18,9 @@ string_flag(
     build_setting_default = "",
     visibility = ["//bazel/astore:__pkg__"],
 )
+
+label_flag(
+    name = "uploader",
+    build_setting_default = "//bazel/astore:astore_upload_files",
+    visibility = ["//bazel/astore:__pkg__"],
+)


### PR DESCRIPTION
This change makes the wrapper tool for `astore_upload` rules switchable
on the command-line, which will be useful for release builds where we
want the tool to have extra behavior, and we don't want to expose this
behavior publicly.

This would look something like:

```
bazel run \
  --@enkit//f/astore:uploader=//my/custom/upload:tool \
  //my/astore/upload:target
```

Tested: manually; `astore_upload` rules have same behavior as before.