### PR TITLE
mcu: Add perf to arm kernel build

### DIFF
--- a/kbuild/v2/scripts/build-kernel-tree.sh
+++ b/kbuild/v2/scripts/build-kernel-tree.sh
@@ -232,7 +232,7 @@ make $QUIET \
      $arch_args \
      KERNELRELEASE="$kernel_version" \
      prepare modules \
-     $arch_image
+     $arch_image tools/perf
 
 # make source symlink relative
 rm -f "${build_dir}/source"


### PR DESCRIPTION
perf is a utility to record performance statistics, useful for optimizing applications which run on linux. It is related to kernel version as it requires access to counters etc.  As such, as part of the arm build make perf as well, so it is available to the Mcud team to profile applications on the E1s.

Tickets:
MCU-3984