### PR TITLE
fix(atore_upload): update AstorePath when reporting JSON

### DIFF
--- a/bazel/astore/astore_upload_files.py
+++ b/bazel/astore/astore_upload_files.py
@@ -156,12 +156,12 @@ def main(argv):
             # Print output based on format
             if FLAGS.output_format == "json":
                 data = json.loads(result.stdout)
-                if FLAGS.astore_base_path.endswith("/"):
+                if astore_path.endswith("/"):
                     data["Artifacts"][0]["AstorePath"] = (
-                        pathlib.Path(FLAGS.astore_base_path) / local_path.name
+                        pathlib.Path(astore_path) / local_path.name
                     )
                 else:
-                    data["Artifacts"][0]["AstorePath"] = FLAGS.astore_base_path
+                    data["Artifacts"][0]["AstorePath"] = astore_path
                 data["Artifacts"][0]["LocalPath"] = str(local_path.resolve())
                 if not json_data:
                     json_data = data


### PR DESCRIPTION
Update AstorePath when reporting JSON.

Tested:
```
$ bazel run //flextape/server:astore_push --//f/astore:path_prefix=home/roman/temp --@enkit//f/astore:outp
ut_format=json
...
I0724 19:51:15.036257 140110492763968 astore_upload_files.py:107] Processing files: ['flextape/server/flextape_/flextape']
I0724 19:51:15.036723 140110492763968 astore_upload_files.py:148] Running command: /home/roman/.cache/bazel/_bazel_roman/ee0660e17c2d27c37d6d137e281c2314/execroot/_main/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/astore/client/astore_/astore upload --disable-git --file home/roman/temp/infra/flextape/flextape_server --meta-file /tmp/astore.j0xkrjec.json --console-format json flextape/server/flextape_/flextape
{"Artifacts": [{"sid": "qo/54/h58ivnsk5cjjf6xjj4epqeed4swy", "uid": "m3qcftzigjvgfvwh57eni3v5k5sf5mux", "tag": ["latest"], "MD5": "8RWC4BOP5qhRym5A3QfRxg==", "size": 13848868, "creator": "roman@enfabrica.net", "created": 1753386685359183928, "architecture": "amd64-linux", "AstorePath": "home/roman/temp/infra/flextape/flextape_server", "LocalPath": "/home/roman/.cache/bazel/_bazel_roman/ee0660e17c2d27c37d6d137e281c2314/execroot/_main/bazel-out/k8-fastbuild/bin/flextape/server/flextape_/flextape"}], "Elements": null}
```
