### PR TITLE
muk: Fall back to builtin `py_*` rules

### DIFF
--- a/bazel/utils/container/muk/BUILD.bazel
+++ b/bazel/utils/container/muk/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library", "py_test")
 load("@enkit_pip_deps//:requirements.bzl", "requirement")
 load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")


### PR DESCRIPTION
The `aspect_rules_py` rules appear to introduce wrapper scripts that are breaking `muk` usage by downstream rules. This change reverts us back to the built-in bazel rules for `muk` to unblock users while a more permanent fix is investigated.

Tested: `bazel run` of `nonhermetic_image_builder` target with `--help` flag prints help text, as expected:

```
bazel run --override_module=enkit=/home/scott/dev/enfabrica/enkit <target_redacted> -- --help
```

Jira: INFRA-11884