### PR TITLE
ENGPROD-1249: do not use custom repository cache in serial affected targets

### DIFF
--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -203,7 +203,6 @@ func SerialQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 	result.StartQueryResult, err = startWorkspace.Query(
 		opt.Query,
 		WithUnorderedOutput(),
-		WithRepositoryCache(),
 		workspaceLogStart,
 	)
 	if err != nil {
@@ -214,10 +213,9 @@ func SerialQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 	}
 
 	log.Infof("Querying dependency graph for 'after' workspace...")
-	result.EndQueryResult, err = endWorkspace.Query(
+	result.EndQueryResult, err = endWorkspace.Queryp(
 		opt.Query,
 		WithUnorderedOutput(),
-		WithRepositoryCache(),
 		workspaceLogEnd,
 	)
 	if err != nil {

--- a/lib/bazel/affected_targets.go
+++ b/lib/bazel/affected_targets.go
@@ -213,7 +213,7 @@ func SerialQuery(opt GetModeOptions, log logger.Logger) (*GetResult, error) {
 	}
 
 	log.Infof("Querying dependency graph for 'after' workspace...")
-	result.EndQueryResult, err = endWorkspace.Queryp(
+	result.EndQueryResult, err = endWorkspace.Query(
 		opt.Query,
 		WithUnorderedOutput(),
 		workspaceLogEnd,


### PR DESCRIPTION
It is excessive optimization for serial affected targets calculation