### PR TITLE
gee: fix "gh pr checks" parsing

### DIFF
--- a/scripts/gee
+++ b/scripts/gee
@@ -4641,7 +4641,7 @@ function gee__pr_check() {
     if [[ "${CURRENT_BRANCH}" == "pr_"* ]]; then
       PRNUM="${CURRENT_BRANCH:3}"
     else
-      PRNUM="$(gh pr view | grep number | awk '{print $2}'; exit "${PIPESTATUS[0]}")"
+      PRNUM="$(gh pr view | grep ^number: | awk '{print $2}'; exit "${PIPESTATUS[0]}")"
     fi
   fi
 


### PR DESCRIPTION
Something changed recently in our github configuration, causing the way I was parsing
`gh pr checks` output to start failing.  This PR corrects the regression.

Tested: Manually running `gh pr_checks`.


